### PR TITLE
Iconic timeline

### DIFF
--- a/LifeBoard.xcodeproj/project.pbxproj
+++ b/LifeBoard.xcodeproj/project.pbxproj
@@ -7,339 +7,339 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		00E2B96FE676ECE56D1C1587 /* OnboardingSelectionSummaryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F70E654847A2B4F0458F49F /* OnboardingSelectionSummaryCard.swift */; };
-		00E943E7872FB1B20D349D99 /* CoreDataOccurrenceRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E54F6F587FF89056E429DF /* CoreDataOccurrenceRepository.swift */; };
-		0122C4D3D195380D2CDCBED5 /* OnboardingChecklistCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA878C13E4A9CF39A3D86B40 /* OnboardingChecklistCard.swift */; };
-		014575655AA3DBD8B1BD4C5F /* LifeManagementProjectDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10E031C3127045DB0AF8ACF9 /* LifeManagementProjectDetailView.swift */; };
-		01D3E1ADABC2FB7D419F301E /* AppOnboardingSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1859F3D260EADFEA49FDBA98 /* AppOnboardingSummary.swift */; };
+		00E2B96FE676ECE56D1C1587 /* LifeBoard/Onboarding/Components/OnboardingSelectionSummaryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F70E654847A2B4F0458F49F /* LifeBoard/Onboarding/Components/OnboardingSelectionSummaryCard.swift */; };
+		00E943E7872FB1B20D349D99 /* LifeBoard/State/Repositories/CoreDataOccurrenceRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E54F6F587FF89056E429DF /* LifeBoard/State/Repositories/CoreDataOccurrenceRepository.swift */; };
+		0122C4D3D195380D2CDCBED5 /* LifeBoard/Onboarding/Components/OnboardingChecklistCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA878C13E4A9CF39A3D86B40 /* LifeBoard/Onboarding/Components/OnboardingChecklistCard.swift */; };
+		014575655AA3DBD8B1BD4C5F /* LifeBoard/Views/Settings/LifeManagement/LifeManagementProjectDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10E031C3127045DB0AF8ACF9 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementProjectDetailView.swift */; };
+		01D3E1ADABC2FB7D419F301E /* LifeBoard/Onboarding/Models/AppOnboardingSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1859F3D260EADFEA49FDBA98 /* LifeBoard/Onboarding/Models/AppOnboardingSummary.swift */; };
 		02548417398F2FC3E57621F1 /* HomeArchitectureProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D48163BE7D31AF707E99B7 /* HomeArchitectureProtocols.swift */; };
-		02828F570030008E7C1B441C /* LifeAreaRepositoryProtocolExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4791B51EBAFFF32DE7642287 /* LifeAreaRepositoryProtocolExtension.swift */; };
-		032A6D4BF36C354B8064310D /* TimelineEndAddMarker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7694AF03A3EBC6AF9B70F6D5 /* TimelineEndAddMarker.swift */; };
-		032EBA2A2DF996C1E0110D70 /* DailyTimelineAgendaView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAED50033BDBC1C4321DF9AA /* DailyTimelineAgendaView.swift */; };
-		036E9881C0F7EC40685393B7 /* HomeOnboardingGuidanceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D9B95BD66FD5C98B9AB37AE /* HomeOnboardingGuidanceModel.swift */; };
-		03C55431D0F00584B024BACF /* TimelineStreamPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 093C76FA2FAF1A80BE897904 /* TimelineStreamPalette.swift */; };
-		03EE1F33BC0AB56FA78CCCBE /* TimelineTimeBlockCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 655BA9C40207D74248D209EE /* TimelineTimeBlockCard.swift */; };
-		041BEC95EB82F86644971605 /* HomeViewModel+TaskActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E1864B29C7801E433C2D11 /* HomeViewModel+TaskActions.swift */; };
+		02828F570030008E7C1B441C /* LifeBoard/Onboarding/Models/LifeAreaRepositoryProtocolExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4791B51EBAFFF32DE7642287 /* LifeBoard/Onboarding/Models/LifeAreaRepositoryProtocolExtension.swift */; };
+		032A6D4BF36C354B8064310D /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineEndAddMarker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7694AF03A3EBC6AF9B70F6D5 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineEndAddMarker.swift */; };
+		032EBA2A2DF996C1E0110D70 /* LifeBoard/Presentation/Home/Timeline/Surface/DailyTimelineAgendaView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAED50033BDBC1C4321DF9AA /* LifeBoard/Presentation/Home/Timeline/Surface/DailyTimelineAgendaView.swift */; };
+		036E9881C0F7EC40685393B7 /* LifeBoard/Onboarding/Services/HomeOnboardingGuidanceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D9B95BD66FD5C98B9AB37AE /* LifeBoard/Onboarding/Services/HomeOnboardingGuidanceModel.swift */; };
+		03C55431D0F00584B024BACF /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 093C76FA2FAF1A80BE897904 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamPalette.swift */; };
+		03EE1F33BC0AB56FA78CCCBE /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineTimeBlockCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 655BA9C40207D74248D209EE /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineTimeBlockCard.swift */; };
+		041BEC95EB82F86644971605 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+TaskActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E1864B29C7801E433C2D11 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+TaskActions.swift */; };
 		044ECC7C2F392E01E778DF95 /* ElevationTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADB62B5450F5D70EBBEC2940 /* ElevationTokens.swift */; };
 		0458C5D6A8E64302B1D4F06F /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 7524B71A2DE4EAC90026D865 /* GoogleService-Info.plist */; };
-		04821EE8B574D3BAF98E7B76 /* DeleteProjectSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8565ACC6D97DD8CCE34EA3E0 /* DeleteProjectSheet.swift */; };
-		04AD0E929FAB37FD57D8BCB8 /* OnboardingPainPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1DD1A6ABC050A464C7B4397 /* OnboardingPainPoint.swift */; };
-		05017EDD38C8DCBBD917220C /* timelineAccessibilityIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B6CF6BCC0828B64D4447931 /* timelineAccessibilityIdentifier.swift */; };
-		050AE50E81D4703777D6F0C1 /* HomeViewModel+RenderTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E69586D6A0661BB639FAE5F /* HomeViewModel+RenderTransaction.swift */; };
-		0512B30196300E86AE6ABE53 /* OnboardingFlowModel+CatalogPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079A43F8E9012BEFEACB658C /* OnboardingFlowModel+CatalogPresentation.swift */; };
+		04821EE8B574D3BAF98E7B76 /* LifeBoard/Views/Settings/LifeManagement/DeleteProjectSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8565ACC6D97DD8CCE34EA3E0 /* LifeBoard/Views/Settings/LifeManagement/DeleteProjectSheet.swift */; };
+		04AD0E929FAB37FD57D8BCB8 /* LifeBoard/Onboarding/Models/OnboardingPainPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1DD1A6ABC050A464C7B4397 /* LifeBoard/Onboarding/Models/OnboardingPainPoint.swift */; };
+		05017EDD38C8DCBBD917220C /* LifeBoard/Presentation/Home/Timeline/Surface/timelineAccessibilityIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B6CF6BCC0828B64D4447931 /* LifeBoard/Presentation/Home/Timeline/Surface/timelineAccessibilityIdentifier.swift */; };
+		050AE50E81D4703777D6F0C1 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+RenderTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E69586D6A0661BB639FAE5F /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+RenderTransaction.swift */; };
+		0512B30196300E86AE6ABE53 /* LifeBoard/Onboarding/Services/OnboardingFlowModel+CatalogPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079A43F8E9012BEFEACB658C /* LifeBoard/Onboarding/Services/OnboardingFlowModel+CatalogPresentation.swift */; };
 		0512DBCE948D6692B0F1857F /* LifeBoardThemeManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DA1D87ADF956BED887FE0CC /* LifeBoardThemeManagerTests.swift */; };
-		07F9DF04416807600DA792AA /* OnboardingInputField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0782589C1467EBE5827782EF /* OnboardingInputField.swift */; };
-		082C004A39ABC9840802B32C /* OverdueRescueUndoRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29E5D918391FC0B0AFC174A /* OverdueRescueUndoRecord.swift */; };
-		08CCE589CA3E83FE266289D1 /* CoreDataAssistantActionRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6747A1FAF23571C7A3DA320 /* CoreDataAssistantActionRepository.swift */; };
-		094363D420BA00C23B9DC952 /* ResolveHabitOccurrenceUseCaseExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72FC1B3486FA846731E8FCE6 /* ResolveHabitOccurrenceUseCaseExtension.swift */; };
-		096DC7AAFD7B5580A3DABEC3 /* lifeManagementHabitStatusText.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7E431C4A4980AE71FE5AB35 /* lifeManagementHabitStatusText.swift */; };
-		09C4C3472A904F2E9C0E819A /* SunriseTimelineSurface+PlacementHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51669681D49905D56C3864BD /* SunriseTimelineSurface+PlacementHelpers.swift */; };
-		09CD9170481BB868874A059E /* OnboardingPromptFooterMaterialModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 102FF39D56775B7335081882 /* OnboardingPromptFooterMaterialModifier.swift */; };
-		0A2C5397D36D0D8C6B082AE8 /* OverdueRescueDecisionAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510B0D69D4D3766C988BF637 /* OverdueRescueDecisionAction.swift */; };
-		0A469058A907DD61A98AAF4C /* LifeManagementComposerPreviewMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = 856DDB017465F5A7BA124E09 /* LifeManagementComposerPreviewMetric.swift */; };
-		0AA9543F5B27EAE43ABA8843 /* RecurrenceInstanceSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC4E24E658AA95B6A485F4AA /* RecurrenceInstanceSnapshot.swift */; };
-		0ACC457D0516F36AB25D3367 /* OnboardingPromptGlassPanelModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F67F2F26774817EB86045D0 /* OnboardingPromptGlassPanelModifier.swift */; };
-		0ACC594D16D9F9D83D812052 /* OnboardingFrictionProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9CD88BD827717D7C56D112A /* OnboardingFrictionProfile.swift */; };
-		0B2EA9B1BC50C6D572DBDA14 /* OnboardingWorkspaceSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 862166F085A7F815ADA70872 /* OnboardingWorkspaceSnapshot.swift */; };
-		0B3ACC1A28B21B661E547518 /* OnboardingFocusHeroCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 950F69C7A81EE1B80D656D06 /* OnboardingFocusHeroCard.swift */; };
+		07F9DF04416807600DA792AA /* LifeBoard/Onboarding/Models/OnboardingInputField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0782589C1467EBE5827782EF /* LifeBoard/Onboarding/Models/OnboardingInputField.swift */; };
+		082C004A39ABC9840802B32C /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueUndoRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29E5D918391FC0B0AFC174A /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueUndoRecord.swift */; };
+		08CCE589CA3E83FE266289D1 /* LifeBoard/State/Repositories/CoreDataAssistantActionRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6747A1FAF23571C7A3DA320 /* LifeBoard/State/Repositories/CoreDataAssistantActionRepository.swift */; };
+		094363D420BA00C23B9DC952 /* LifeBoard/Onboarding/Models/ResolveHabitOccurrenceUseCaseExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72FC1B3486FA846731E8FCE6 /* LifeBoard/Onboarding/Models/ResolveHabitOccurrenceUseCaseExtension.swift */; };
+		096DC7AAFD7B5580A3DABEC3 /* LifeBoard/Views/Settings/LifeManagement/lifeManagementHabitStatusText.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7E431C4A4980AE71FE5AB35 /* LifeBoard/Views/Settings/LifeManagement/lifeManagementHabitStatusText.swift */; };
+		09C4C3472A904F2E9C0E819A /* LifeBoard/Presentation/Home/Timeline/Surface/SunriseTimelineSurface+PlacementHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51669681D49905D56C3864BD /* LifeBoard/Presentation/Home/Timeline/Surface/SunriseTimelineSurface+PlacementHelpers.swift */; };
+		09CD9170481BB868874A059E /* LifeBoard/Onboarding/Models/OnboardingPromptFooterMaterialModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 102FF39D56775B7335081882 /* LifeBoard/Onboarding/Models/OnboardingPromptFooterMaterialModifier.swift */; };
+		0A2C5397D36D0D8C6B082AE8 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDecisionAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510B0D69D4D3766C988BF637 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDecisionAction.swift */; };
+		0A469058A907DD61A98AAF4C /* LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerPreviewMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = 856DDB017465F5A7BA124E09 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerPreviewMetric.swift */; };
+		0AA9543F5B27EAE43ABA8843 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/RecurrenceInstanceSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC4E24E658AA95B6A485F4AA /* LifeBoard/Presentation/Home/Modals/OverdueRescue/RecurrenceInstanceSnapshot.swift */; };
+		0ACC457D0516F36AB25D3367 /* LifeBoard/Onboarding/Models/OnboardingPromptGlassPanelModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F67F2F26774817EB86045D0 /* LifeBoard/Onboarding/Models/OnboardingPromptGlassPanelModifier.swift */; };
+		0ACC594D16D9F9D83D812052 /* LifeBoard/Onboarding/Models/OnboardingFrictionProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9CD88BD827717D7C56D112A /* LifeBoard/Onboarding/Models/OnboardingFrictionProfile.swift */; };
+		0B2EA9B1BC50C6D572DBDA14 /* LifeBoard/Onboarding/Models/OnboardingWorkspaceSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 862166F085A7F815ADA70872 /* LifeBoard/Onboarding/Models/OnboardingWorkspaceSnapshot.swift */; };
+		0B3ACC1A28B21B661E547518 /* LifeBoard/Onboarding/Components/OnboardingFocusHeroCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 950F69C7A81EE1B80D656D06 /* LifeBoard/Onboarding/Components/OnboardingFocusHeroCard.swift */; };
 		0BF080CECE0D47F110E23C11 /* SettingsRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC92DC6157EF1B9AAB1422D9 /* SettingsRootView.swift */; };
-		0C1F3166AD2FCCA3FF3814DC /* OverdueRescueEditDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035ACE6073D062BB622B9CF2 /* OverdueRescueEditDraft.swift */; };
-		0C2ECCAB66276D4F1B630EBE /* OnboardingFrictionSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74E0C50451A57E60BB0E3EC8 /* OnboardingFrictionSelector.swift */; };
-		0C972AF626F688F063459503 /* timelineTitleColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A455CC1761B05C261D2051B /* timelineTitleColor.swift */; };
-		0CE03D5DE6944FB2FE2FBA3F /* timelineSuggestedAddDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B7A1ACCF6D1219FEF880EC /* timelineSuggestedAddDate.swift */; };
-		0D77AD04BFBCEC5DAB92B68D /* ScheduleRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712BE2C322E8930A4886933B /* ScheduleRepositoryProtocol.swift */; };
-		0D84D0166C11E5E8015ACA82 /* HomeTimelineSnapshotCacheKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6FB0479B78BDE0B210F2E8 /* HomeTimelineSnapshotCacheKey.swift */; };
-		0DDCFBDB474413795EC30643 /* HomeCalendarEventDetailSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16B708DAB6EC819BECE9B5A8 /* HomeCalendarEventDetailSelection.swift */; };
-		0EC49C3CF56F9FF0863151BD /* HomeViewModelRoot.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2CDAC6D56F874D92E1DD4D /* HomeViewModelRoot.swift */; };
-		0EC4FE8730866512296A0674 /* OverdueRescueDecisionSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F86906A0E4C13F4F10D0C6B /* OverdueRescueDecisionSource.swift */; };
-		0EDFDE262FBEB052B1E2BDFE /* EvaChatSunriseBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2D47EF8C1159050CDCE28D6 /* EvaChatSunriseBackground.swift */; };
+		0C1F3166AD2FCCA3FF3814DC /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueEditDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035ACE6073D062BB622B9CF2 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueEditDraft.swift */; };
+		0C2ECCAB66276D4F1B630EBE /* LifeBoard/Onboarding/Components/OnboardingFrictionSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74E0C50451A57E60BB0E3EC8 /* LifeBoard/Onboarding/Components/OnboardingFrictionSelector.swift */; };
+		0C972AF626F688F063459503 /* LifeBoard/Presentation/Home/Timeline/Surface/timelineTitleColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A455CC1761B05C261D2051B /* LifeBoard/Presentation/Home/Timeline/Surface/timelineTitleColor.swift */; };
+		0CE03D5DE6944FB2FE2FBA3F /* LifeBoard/Presentation/Home/Timeline/Surface/timelineSuggestedAddDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B7A1ACCF6D1219FEF880EC /* LifeBoard/Presentation/Home/Timeline/Surface/timelineSuggestedAddDate.swift */; };
+		0D77AD04BFBCEC5DAB92B68D /* LifeBoard/Domain/Interfaces/ScheduleRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712BE2C322E8930A4886933B /* LifeBoard/Domain/Interfaces/ScheduleRepositoryProtocol.swift */; };
+		0D84D0166C11E5E8015ACA82 /* LifeBoard/Presentation/ViewModels/Home/HomeTimelineSnapshotCacheKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6FB0479B78BDE0B210F2E8 /* LifeBoard/Presentation/ViewModels/Home/HomeTimelineSnapshotCacheKey.swift */; };
+		0DDCFBDB474413795EC30643 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeCalendarEventDetailSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16B708DAB6EC819BECE9B5A8 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeCalendarEventDetailSelection.swift */; };
+		0EC49C3CF56F9FF0863151BD /* LifeBoard/Presentation/ViewModels/Home/HomeViewModelRoot.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2CDAC6D56F874D92E1DD4D /* LifeBoard/Presentation/ViewModels/Home/HomeViewModelRoot.swift */; };
+		0EC4FE8730866512296A0674 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDecisionSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F86906A0E4C13F4F10D0C6B /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDecisionSource.swift */; };
+		0EDFDE262FBEB052B1E2BDFE /* LifeBoard/LLM/Views/Chat/Chrome/EvaChatSunriseBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2D47EF8C1159050CDCE28D6 /* LifeBoard/LLM/Views/Chat/Chrome/EvaChatSunriseBackground.swift */; };
 		0F2D95B3C4177167351607FF /* SlashCommandPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D25A779BBE1A1B798EFA4D /* SlashCommandPickerView.swift */; };
-		0F67D9989E8924F5B6E2B2EE /* CoreDataLifeAreaRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26D9ECAA7CAE990AACBF05E5 /* CoreDataLifeAreaRepository.swift */; };
-		0F7C061EF4DA8BEF5A8909BC /* WidgetSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21637D8476DC186EA285FB33 /* WidgetSnapshot.swift */; };
-		0F97D0D0CB26167BF4F3E1DD /* HomeViewModel+DailyReflectionPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = E76B472B10FBCD33AF5BF327 /* HomeViewModel+DailyReflectionPreview.swift */; };
-		0FF401A34059E3AECC2B14B1 /* OnboardingProjectDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98AB62BE5A27121F39C5F499 /* OnboardingProjectDraft.swift */; };
-		108EDCB9266B21C80D773BBC /* TimelineUtilityRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ABE9BAD19D384E04867D9B2 /* TimelineUtilityRow.swift */; };
-		10BDA207EE601292AB9E1231 /* OnboardingTaskPreviewCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4A401D3FB5682FC6804B6F /* OnboardingTaskPreviewCard.swift */; };
-		10F906589FFC0DE720F5FEB2 /* TimelineEmptyStateCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77551CB92362A8FB48666198 /* TimelineEmptyStateCard.swift */; };
-		1138787A92BD5440BF7B4D2D /* CurvingDayStreamView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341974EF0AE031E749EE396D /* CurvingDayStreamView.swift */; };
-		117D70E33461D260AF2A46C1 /* HomeDenseSurfaceModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 786CACDAB366EB8BCBB657A3 /* HomeDenseSurfaceModifier.swift */; };
-		1189D09985E33267B5E56A34 /* NSLockExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F0DB5144721E54F43222D3D /* NSLockExtension.swift */; };
+		0F67D9989E8924F5B6E2B2EE /* LifeBoard/State/Repositories/CoreDataLifeAreaRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26D9ECAA7CAE990AACBF05E5 /* LifeBoard/State/Repositories/CoreDataLifeAreaRepository.swift */; };
+		0F7C061EF4DA8BEF5A8909BC /* Shared/WidgetSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21637D8476DC186EA285FB33 /* Shared/WidgetSnapshot.swift */; };
+		0F97D0D0CB26167BF4F3E1DD /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+DailyReflectionPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = E76B472B10FBCD33AF5BF327 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+DailyReflectionPreview.swift */; };
+		0FF401A34059E3AECC2B14B1 /* LifeBoard/Onboarding/Models/OnboardingProjectDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98AB62BE5A27121F39C5F499 /* LifeBoard/Onboarding/Models/OnboardingProjectDraft.swift */; };
+		108EDCB9266B21C80D773BBC /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineUtilityRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ABE9BAD19D384E04867D9B2 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineUtilityRow.swift */; };
+		10BDA207EE601292AB9E1231 /* LifeBoard/Onboarding/Components/OnboardingTaskPreviewCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4A401D3FB5682FC6804B6F /* LifeBoard/Onboarding/Components/OnboardingTaskPreviewCard.swift */; };
+		10F906589FFC0DE720F5FEB2 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineEmptyStateCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77551CB92362A8FB48666198 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineEmptyStateCard.swift */; };
+		1138787A92BD5440BF7B4D2D /* LifeBoard/Presentation/Home/Timeline/Surface/CurvingDayStreamView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 341974EF0AE031E749EE396D /* LifeBoard/Presentation/Home/Timeline/Surface/CurvingDayStreamView.swift */; };
+		117D70E33461D260AF2A46C1 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeDenseSurfaceModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 786CACDAB366EB8BCBB657A3 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeDenseSurfaceModifier.swift */; };
+		1189D09985E33267B5E56A34 /* LifeBoard/Presentation/ViewModels/Home/NSLockExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F0DB5144721E54F43222D3D /* LifeBoard/Presentation/ViewModels/Home/NSLockExtension.swift */; };
 		11B9B8EE3F64B7B3AC3E53AC /* DueSoonLeadTimeCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267DB3EE27A6E3C161F380D5 /* DueSoonLeadTimeCard.swift */; };
-		11E1CAF9151542D119B4883B /* OnboardingPromptPrimaryCTAButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = F29A008521575A41C80A3750 /* OnboardingPromptPrimaryCTAButtonStyle.swift */; };
-		1225D0DCBDEB90ACA96B6B5F /* TimelineCapsule.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F234318A9DB1B304DDACC7 /* TimelineCapsule.swift */; };
-		125D26BDB072E9A8F3E515D7 /* OnboardingTaskTemplateState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 098E6EFC49514867101BA977 /* OnboardingTaskTemplateState.swift */; };
-		1274375D849BBF28D4DF1408 /* OnboardingDownloadStatusPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DB2B7298DBBD959D03B5D5 /* OnboardingDownloadStatusPill.swift */; };
-		1325F41FAECBAE30E66C3E42 /* V2RepositoryProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42AD2BFC988A80E8157AD2B2 /* V2RepositoryProtocols.swift */; };
-		13654561D6AE1564FAA82441 /* OverdueRescueBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DC33D900FB020DE25E9BA33 /* OverdueRescueBackground.swift */; };
-		13AFF7E41F28B08AD43AA900 /* StarterHabitTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C18263F8735AB2DC17840F5 /* StarterHabitTemplate.swift */; };
-		13B527B121DA29E15716552A /* TimelineRailMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DE0001352EA0BD0110E4A7F /* TimelineRailMetrics.swift */; };
-		13E26BA7B62EB8B9BACF274E /* AppOnboardingBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78CBCB775F9593EF36C11AB8 /* AppOnboardingBackground.swift */; };
-		144C7E3E26AF1D97BC310AFF /* ProjectListRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76771B9AECD05123393780BE /* ProjectListRow.swift */; };
-		147231A5B5EE1AFA9351EA13 /* TagDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2C66FE334854F296A4203FD /* TagDefinition.swift */; };
+		11E1CAF9151542D119B4883B /* LifeBoard/Onboarding/Components/OnboardingPromptPrimaryCTAButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = F29A008521575A41C80A3750 /* LifeBoard/Onboarding/Components/OnboardingPromptPrimaryCTAButtonStyle.swift */; };
+		1225D0DCBDEB90ACA96B6B5F /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCapsule.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F234318A9DB1B304DDACC7 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCapsule.swift */; };
+		125D26BDB072E9A8F3E515D7 /* LifeBoard/Onboarding/Models/OnboardingTaskTemplateState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 098E6EFC49514867101BA977 /* LifeBoard/Onboarding/Models/OnboardingTaskTemplateState.swift */; };
+		1274375D849BBF28D4DF1408 /* LifeBoard/Onboarding/Models/OnboardingDownloadStatusPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DB2B7298DBBD959D03B5D5 /* LifeBoard/Onboarding/Models/OnboardingDownloadStatusPill.swift */; };
+		1325F41FAECBAE30E66C3E42 /* LifeBoard/Domain/Interfaces/V2RepositoryProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42AD2BFC988A80E8157AD2B2 /* LifeBoard/Domain/Interfaces/V2RepositoryProtocols.swift */; };
+		13654561D6AE1564FAA82441 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DC33D900FB020DE25E9BA33 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueBackground.swift */; };
+		13AFF7E41F28B08AD43AA900 /* LifeBoard/Onboarding/Models/StarterHabitTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C18263F8735AB2DC17840F5 /* LifeBoard/Onboarding/Models/StarterHabitTemplate.swift */; };
+		13B527B121DA29E15716552A /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DE0001352EA0BD0110E4A7F /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailMetrics.swift */; };
+		13E26BA7B62EB8B9BACF274E /* LifeBoard/Onboarding/Views/AppOnboardingBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78CBCB775F9593EF36C11AB8 /* LifeBoard/Onboarding/Views/AppOnboardingBackground.swift */; };
+		144C7E3E26AF1D97BC310AFF /* LifeBoard/Views/Settings/LifeManagement/ProjectListRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76771B9AECD05123393780BE /* LifeBoard/Views/Settings/LifeManagement/ProjectListRow.swift */; };
+		147231A5B5EE1AFA9351EA13 /* LifeBoard/Domain/Models/TagDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2C66FE334854F296A4203FD /* LifeBoard/Domain/Models/TagDefinition.swift */; };
 		148DF59423DB8F002C665F90 /* HomeViewController+Navigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F90A4ACBFBF5EEA42C69976 /* HomeViewController+Navigation.swift */; };
-		14CDB6B6887E83C9AF1E8412 /* OnboardingPromptBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8F9A299A8C725C1852BB744 /* OnboardingPromptBackground.swift */; };
-		160F368EB1102A7D052D2220 /* HomeOverdueRescueLauncherState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C12D0895BE1B134C2DEDF5 /* HomeOverdueRescueLauncherState.swift */; };
-		166AB064CD81E7EAF6579B7E /* CoreDataSectionRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0E3799E6AD3B71C2BCAA18D /* CoreDataSectionRepository.swift */; };
-		1670AB6E54D82AC77EBC9B3D /* CoreDataScheduleRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6248E090BE231D70E41F08C /* CoreDataScheduleRepository.swift */; };
-		16E09E0E5A4633E33062DF74 /* HomeViewModel+DueTodayAgenda.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06C9F0E1B9A7D11A42BEFEB1 /* HomeViewModel+DueTodayAgenda.swift */; };
-		16FDAE94A8B5B7D16F330DF2 /* HomeHabitMutationRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E03A10085F34C95F49402B3 /* HomeHabitMutationRequest.swift */; };
-		170D294E77D3B8898DFD0D85 /* HomeViewModel+FocusPins.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66890102B461937BC39F7607 /* HomeViewModel+FocusPins.swift */; };
-		17EF835E3AB7BCA161FBFB5C /* logOnboardingInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB34BB65B7298F039E9C6A1C /* logOnboardingInfo.swift */; };
-		181CC936773A7F7700000000 /* HomeViewModel+Bindings.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF57C7F694B30CF25D4C71B7 /* HomeViewModel+Bindings.swift */; };
-		182AF6ED0E5475309A58CDF0 /* OverdueRescueViewModel+SessionPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECDCDBED7855DBFB44F46DFD /* OverdueRescueViewModel+SessionPersistence.swift */; };
-		1842D1AB7AB9D66E5A024CEE /* OnboardingFilterChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F2067B7B6ACA2A4A2DA6279 /* OnboardingFilterChip.swift */; };
-		18BC4EA3F8C23BB362367B1B /* OnboardingHabitStreakPreviewCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC2F92D22CA429D62EFD9F46 /* OnboardingHabitStreakPreviewCard.swift */; };
+		14CDB6B6887E83C9AF1E8412 /* LifeBoard/Onboarding/Components/OnboardingPromptBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8F9A299A8C725C1852BB744 /* LifeBoard/Onboarding/Components/OnboardingPromptBackground.swift */; };
+		160F368EB1102A7D052D2220 /* LifeBoard/Presentation/ViewModels/Home/HomeOverdueRescueLauncherState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C12D0895BE1B134C2DEDF5 /* LifeBoard/Presentation/ViewModels/Home/HomeOverdueRescueLauncherState.swift */; };
+		166AB064CD81E7EAF6579B7E /* LifeBoard/State/Repositories/CoreDataSectionRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0E3799E6AD3B71C2BCAA18D /* LifeBoard/State/Repositories/CoreDataSectionRepository.swift */; };
+		1670AB6E54D82AC77EBC9B3D /* LifeBoard/State/Repositories/CoreDataScheduleRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6248E090BE231D70E41F08C /* LifeBoard/State/Repositories/CoreDataScheduleRepository.swift */; };
+		16E09E0E5A4633E33062DF74 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+DueTodayAgenda.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06C9F0E1B9A7D11A42BEFEB1 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+DueTodayAgenda.swift */; };
+		16FDAE94A8B5B7D16F330DF2 /* LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E03A10085F34C95F49402B3 /* LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationRequest.swift */; };
+		170D294E77D3B8898DFD0D85 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+FocusPins.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66890102B461937BC39F7607 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+FocusPins.swift */; };
+		17EF835E3AB7BCA161FBFB5C /* LifeBoard/Onboarding/Models/logOnboardingInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB34BB65B7298F039E9C6A1C /* LifeBoard/Onboarding/Models/logOnboardingInfo.swift */; };
+		181CC936773A7F7700000000 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+Bindings.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF57C7F694B30CF25D4C71B7 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+Bindings.swift */; };
+		182AF6ED0E5475309A58CDF0 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueViewModel+SessionPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECDCDBED7855DBFB44F46DFD /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueViewModel+SessionPersistence.swift */; };
+		1842D1AB7AB9D66E5A024CEE /* LifeBoard/Onboarding/Components/OnboardingFilterChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F2067B7B6ACA2A4A2DA6279 /* LifeBoard/Onboarding/Components/OnboardingFilterChip.swift */; };
+		18BC4EA3F8C23BB362367B1B /* LifeBoard/Onboarding/Components/OnboardingHabitStreakPreviewCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC2F92D22CA429D62EFD9F46 /* LifeBoard/Onboarding/Components/OnboardingHabitStreakPreviewCard.swift */; };
 		18C32A093ADC765E90DBA71D /* AddTaskTagMultiSelect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95932952BC5EBADE8D30791C /* AddTaskTagMultiSelect.swift */; };
-		19062C6842CD068931CB3D63 /* OverdueRescuePlant.swift in Sources */ = {isa = PBXBuildFile; fileRef = B543DD59DC3D9705F73261A4 /* OverdueRescuePlant.swift */; };
-		193F65F5AD20237F0366DCF8 /* StarterTaskTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A7A770EE9760A923219618 /* StarterTaskTemplate.swift */; };
-		19B603FD5B8EFE10233D20EE /* HomeReplanUndoEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC10C732F02AD5EBF16333E3 /* HomeReplanUndoEntry.swift */; };
-		1A469FF8CAAD8B2B7D9A2FEF /* HomeTimelineReplanStateSignature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078F0DB7D6806A7A2A660437 /* HomeTimelineReplanStateSignature.swift */; };
-		1AC6BA7B2FA7EB7216540681 /* LifeManagementMenuLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D2BF6A90C40333A4450474A /* LifeManagementMenuLabel.swift */; };
+		19062C6842CD068931CB3D63 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescuePlant.swift in Sources */ = {isa = PBXBuildFile; fileRef = B543DD59DC3D9705F73261A4 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescuePlant.swift */; };
+		193F65F5AD20237F0366DCF8 /* LifeBoard/Onboarding/Models/StarterTaskTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A7A770EE9760A923219618 /* LifeBoard/Onboarding/Models/StarterTaskTemplate.swift */; };
+		19B603FD5B8EFE10233D20EE /* LifeBoard/Presentation/ViewModels/Home/HomeReplanUndoEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC10C732F02AD5EBF16333E3 /* LifeBoard/Presentation/ViewModels/Home/HomeReplanUndoEntry.swift */; };
+		1A469FF8CAAD8B2B7D9A2FEF /* LifeBoard/Presentation/ViewModels/Home/HomeTimelineReplanStateSignature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078F0DB7D6806A7A2A660437 /* LifeBoard/Presentation/ViewModels/Home/HomeTimelineReplanStateSignature.swift */; };
+		1AC6BA7B2FA7EB7216540681 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementMenuLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D2BF6A90C40333A4450474A /* LifeBoard/Views/Settings/LifeManagement/LifeManagementMenuLabel.swift */; };
 		1ACBC36A38323DB2A8E4EC02 /* CornerTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C72110A1F555F951D89BBEB /* CornerTokens.swift */; };
 		1B77769B1FFEBB2FA951419F /* AddTaskMetadataRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607D98C13538414095C75E7B /* AddTaskMetadataRow.swift */; };
-		1C0ACEFFC26353A9CA10873F /* lifeManagementResolvedColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50AA42860707B829E6114218 /* lifeManagementResolvedColor.swift */; };
-		1D443F47BB19EE9B20BFC4EE /* HomeHabitMutationKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AB81062DAE961E3F10652E2 /* HomeHabitMutationKey.swift */; };
-		1D79C65FEB0FF79A7D4C349D /* RecordXPUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05E5245EF6140902F09F99CA /* RecordXPUseCase.swift */; };
-		1D8B3A4014113650D7298CA5 /* LifeManagementComposerRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BD755574209F1D4DACEFE20 /* LifeManagementComposerRoute.swift */; };
-		1D91EF2A13A06697AF7AB056 /* LifeManagementComposerFieldLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D285845FE9143539A3C857A /* LifeManagementComposerFieldLabel.swift */; };
-		1E448F0CF8BEEFF9349F0F7E /* TimelineLongGapIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F71AFCC54832F564B2D7CED /* TimelineLongGapIndicator.swift */; };
-		1E4C2C3AAF40D4455D5A2625 /* ManageHabitsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B69EFFAB72804AE4A38EB3 /* ManageHabitsUseCase.swift */; };
+		1C0ACEFFC26353A9CA10873F /* LifeBoard/Views/Settings/LifeManagement/lifeManagementResolvedColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50AA42860707B829E6114218 /* LifeBoard/Views/Settings/LifeManagement/lifeManagementResolvedColor.swift */; };
+		1D443F47BB19EE9B20BFC4EE /* LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AB81062DAE961E3F10652E2 /* LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationKey.swift */; };
+		1D79C65FEB0FF79A7D4C349D /* LifeBoard/UseCases/Gamification/RecordXPUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05E5245EF6140902F09F99CA /* LifeBoard/UseCases/Gamification/RecordXPUseCase.swift */; };
+		1D8B3A4014113650D7298CA5 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BD755574209F1D4DACEFE20 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerRoute.swift */; };
+		1D91EF2A13A06697AF7AB056 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerFieldLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D285845FE9143539A3C857A /* LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerFieldLabel.swift */; };
+		1E448F0CF8BEEFF9349F0F7E /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineLongGapIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F71AFCC54832F564B2D7CED /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineLongGapIndicator.swift */; };
+		1E4C2C3AAF40D4455D5A2625 /* LifeBoard/UseCases/Habit/ManageHabitsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B69EFFAB72804AE4A38EB3 /* LifeBoard/UseCases/Habit/ManageHabitsUseCase.swift */; };
 		1E5654B0467738918FD0492C /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C3D8D5167F9519588886C38B /* Foundation.framework */; };
-		1E7D50D956C53289A4DC9691 /* TimelineFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EA1722FAD5507224C2ED584 /* TimelineFormatting.swift */; };
-		1E8F023F70606AF2879DEFBE /* LifeManagementAreaPaletteOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F73F08CE7AF7398D7835E7F /* LifeManagementAreaPaletteOption.swift */; };
-		1F2D5D429CB73C24348EE788 /* EvaWorkingStatusLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0E5A5DE6FF2E8EEACA4280 /* EvaWorkingStatusLibrary.swift */; };
+		1E7D50D956C53289A4DC9691 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EA1722FAD5507224C2ED584 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineFormatting.swift */; };
+		1E8F023F70606AF2879DEFBE /* LifeBoard/Views/Settings/LifeManagement/LifeManagementAreaPaletteOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F73F08CE7AF7398D7835E7F /* LifeBoard/Views/Settings/LifeManagement/LifeManagementAreaPaletteOption.swift */; };
+		1F2D5D429CB73C24348EE788 /* LifeBoard/LLM/Views/Chat/Conversation/EvaWorkingStatusLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0E5A5DE6FF2E8EEACA4280 /* LifeBoard/LLM/Views/Chat/Conversation/EvaWorkingStatusLibrary.swift */; };
 		1F9B00012FBA700000000001 /* HomeNavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F9B00002FBA700000000001 /* HomeNavigationCoordinator.swift */; };
 		1F9B00032FBA700000000003 /* HomeReloadCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F9B00022FBA700000000003 /* HomeReloadCoordinator.swift */; };
 		1F9B00052FBA700000000005 /* HomeNavigationIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F9B00042FBA700000000004 /* HomeNavigationIntent.swift */; };
 		1F9B00072FBA700000000007 /* HomeNavigationEventAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F9B00062FBA700000000006 /* HomeNavigationEventAdapter.swift */; };
 		1F9B00092FBA700000000009 /* HomeLaunchHarnessService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F9B00082FBA700000000008 /* HomeLaunchHarnessService.swift */; };
 		200250316B998CD442EAD960 /* TimelineRendererModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4777F58ED4D4C8E747F0F901 /* TimelineRendererModels.swift */; };
-		20E905AEA02392CC5482222E /* HomeViewModel+RescueEligibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 391110AA08B7ED7F8ED57B9C /* HomeViewModel+RescueEligibility.swift */; };
-		20F7A92A6373992D5B74E817 /* OnboardingHabitTemplateState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E4F64519A39289AF03A73C /* OnboardingHabitTemplateState.swift */; };
-		21828AB3835916ECE946A73F /* OverdueRescueDeleteOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63D95372962F61A5E50E9F9 /* OverdueRescueDeleteOverlay.swift */; };
-		21D645FE5F1A842122F06A51 /* HomeTaskDetailMetadataState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B60F4DC92BA3ACD065F8D3 /* HomeTaskDetailMetadataState.swift */; };
-		21F6DC4C03DB207B0F93B967 /* TimelineStreamDirection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D721CBA93E7A9DDD50E1C65C /* TimelineStreamDirection.swift */; };
-		220B2D5DF3B84749D8AABC99 /* HomeViewModel+DailySummaryModal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81B4061464040091D355959D /* HomeViewModel+DailySummaryModal.swift */; };
-		223050CBCB2512809C97BFE4 /* OverdueRescueTaskCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 931896F94542B69EC7D8FCB7 /* OverdueRescueTaskCard.swift */; };
-		2330C3F5294BC6FE822B80D0 /* EvaChiefOfStaffGuideContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42885152818D9953B13C071B /* EvaChiefOfStaffGuideContent.swift */; };
-		23D6911A2603575D6C3B32B4 /* TimelineVisualTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = A109D2B957E1D5A47149A0D9 /* TimelineVisualTokens.swift */; };
-		23D6A9438FB6BD00F6A8483A /* HomeTimelineEventSignature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EC8D7FF629E27D3B426AD36 /* HomeTimelineEventSignature.swift */; };
-		25FC3C1A435E0F8199ADBCD5 /* ProjectRepositoryProtocolExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DF50E6CD46F6C802CC86EE /* ProjectRepositoryProtocolExtension.swift */; };
-		262A9D38982EE6BE9E44E616 /* OnboardingPresentationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2139792A102DCF4971E889CC /* OnboardingPresentationQueue.swift */; };
-		263B577D54B198C0599992DE /* HomeHabitMutationSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72A5D667C54915B85FDEAA65 /* HomeHabitMutationSnapshot.swift */; };
+		20E905AEA02392CC5482222E /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+RescueEligibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 391110AA08B7ED7F8ED57B9C /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+RescueEligibility.swift */; };
+		20F7A92A6373992D5B74E817 /* LifeBoard/Onboarding/Models/OnboardingHabitTemplateState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E4F64519A39289AF03A73C /* LifeBoard/Onboarding/Models/OnboardingHabitTemplateState.swift */; };
+		21828AB3835916ECE946A73F /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDeleteOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63D95372962F61A5E50E9F9 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDeleteOverlay.swift */; };
+		21D645FE5F1A842122F06A51 /* LifeBoard/Presentation/ViewModels/Home/HomeTaskDetailMetadataState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B60F4DC92BA3ACD065F8D3 /* LifeBoard/Presentation/ViewModels/Home/HomeTaskDetailMetadataState.swift */; };
+		21F6DC4C03DB207B0F93B967 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamDirection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D721CBA93E7A9DDD50E1C65C /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamDirection.swift */; };
+		220B2D5DF3B84749D8AABC99 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+DailySummaryModal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81B4061464040091D355959D /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+DailySummaryModal.swift */; };
+		223050CBCB2512809C97BFE4 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueTaskCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 931896F94542B69EC7D8FCB7 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueTaskCard.swift */; };
+		2330C3F5294BC6FE822B80D0 /* LifeBoard/LLM/Views/Chat/Chrome/EvaChiefOfStaffGuideContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42885152818D9953B13C071B /* LifeBoard/LLM/Views/Chat/Chrome/EvaChiefOfStaffGuideContent.swift */; };
+		23D6911A2603575D6C3B32B4 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineVisualTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = A109D2B957E1D5A47149A0D9 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineVisualTokens.swift */; };
+		23D6A9438FB6BD00F6A8483A /* LifeBoard/Presentation/ViewModels/Home/HomeTimelineEventSignature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EC8D7FF629E27D3B426AD36 /* LifeBoard/Presentation/ViewModels/Home/HomeTimelineEventSignature.swift */; };
+		25FC3C1A435E0F8199ADBCD5 /* LifeBoard/Onboarding/Models/ProjectRepositoryProtocolExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DF50E6CD46F6C802CC86EE /* LifeBoard/Onboarding/Models/ProjectRepositoryProtocolExtension.swift */; };
+		262A9D38982EE6BE9E44E616 /* LifeBoard/Onboarding/Models/OnboardingPresentationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2139792A102DCF4971E889CC /* LifeBoard/Onboarding/Models/OnboardingPresentationQueue.swift */; };
+		263B577D54B198C0599992DE /* LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72A5D667C54915B85FDEAA65 /* LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationSnapshot.swift */; };
 		268BE6701AAC432C4DDDF880 /* SpacingTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = D39BBE25D96F4BE6E41320B1 /* SpacingTokens.swift */; };
-		2721FCB8D7ABE25DBC7508B1 /* TimelineOverlapItemCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B5B7AA06E3FAF9CBF2A49AE /* TimelineOverlapItemCard.swift */; };
+		2721FCB8D7ABE25DBC7508B1 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineOverlapItemCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B5B7AA06E3FAF9CBF2A49AE /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineOverlapItemCard.swift */; };
 		273B0CB5CC4D28068F5487FC /* TimelinePreferenceKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1144C788F612CB7B2BB7458B /* TimelinePreferenceKeys.swift */; };
 		27F1CA9185082A8916CE7149 /* ColorTokenGenerationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24EC3451B4B59726B8F286E2 /* ColorTokenGenerationTests.swift */; };
-		28F2FC0F85DA578FDDEC4C32 /* OnboardingPromptChecklistCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3206AE8D772083ABEFFE26DA /* OnboardingPromptChecklistCard.swift */; };
-		29AAA780F791C00A198F8FA7 /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E05701BAFA3071AD793273F1 /* StringExtension.swift */; };
+		28F2FC0F85DA578FDDEC4C32 /* LifeBoard/Onboarding/Components/OnboardingPromptChecklistCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3206AE8D772083ABEFFE26DA /* LifeBoard/Onboarding/Components/OnboardingPromptChecklistCard.swift */; };
+		29AAA780F791C00A198F8FA7 /* LifeBoard/Views/Settings/LifeManagement/StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E05701BAFA3071AD793273F1 /* LifeBoard/Views/Settings/LifeManagement/StringExtension.swift */; };
 		2B71D2795D489D1A2A582629 /* AppIntents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 35E5A3CA91F06A962F9FF9FA /* AppIntents.framework */; };
-		2C3429C2681D310EA9197AE3 /* LinkExternalRemindersUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C109B5D75A091971FB33633 /* LinkExternalRemindersUseCase.swift */; };
-		2C4A24B77FA545940760F514 /* EvaOverdueRescueSheetV2Root.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269A705710B0EA3EFEDCBE82 /* EvaOverdueRescueSheetV2Root.swift */; };
-		2C9423200947462BB96E027D /* OverdueRescueBackCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A57B08A1BB4BC36FE63B9B /* OverdueRescueBackCards.swift */; };
-		2CBC973505B2E0B6424541FB /* TimelineCompactLayoutPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0C44769FFD55EF43FB1B63 /* TimelineCompactLayoutPlan.swift */; };
-		2D8D1185CFE2993F5861CAC2 /* SunriseTimelineSurfaceRoot.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5AE575AEC28DEC3F5464818 /* SunriseTimelineSurfaceRoot.swift */; };
-		2DAC4DF99D4D0356E58AC4C2 /* TimelinePalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B764C348624AC32EFC9F04F /* TimelinePalette.swift */; };
-		2E47612416B8D316F93760D1 /* TimelineGapExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82CED5AEF0E893280880972E /* TimelineGapExtension.swift */; };
-		2E5BDB7E8B94F068AE98C73B /* OnboardingSuccessSummaryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E20317B5C516035FAEE85D /* OnboardingSuccessSummaryCard.swift */; };
-		2E5FB69076ABDE23D77BDCF4 /* OverdueRescueQuickEditSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B700950871CD345DFF559A61 /* OverdueRescueQuickEditSheet.swift */; };
-		2EAFE882376B87E7901A885D /* TimelineSpineMounting.swift in Sources */ = {isa = PBXBuildFile; fileRef = B822ABD8182F921799838D39 /* TimelineSpineMounting.swift */; };
+		2C3429C2681D310EA9197AE3 /* LifeBoard/UseCases/Sync/LinkExternalRemindersUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C109B5D75A091971FB33633 /* LifeBoard/UseCases/Sync/LinkExternalRemindersUseCase.swift */; };
+		2C4A24B77FA545940760F514 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/EvaOverdueRescueSheetV2Root.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269A705710B0EA3EFEDCBE82 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/EvaOverdueRescueSheetV2Root.swift */; };
+		2C9423200947462BB96E027D /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueBackCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A57B08A1BB4BC36FE63B9B /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueBackCards.swift */; };
+		2CBC973505B2E0B6424541FB /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompactLayoutPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0C44769FFD55EF43FB1B63 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompactLayoutPlan.swift */; };
+		2D8D1185CFE2993F5861CAC2 /* LifeBoard/Presentation/Home/Timeline/Surface/SunriseTimelineSurfaceRoot.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5AE575AEC28DEC3F5464818 /* LifeBoard/Presentation/Home/Timeline/Surface/SunriseTimelineSurfaceRoot.swift */; };
+		2DAC4DF99D4D0356E58AC4C2 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelinePalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B764C348624AC32EFC9F04F /* LifeBoard/Presentation/Home/Timeline/Surface/TimelinePalette.swift */; };
+		2E47612416B8D316F93760D1 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineGapExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82CED5AEF0E893280880972E /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineGapExtension.swift */; };
+		2E5BDB7E8B94F068AE98C73B /* LifeBoard/Onboarding/Components/OnboardingSuccessSummaryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E20317B5C516035FAEE85D /* LifeBoard/Onboarding/Components/OnboardingSuccessSummaryCard.swift */; };
+		2E5FB69076ABDE23D77BDCF4 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueQuickEditSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B700950871CD345DFF559A61 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueQuickEditSheet.swift */; };
+		2EAFE882376B87E7901A885D /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineSpineMounting.swift in Sources */ = {isa = PBXBuildFile; fileRef = B822ABD8182F921799838D39 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineSpineMounting.swift */; };
 		2F8630D073B32E4FB52F1DAE /* NextActionModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FCA458CC709E59AA20BC5C8 /* NextActionModule.swift */; };
-		2F9410224630703F3E950DDD /* OnboardingStepVisualTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38BF65FECAAA9E50000FFA9E /* OnboardingStepVisualTheme.swift */; };
-		300E318A0AD9AB7F088C497E /* ManageTagsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0643A03092D9D90FE7DC26D4 /* ManageTagsUseCase.swift */; };
-		308A7EC3564F5C557224C776 /* OccurrenceRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74615C475C9EB3F67E96D7FE /* OccurrenceRepositoryProtocol.swift */; };
-		30B49EE9EC93A901D247EA1F /* CoreSchedulingEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = F311D68194F7FDAA5BAD7ADA /* CoreSchedulingEngine.swift */; };
-		30CF71E853B4D59EBDBDA4AE /* ChatEmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 509DC1C9038663BEFE00C96F /* ChatEmptyStateView.swift */; };
-		314809E17C3C294340F2DA1E /* LifeManagementAppearanceLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43CB43D27ACFD36EEFFDD829 /* LifeManagementAppearanceLine.swift */; };
-		319DAA1BD9A0076B2E78F2C7 /* TimelineFlockBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B9E9E50F4A0FB453B025B6A /* TimelineFlockBlock.swift */; };
+		2F9410224630703F3E950DDD /* LifeBoard/Onboarding/Models/OnboardingStepVisualTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38BF65FECAAA9E50000FFA9E /* LifeBoard/Onboarding/Models/OnboardingStepVisualTheme.swift */; };
+		300E318A0AD9AB7F088C497E /* LifeBoard/UseCases/Tag/ManageTagsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0643A03092D9D90FE7DC26D4 /* LifeBoard/UseCases/Tag/ManageTagsUseCase.swift */; };
+		308A7EC3564F5C557224C776 /* LifeBoard/Domain/Interfaces/OccurrenceRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74615C475C9EB3F67E96D7FE /* LifeBoard/Domain/Interfaces/OccurrenceRepositoryProtocol.swift */; };
+		30B49EE9EC93A901D247EA1F /* LifeBoard/State/Services/CoreSchedulingEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = F311D68194F7FDAA5BAD7ADA /* LifeBoard/State/Services/CoreSchedulingEngine.swift */; };
+		30CF71E853B4D59EBDBDA4AE /* LifeBoard/LLM/Views/Chat/Chrome/ChatEmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 509DC1C9038663BEFE00C96F /* LifeBoard/LLM/Views/Chat/Chrome/ChatEmptyStateView.swift */; };
+		314809E17C3C294340F2DA1E /* LifeBoard/Views/Settings/LifeManagement/LifeManagementAppearanceLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43CB43D27ACFD36EEFFDD829 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementAppearanceLine.swift */; };
+		319DAA1BD9A0076B2E78F2C7 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineFlockBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B9E9E50F4A0FB453B025B6A /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineFlockBlock.swift */; };
 		31A6BA2B4F9CC95D728CCA8D /* HomeFilterState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E753995C5FB25BE948BE1E9 /* HomeFilterState.swift */; };
-		32004AA08DF5D7FE9587C767 /* HomeCanonicalHabitMutationLoadState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B64FFD6CD4BC91A0687E1B2 /* HomeCanonicalHabitMutationLoadState.swift */; };
-		320E8E819E057D02D689989F /* DailyTimelineCanvas+ItemRendering.swift in Sources */ = {isa = PBXBuildFile; fileRef = D42FAE002A15C49C424D0C95 /* DailyTimelineCanvas+ItemRendering.swift */; };
-		3273E07D3C81B8301BCC6111 /* HomeViewModel+HabitMutations.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3CBE8CE6330FA556306A57F /* HomeViewModel+HabitMutations.swift */; };
-		328B171396378ED1B150C54A /* HomeHabitRowPlacementBucket.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3971F5A044B9EC46E27BEC2 /* HomeHabitRowPlacementBucket.swift */; };
+		32004AA08DF5D7FE9587C767 /* LifeBoard/Presentation/ViewModels/Home/HomeCanonicalHabitMutationLoadState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B64FFD6CD4BC91A0687E1B2 /* LifeBoard/Presentation/ViewModels/Home/HomeCanonicalHabitMutationLoadState.swift */; };
+		320E8E819E057D02D689989F /* LifeBoard/Presentation/Home/Timeline/Surface/DailyTimelineCanvas+ItemRendering.swift in Sources */ = {isa = PBXBuildFile; fileRef = D42FAE002A15C49C424D0C95 /* LifeBoard/Presentation/Home/Timeline/Surface/DailyTimelineCanvas+ItemRendering.swift */; };
+		3273E07D3C81B8301BCC6111 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+HabitMutations.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3CBE8CE6330FA556306A57F /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+HabitMutations.swift */; };
+		328B171396378ED1B150C54A /* LifeBoard/Presentation/ViewModels/Home/HomeHabitRowPlacementBucket.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3971F5A044B9EC46E27BEC2 /* LifeBoard/Presentation/ViewModels/Home/HomeHabitRowPlacementBucket.swift */; };
 		32CEC1ABC506CDA117F1CB3B /* SunriseTaskListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E526F0CB3E9299C87861646E /* SunriseTaskListView.swift */; };
-		32FB0E5EB16490C5930975F4 /* OnboardingPermissionHeroIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E66ADE238E28DD2BC20A9C7 /* OnboardingPermissionHeroIcon.swift */; };
-		3367A12ABAB9C8FAB90843C2 /* CoreDataTombstoneRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A78189DAF93E5F5EA0C769 /* CoreDataTombstoneRepository.swift */; };
-		3447A60285674490A2726759 /* LifeManagementAreaComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 382D7A14C1F519D843A2365D /* LifeManagementAreaComposerView.swift */; };
+		32FB0E5EB16490C5930975F4 /* LifeBoard/Onboarding/Components/OnboardingPermissionHeroIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E66ADE238E28DD2BC20A9C7 /* LifeBoard/Onboarding/Components/OnboardingPermissionHeroIcon.swift */; };
+		3367A12ABAB9C8FAB90843C2 /* LifeBoard/State/Repositories/CoreDataTombstoneRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A78189DAF93E5F5EA0C769 /* LifeBoard/State/Repositories/CoreDataTombstoneRepository.swift */; };
+		3447A60285674490A2726759 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementAreaComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 382D7A14C1F519D843A2365D /* LifeBoard/Views/Settings/LifeManagement/LifeManagementAreaComposerView.swift */; };
 		3464C0D69143BB1C99FBFD7A /* SettingsSectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82ACA5EA351487686C155548 /* SettingsSectionHeader.swift */; };
 		3494FE9BF173433EE0791F1B /* TypographyTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32CFD17024C4F8FF10386CE1 /* TypographyTokenTests.swift */; };
 		350E661527174B8BDEE11FCC /* SunriseTaskRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D379A868382E81C83D874E36 /* SunriseTaskRowView.swift */; };
 		355015C0A77A72D864F1AC64 /* SunriseAppShellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF5D7161411B42651DF00D60 /* SunriseAppShellView.swift */; };
-		35EE69887A851F70BD73AB93 /* ManageLifeAreasUseCaseExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69507E47E2C799073FE4018A /* ManageLifeAreasUseCaseExtension.swift */; };
-		36235D01BFCF2D2001A39CCE /* FocusSessionUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CC4B584282446580AA72B44 /* FocusSessionUseCase.swift */; };
-		3726D051C70DA7D059BBC8F4 /* OverdueRescueCardModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE79C7D2227A80F8ECDFDFD2 /* OverdueRescueCardModel.swift */; };
-		37A2B8A6A25F06C72606019E /* TaskDefinitionMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592346DCA3C3FE56E12617C2 /* TaskDefinitionMapper.swift */; };
-		3832EF761CF5E6940EC8391C /* TimelineStreamSample.swift in Sources */ = {isa = PBXBuildFile; fileRef = A686073CD1BB07971DFD578B /* TimelineStreamSample.swift */; };
-		38B214F1E69681E0A58C8665 /* OnboardingTrustRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351390B6BEADE2277EF6ECBA /* OnboardingTrustRow.swift */; };
-		390DB347BE033669B7CF9A28 /* ViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C53A20FDEE1A1CCD05E76506 /* ViewExtension.swift */; };
-		396F9CD34E10195B8C5FE0F7 /* CompleteTaskDefinitionUseCaseExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E224DFA4DB09C938556B07B /* CompleteTaskDefinitionUseCaseExtension.swift */; };
+		35EE69887A851F70BD73AB93 /* LifeBoard/Onboarding/Models/ManageLifeAreasUseCaseExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69507E47E2C799073FE4018A /* LifeBoard/Onboarding/Models/ManageLifeAreasUseCaseExtension.swift */; };
+		36235D01BFCF2D2001A39CCE /* LifeBoard/UseCases/Gamification/FocusSessionUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CC4B584282446580AA72B44 /* LifeBoard/UseCases/Gamification/FocusSessionUseCase.swift */; };
+		3726D051C70DA7D059BBC8F4 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueCardModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE79C7D2227A80F8ECDFDFD2 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueCardModel.swift */; };
+		37A2B8A6A25F06C72606019E /* LifeBoard/Domain/Mappers/TaskDefinitionMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592346DCA3C3FE56E12617C2 /* LifeBoard/Domain/Mappers/TaskDefinitionMapper.swift */; };
+		3832EF761CF5E6940EC8391C /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamSample.swift in Sources */ = {isa = PBXBuildFile; fileRef = A686073CD1BB07971DFD578B /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamSample.swift */; };
+		38B214F1E69681E0A58C8665 /* LifeBoard/Onboarding/Components/OnboardingTrustRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351390B6BEADE2277EF6ECBA /* LifeBoard/Onboarding/Components/OnboardingTrustRow.swift */; };
+		390DB347BE033669B7CF9A28 /* LifeBoard/Onboarding/Components/ViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C53A20FDEE1A1CCD05E76506 /* LifeBoard/Onboarding/Components/ViewExtension.swift */; };
+		396F9CD34E10195B8C5FE0F7 /* LifeBoard/Onboarding/Models/CompleteTaskDefinitionUseCaseExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E224DFA4DB09C938556B07B /* LifeBoard/Onboarding/Models/CompleteTaskDefinitionUseCaseExtension.swift */; };
 		3988CE7E8470D1506CB290C1 /* HomeViewController+SurfacePreparation.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFBD3BC2B501293FC35C162C /* HomeViewController+SurfacePreparation.swift */; };
-		39B8F09956E3FFEF16B72812 /* EvaDayHabitHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 081764019CFE89EAC4FE6BBD /* EvaDayHabitHeaderView.swift */; };
-		3A549BEBEF3902410F96971A /* SunriseFocusTimerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E2466DBE2A76A73458F530 /* SunriseFocusTimerView.swift */; };
+		39B8F09956E3FFEF16B72812 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 081764019CFE89EAC4FE6BBD /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitHeaderView.swift */; };
+		3A549BEBEF3902410F96971A /* LifeBoard/View/SunriseFocusTimerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E2466DBE2A76A73458F530 /* LifeBoard/View/SunriseFocusTimerView.swift */; };
 		3AB385B89C00477CF14637A3 /* AddTaskPriorityPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDFDBE1A33B827BB4D7FD04A /* AddTaskPriorityPicker.swift */; };
-		3B95A6809B4D22F1D58A51E2 /* TimelineRailTimeFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683FBF4822AC0FD20D70E253 /* TimelineRailTimeFormatter.swift */; };
-		3BF5A228B4CE3008B8672DA1 /* TimelineBottomProtectionBudget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526C43C6A27A7D7271C5528E /* TimelineBottomProtectionBudget.swift */; };
-		3BFD0F4FDBF2CF845F1ED1BA /* EvaDayHabitMetadataView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2C41DCBFDB00CEEAF73CC0 /* EvaDayHabitMetadataView.swift */; };
-		3BFDC99E090DF4551C917CE6 /* AppOnboardingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AADEA1EA2E960494BF2F708 /* AppOnboardingState.swift */; };
-		3CA024512D42A38C712034E0 /* DeleteAreaSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = BED7C8A4030249843AED943D /* DeleteAreaSheet.swift */; };
-		3D26E03F6D3A9571E7204553 /* CoreDataExternalSyncRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CEBA82D3CB1ACE79D0E158 /* CoreDataExternalSyncRepository.swift */; };
-		3D5A1FDECBC53839EF1F4953 /* WidgetSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21637D8476DC186EA285FB33 /* WidgetSnapshot.swift */; };
+		3B95A6809B4D22F1D58A51E2 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailTimeFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683FBF4822AC0FD20D70E253 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailTimeFormatter.swift */; };
+		3BF5A228B4CE3008B8672DA1 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineBottomProtectionBudget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526C43C6A27A7D7271C5528E /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineBottomProtectionBudget.swift */; };
+		3BFD0F4FDBF2CF845F1ED1BA /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitMetadataView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2C41DCBFDB00CEEAF73CC0 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitMetadataView.swift */; };
+		3BFDC99E090DF4551C917CE6 /* LifeBoard/Onboarding/Models/AppOnboardingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AADEA1EA2E960494BF2F708 /* LifeBoard/Onboarding/Models/AppOnboardingState.swift */; };
+		3CA024512D42A38C712034E0 /* LifeBoard/Views/Settings/LifeManagement/DeleteAreaSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = BED7C8A4030249843AED943D /* LifeBoard/Views/Settings/LifeManagement/DeleteAreaSheet.swift */; };
+		3D26E03F6D3A9571E7204553 /* LifeBoard/State/Repositories/CoreDataExternalSyncRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CEBA82D3CB1ACE79D0E158 /* LifeBoard/State/Repositories/CoreDataExternalSyncRepository.swift */; };
+		3D5A1FDECBC53839EF1F4953 /* Shared/WidgetSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21637D8476DC186EA285FB33 /* Shared/WidgetSnapshot.swift */; };
 		3DB15BBF268BC66ABA3862AD /* HomeTaskListWidgetSnapshotService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A7BCB477B2EA5D03B6F3FF0 /* HomeTaskListWidgetSnapshotService.swift */; };
-		3E939305B64D29F91B6C188B /* CalendarCardChromeModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02140BA5618285E3AC49CA18 /* CalendarCardChromeModifier.swift */; };
-		3EA2500F6FA7AE834A238C3A /* ScheduleReminderUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DD613471ECDE5AFB1BB199B /* ScheduleReminderUseCase.swift */; };
+		3E939305B64D29F91B6C188B /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/CalendarCardChromeModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02140BA5618285E3AC49CA18 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/CalendarCardChromeModifier.swift */; };
+		3EA2500F6FA7AE834A238C3A /* LifeBoard/UseCases/Reminder/ScheduleReminderUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DD613471ECDE5AFB1BB199B /* LifeBoard/UseCases/Reminder/ScheduleReminderUseCase.swift */; };
 		3F4C0EC2880374F5E1710E7F /* AddTaskDatePresetRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA9D6B0D45CD7BA946FCF6F3 /* AddTaskDatePresetRow.swift */; };
-		3F64B79D565266A18289D9CC /* OnboardingDownloadStatusStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CA0CB88D6BCF379DD02183 /* OnboardingDownloadStatusStrip.swift */; };
+		3F64B79D565266A18289D9CC /* LifeBoard/Onboarding/Models/OnboardingDownloadStatusStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CA0CB88D6BCF379DD02183 /* LifeBoard/Onboarding/Models/OnboardingDownloadStatusStrip.swift */; };
 		4026F77624CAF2E20A59D057 /* TypographyTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA35E641ED7341169B9EC48D /* TypographyTokens.swift */; };
-		40E1706994A23C948306E25F /* LifeManagementComposerPreviewCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B34D157D734D31C764453F /* LifeManagementComposerPreviewCard.swift */; };
-		41C931CFD888EF92197B0D24 /* HomeHabitMutationFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = A07E21E632557DE3A511B5C8 /* HomeHabitMutationFeedback.swift */; };
-		4204230B763861761BB75AF3 /* CoreDataTagRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FD8DED9951762C1A0ACCBDD /* CoreDataTagRepository.swift */; };
-		424A813126216FCDBB3BB9D3 /* HomeRenderInvalidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77DC1194E3FDC7C550953B31 /* HomeRenderInvalidation.swift */; };
-		429BC3BC461278EFC2DCE53B /* HomeViewModel+EvaFocus.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC8C891FA22F9B04EA07D70E /* HomeViewModel+EvaFocus.swift */; };
-		433493DCACF59AC715A519C4 /* GenerateOccurrencesUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F80480EA58FB983550B882B /* GenerateOccurrencesUseCase.swift */; };
-		43672EBCA0F500EAA29B3088 /* HomeViewModel+InsightsLaunch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5991B0FA3A61ED01648C82AC /* HomeViewModel+InsightsLaunch.swift */; };
-		4455C821CEE50484216FDFC3 /* timelineRailText.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD6F79B4F4AF4D2B4E34CD17 /* timelineRailText.swift */; };
-		446C1ECFEE836138F6A2FC04 /* HomeViewModel+ReloadBatchingAndReplanLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7DF103FD6883BAB8A15A117 /* HomeViewModel+ReloadBatchingAndReplanLauncher.swift */; };
+		40E1706994A23C948306E25F /* LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerPreviewCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B34D157D734D31C764453F /* LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerPreviewCard.swift */; };
+		41C931CFD888EF92197B0D24 /* LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = A07E21E632557DE3A511B5C8 /* LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationFeedback.swift */; };
+		4204230B763861761BB75AF3 /* LifeBoard/State/Repositories/CoreDataTagRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FD8DED9951762C1A0ACCBDD /* LifeBoard/State/Repositories/CoreDataTagRepository.swift */; };
+		424A813126216FCDBB3BB9D3 /* LifeBoard/Presentation/ViewModels/Home/HomeRenderInvalidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77DC1194E3FDC7C550953B31 /* LifeBoard/Presentation/ViewModels/Home/HomeRenderInvalidation.swift */; };
+		429BC3BC461278EFC2DCE53B /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+EvaFocus.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC8C891FA22F9B04EA07D70E /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+EvaFocus.swift */; };
+		433493DCACF59AC715A519C4 /* LifeBoard/UseCases/Schedule/GenerateOccurrencesUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F80480EA58FB983550B882B /* LifeBoard/UseCases/Schedule/GenerateOccurrencesUseCase.swift */; };
+		43672EBCA0F500EAA29B3088 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+InsightsLaunch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5991B0FA3A61ED01648C82AC /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+InsightsLaunch.swift */; };
+		4455C821CEE50484216FDFC3 /* LifeBoard/Presentation/Home/Timeline/Surface/timelineRailText.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD6F79B4F4AF4D2B4E34CD17 /* LifeBoard/Presentation/Home/Timeline/Surface/timelineRailText.swift */; };
+		446C1ECFEE836138F6A2FC04 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+ReloadBatchingAndReplanLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7DF103FD6883BAB8A15A117 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+ReloadBatchingAndReplanLauncher.swift */; };
 		44A001832E330AF45EED98AA /* QuietHoursCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1DA9F6A39882873264672B /* QuietHoursCard.swift */; };
-		44E3D8F1869822A9B8AFE2F9 /* HomeViewModel+FiltersAndSavedViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7E56873BA58AFC39AFB0D20 /* HomeViewModel+FiltersAndSavedViews.swift */; };
-		44E3EB20B7DF2407719E6B2F /* OnboardingCopy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D1039EA2610A24D8D430EAD /* OnboardingCopy.swift */; };
-		453DD6D72ACCC238FEFE9ACB /* SchedulingEngineProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71FDD1869D0A6C117882AD37 /* SchedulingEngineProtocol.swift */; };
+		44E3D8F1869822A9B8AFE2F9 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+FiltersAndSavedViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7E56873BA58AFC39AFB0D20 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+FiltersAndSavedViews.swift */; };
+		44E3EB20B7DF2407719E6B2F /* LifeBoard/Onboarding/Models/OnboardingCopy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D1039EA2610A24D8D430EAD /* LifeBoard/Onboarding/Models/OnboardingCopy.swift */; };
+		453DD6D72ACCC238FEFE9ACB /* LifeBoard/Domain/Interfaces/SchedulingEngineProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71FDD1869D0A6C117882AD37 /* LifeBoard/Domain/Interfaces/SchedulingEngineProtocol.swift */; };
 		46A6B044AA174C2577BE9C87 /* HomeViewController+AdaptivePresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA1AC6826CEC438ED475A25E /* HomeViewController+AdaptivePresentation.swift */; };
 		470D7F96B8766217C5B2F698 /* AddTaskEnumPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4AB324AE764BB56051B2AA8 /* AddTaskEnumPicker.swift */; };
-		47EE4E9B0C3B5EC21C43BED8 /* ReminderMergeEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AE41E54BA355D96A678CBF7 /* ReminderMergeEngine.swift */; };
-		481A6828453BE977412FD2EB /* NextMilestoneWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89676F376DC27DF3823AB623 /* NextMilestoneWidget.swift */; };
-		4835621B71E16E83CE9A39F5 /* HomeHabitWidgetRowsState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36BCF2891531B59B34A6773C /* HomeHabitWidgetRowsState.swift */; };
+		47EE4E9B0C3B5EC21C43BED8 /* LifeBoard/UseCases/Sync/ReminderMergeEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AE41E54BA355D96A678CBF7 /* LifeBoard/UseCases/Sync/ReminderMergeEngine.swift */; };
+		481A6828453BE977412FD2EB /* LifeBoardWidgets/NextMilestoneWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89676F376DC27DF3823AB623 /* LifeBoardWidgets/NextMilestoneWidget.swift */; };
+		4835621B71E16E83CE9A39F5 /* LifeBoard/Presentation/ViewModels/Home/HomeHabitWidgetRowsState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36BCF2891531B59B34A6773C /* LifeBoard/Presentation/ViewModels/Home/HomeHabitWidgetRowsState.swift */; };
 		4856C38AD2C996768BF11F45 /* HomeViewController+Keyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A134F2A3EA61AB508E9A3ED9 /* HomeViewController+Keyboard.swift */; };
-		48756A3EF4DA7E57686EA3BF /* OnboardingEvaPreparationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40541FE4F6750C143582AC0D /* OnboardingEvaPreparationState.swift */; };
-		48B55AA334E364D314DCE8CB /* ChatComposerView+StructuredComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A6D85F245E9F672238D9E0 /* ChatComposerView+StructuredComposer.swift */; };
+		48756A3EF4DA7E57686EA3BF /* LifeBoard/Onboarding/Models/OnboardingEvaPreparationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40541FE4F6750C143582AC0D /* LifeBoard/Onboarding/Models/OnboardingEvaPreparationState.swift */; };
+		48B55AA334E364D314DCE8CB /* LifeBoard/LLM/Views/Chat/Chrome/ChatComposerView+StructuredComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A6D85F245E9F672238D9E0 /* LifeBoard/LLM/Views/Chat/Chrome/ChatComposerView+StructuredComposer.swift */; };
 		4987E47C4FB2B55409BA424F /* SpacingElevationCornerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ADDF7126AA32EF840CE257C /* SpacingElevationCornerTests.swift */; };
-		49BE8D232D0B830AC1D787AA /* HomeHabitMutationSectionPatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 677222149F21BD5C04EE2EC2 /* HomeHabitMutationSectionPatch.swift */; };
-		49E7E5624BF18A470B23059C /* ChatTimeIntervalExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5308F1488478AD34963168 /* ChatTimeIntervalExtension.swift */; };
-		4A52BB8E16EAECC2A970E287 /* OnboardingOutcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6396B895E176C6D9B55C30EC /* OnboardingOutcome.swift */; };
-		4B65F890786EE2C3F5A39C2C /* DailyTimelineCompactView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6A23DC0DB1740CCDF6D30F /* DailyTimelineCompactView.swift */; };
-		4B6D91346B20578BE27DD080 /* TimelineCanvasLayoutPlan+Positioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A85EFA2BA71673BE1DDF31C /* TimelineCanvasLayoutPlan+Positioning.swift */; };
-		4B7CFEBE8C7C67CCB5E4E73C /* GamificationProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9ADCB5DB568A54708322C8E /* GamificationProfile.swift */; };
-		4BB22BF593C5283CF8557AFE /* AppGroupConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79E40B0ED12A11ACC6A161C8 /* AppGroupConstants.swift */; };
-		4C116CACC08E51B35A4EA8B4 /* lifeManagementAreaPaletteOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6AA12D4A60EA9B1E6A316B7 /* lifeManagementAreaPaletteOptions.swift */; };
+		49BE8D232D0B830AC1D787AA /* LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationSectionPatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 677222149F21BD5C04EE2EC2 /* LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationSectionPatch.swift */; };
+		49E7E5624BF18A470B23059C /* LifeBoard/LLM/Views/Chat/Conversation/ChatTimeIntervalExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5308F1488478AD34963168 /* LifeBoard/LLM/Views/Chat/Conversation/ChatTimeIntervalExtension.swift */; };
+		4A52BB8E16EAECC2A970E287 /* LifeBoard/Onboarding/Models/OnboardingOutcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6396B895E176C6D9B55C30EC /* LifeBoard/Onboarding/Models/OnboardingOutcome.swift */; };
+		4B65F890786EE2C3F5A39C2C /* LifeBoard/Presentation/Home/Timeline/Surface/DailyTimelineCompactView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6A23DC0DB1740CCDF6D30F /* LifeBoard/Presentation/Home/Timeline/Surface/DailyTimelineCompactView.swift */; };
+		4B6D91346B20578BE27DD080 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCanvasLayoutPlan+Positioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A85EFA2BA71673BE1DDF31C /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCanvasLayoutPlan+Positioning.swift */; };
+		4B7CFEBE8C7C67CCB5E4E73C /* LifeBoard/Domain/Models/GamificationProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9ADCB5DB568A54708322C8E /* LifeBoard/Domain/Models/GamificationProfile.swift */; };
+		4BB22BF593C5283CF8557AFE /* Shared/AppGroupConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79E40B0ED12A11ACC6A161C8 /* Shared/AppGroupConstants.swift */; };
+		4C116CACC08E51B35A4EA8B4 /* LifeBoard/Views/Settings/LifeManagement/lifeManagementAreaPaletteOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6AA12D4A60EA9B1E6A316B7 /* LifeBoard/Views/Settings/LifeManagement/lifeManagementAreaPaletteOptions.swift */; };
 		4C1518DF4ED5BA6F4E6D9C81 /* InMemoryCacheService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1019B77D01322B031EC108 /* InMemoryCacheService.swift */; };
 		4C1BDC9E724542DA36739830 /* QuietHoursTimeBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7273F65E17455922134AB7A9 /* QuietHoursTimeBar.swift */; };
-		4C1EDC5A08CA68696B5EADD9 /* OnboardingFloatingNextButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 076D0B0C6429D3BED7BCBF7A /* OnboardingFloatingNextButton.swift */; };
-		4D31E9106C4721F38F1B2394 /* AppGroupConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79E40B0ED12A11ACC6A161C8 /* AppGroupConstants.swift */; };
+		4C1EDC5A08CA68696B5EADD9 /* LifeBoard/Onboarding/Components/OnboardingFloatingNextButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 076D0B0C6429D3BED7BCBF7A /* LifeBoard/Onboarding/Components/OnboardingFloatingNextButton.swift */; };
+		4D31E9106C4721F38F1B2394 /* Shared/AppGroupConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79E40B0ED12A11ACC6A161C8 /* Shared/AppGroupConstants.swift */; };
 		4D3ADE2FAB5DA1161B4263E5 /* HomeQuickView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCBCDF94E1BBCA170FD4E6C2 /* HomeQuickView.swift */; };
-		4DD16D458439FF0B85BA9CF7 /* AppOnboardingJourneyView+OutcomeDraftsAndActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAD49D68C47ABAA22C239873 /* AppOnboardingJourneyView+OutcomeDraftsAndActions.swift */; };
-		4E816E3A12F0DFB4283D9FCF /* EvaHomePromptChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 384185D0DBC900F3E3B48AF3 /* EvaHomePromptChip.swift */; };
-		4EFCDE37C57E117EA5041D85 /* SunriseAppShellView+HabitsAgendaAndFocusStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2B2C9DCA8513C631F384DA /* SunriseAppShellView+HabitsAgendaAndFocusStrip.swift */; };
-		4F19404CD237ADA1ADE1F528 /* OnboardingProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ACB1F98FD6BA7DDDC213D7B /* OnboardingProgress.swift */; };
-		4F4C0C5EE35B10B8DE2B66B8 /* TimelineCurrentTimeMarker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B271BB8000F7BA9D183AA5F /* TimelineCurrentTimeMarker.swift */; };
-		4F71CEC7E0020E4BDABEB6A7 /* TimelineSurfaceMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCFE4928C0407CAB71ECC1B9 /* TimelineSurfaceMetrics.swift */; };
-		4F8081C9186D3E09FC4A1D1E /* GamificationRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220815DD3BB32A14C051A1BF /* GamificationRepositoryProtocol.swift */; };
-		4FDA467939746A454749A279 /* OnboardingFlowModel+EvaPreferencesAndDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2ABCBECDD204257AB9B9506 /* OnboardingFlowModel+EvaPreferencesAndDemo.swift */; };
+		4DD16D458439FF0B85BA9CF7 /* LifeBoard/Onboarding/Views/AppOnboardingJourneyView+OutcomeDraftsAndActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAD49D68C47ABAA22C239873 /* LifeBoard/Onboarding/Views/AppOnboardingJourneyView+OutcomeDraftsAndActions.swift */; };
+		4E816E3A12F0DFB4283D9FCF /* LifeBoard/LLM/Views/Chat/Chrome/EvaHomePromptChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 384185D0DBC900F3E3B48AF3 /* LifeBoard/LLM/Views/Chat/Chrome/EvaHomePromptChip.swift */; };
+		4EFCDE37C57E117EA5041D85 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+HabitsAgendaAndFocusStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2B2C9DCA8513C631F384DA /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+HabitsAgendaAndFocusStrip.swift */; };
+		4F19404CD237ADA1ADE1F528 /* LifeBoard/Onboarding/Models/OnboardingProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ACB1F98FD6BA7DDDC213D7B /* LifeBoard/Onboarding/Models/OnboardingProgress.swift */; };
+		4F4C0C5EE35B10B8DE2B66B8 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCurrentTimeMarker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B271BB8000F7BA9D183AA5F /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCurrentTimeMarker.swift */; };
+		4F71CEC7E0020E4BDABEB6A7 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineSurfaceMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCFE4928C0407CAB71ECC1B9 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineSurfaceMetrics.swift */; };
+		4F8081C9186D3E09FC4A1D1E /* LifeBoard/Domain/Interfaces/GamificationRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220815DD3BB32A14C051A1BF /* LifeBoard/Domain/Interfaces/GamificationRepositoryProtocol.swift */; };
+		4FDA467939746A454749A279 /* LifeBoard/Onboarding/Services/OnboardingFlowModel+EvaPreferencesAndDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2ABCBECDD204257AB9B9506 /* LifeBoard/Onboarding/Services/OnboardingFlowModel+EvaPreferencesAndDemo.swift */; };
 		50117460BC314EEA54344A9E /* GetHomeFilteredTasksUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AF308251FE7FA9FEE55702D /* GetHomeFilteredTasksUseCase.swift */; };
-		5063FF3626FB43ED4C7032FF /* timelineCapsuleHeight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33167B1E5D148BC1B8907161 /* timelineCapsuleHeight.swift */; };
-		511B4F3A5B402E7BCB708321 /* XPEnums.swift in Sources */ = {isa = PBXBuildFile; fileRef = 945E754344BF05CE3FA97D8E /* XPEnums.swift */; };
-		51459E137A715214E7CD7481 /* AreaListRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51840B6F63D4405BC246D786 /* AreaListRow.swift */; };
-		514DDD3FB2EC2CD49EC01B12 /* UserDefaultsOverdueRescueSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032B26704AEC551E42E3A08D /* UserDefaultsOverdueRescueSessionStore.swift */; };
+		5063FF3626FB43ED4C7032FF /* LifeBoard/Presentation/Home/Timeline/Surface/timelineCapsuleHeight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33167B1E5D148BC1B8907161 /* LifeBoard/Presentation/Home/Timeline/Surface/timelineCapsuleHeight.swift */; };
+		511B4F3A5B402E7BCB708321 /* LifeBoard/Domain/Models/XPEnums.swift in Sources */ = {isa = PBXBuildFile; fileRef = 945E754344BF05CE3FA97D8E /* LifeBoard/Domain/Models/XPEnums.swift */; };
+		51459E137A715214E7CD7481 /* LifeBoard/Views/Settings/LifeManagement/AreaListRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51840B6F63D4405BC246D786 /* LifeBoard/Views/Settings/LifeManagement/AreaListRow.swift */; };
+		514DDD3FB2EC2CD49EC01B12 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/UserDefaultsOverdueRescueSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032B26704AEC551E42E3A08D /* LifeBoard/Presentation/Home/Modals/OverdueRescue/UserDefaultsOverdueRescueSessionStore.swift */; };
 		521748F5D68F9EB9E2D40DF8 /* Pods_LifeBoard.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A41487F741A541AD1CB7DD2E /* Pods_LifeBoard.framework */; };
-		525C6689F6C181E296086096 /* OverdueRescueDragResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793E605571E4D4EDFCC2E4DE /* OverdueRescueDragResolver.swift */; };
+		525C6689F6C181E296086096 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDragResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793E605571E4D4EDFCC2E4DE /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDragResolver.swift */; };
 		52623D942AC2922413277FF6 /* LifeBoardWatchApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA3610ABC404898F73D042EA /* LifeBoardWatchApp.swift */; };
-		52CB4508EA7C96B9940B6799 /* TimelinePlacementPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7730F5637D23CE103B743B /* TimelinePlacementPrompt.swift */; };
+		52CB4508EA7C96B9940B6799 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelinePlacementPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7730F5637D23CE103B743B /* LifeBoard/Presentation/Home/Timeline/Surface/TimelinePlacementPrompt.swift */; };
 		52EA01C705B92C45F65720CA /* SunriseTaskSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7397B50382FF7FB4FAEC5F /* SunriseTaskSectionView.swift */; };
-		539F4B713CA94D564337B279 /* DefaultCelebrationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99ED29FB4D6A1C5E61C6A702 /* DefaultCelebrationRouter.swift */; };
-		539FB9E50686C14B24DADEC8 /* OnboardingBreakdownStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93DB4D12EFFDD4985EEBD374 /* OnboardingBreakdownStep.swift */; };
-		546344BD2EA4D1FE47598FBB /* OverdueRescuePalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC4E931BD28EB1FD4F7E2671 /* OverdueRescuePalette.swift */; };
-		54E3898C156FECCEE5A57CE5 /* ResolvedLifeAreaSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E150AE4B6341CE9C52EA4AF0 /* ResolvedLifeAreaSelection.swift */; };
-		54F4A36D13378251013B4956 /* DailySummaryLoadState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F4F0CDFF4458CFC2FFBA4A5 /* DailySummaryLoadState.swift */; };
-		552B5C25F6D738A5BA9CD095 /* EvaDayHabitActionButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97D15C36A06B1399EAC04C8A /* EvaDayHabitActionButtonView.swift */; };
-		55A4869DF1D5E4DD89557A1D /* TimelineRailPresentationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 431D37A2C5059760CA9637D5 /* TimelineRailPresentationSpec.swift */; };
-		55A68085778A4B9EA4FAC65D /* SunriseAppShellView+FocusInsightsAndRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 704D674D0BE292CD679FE13E /* SunriseAppShellView+FocusInsightsAndRouting.swift */; };
-		563FA0843C94B94146D0A715 /* LifeManagementView+BrowserAndTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F730ADFEFDF0357ECA49761 /* LifeManagementView+BrowserAndTree.swift */; };
-		5665C4C2C0BD133E3E4F59AA /* AssistantActionRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 432D634291596A7CBBCFA76B /* AssistantActionRepositoryProtocol.swift */; };
-		56DF97BE6987C2AFF6929D47 /* ManageProjectsUseCaseExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6F510C5BFB0D534AB441244 /* ManageProjectsUseCaseExtension.swift */; };
-		56E4DCAE5C1E65F706523538 /* HomeReloadBatchTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917E928680EC00ECB792B118 /* HomeReloadBatchTracker.swift */; };
-		57F03D79758CC9FB3B892D91 /* DailyTimelineCanvas+RailAndCanvas.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62AFC1C2CACBCE0FD8CD0EB9 /* DailyTimelineCanvas+RailAndCanvas.swift */; };
-		582890EBB89DC028C4FA8F9D /* OnboardingFlowModel+EvaActivationPreparation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 256FD8E6876C56256C606CBF /* OnboardingFlowModel+EvaActivationPreparation.swift */; };
-		58361669F430895FBF2918C5 /* FocusPinResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8E82EED2FB2D349E9F3BE9 /* FocusPinResult.swift */; };
-		58DE2299787427B905EC9D9E /* TimelineStreamGeometry+LaneLayoutAndPaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = 120C5DB7F91E3BDB4BF9580F /* TimelineStreamGeometry+LaneLayoutAndPaths.swift */; };
-		5986289E16E72070D526991E /* OverdueRescueStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3CC802FBBE9AFA39AF7CCFA /* OverdueRescueStateMachine.swift */; };
-		599BA3DB81762830929CF142 /* ManageSectionsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9334755BADE444C8A77BCA3E /* ManageSectionsUseCase.swift */; };
+		539F4B713CA94D564337B279 /* LifeBoard/Presentation/ViewModels/Home/DefaultCelebrationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99ED29FB4D6A1C5E61C6A702 /* LifeBoard/Presentation/ViewModels/Home/DefaultCelebrationRouter.swift */; };
+		539FB9E50686C14B24DADEC8 /* LifeBoard/Onboarding/Models/OnboardingBreakdownStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93DB4D12EFFDD4985EEBD374 /* LifeBoard/Onboarding/Models/OnboardingBreakdownStep.swift */; };
+		546344BD2EA4D1FE47598FBB /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescuePalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC4E931BD28EB1FD4F7E2671 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescuePalette.swift */; };
+		54E3898C156FECCEE5A57CE5 /* LifeBoard/Onboarding/Models/ResolvedLifeAreaSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E150AE4B6341CE9C52EA4AF0 /* LifeBoard/Onboarding/Models/ResolvedLifeAreaSelection.swift */; };
+		54F4A36D13378251013B4956 /* LifeBoard/Presentation/ViewModels/Home/DailySummaryLoadState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F4F0CDFF4458CFC2FFBA4A5 /* LifeBoard/Presentation/ViewModels/Home/DailySummaryLoadState.swift */; };
+		552B5C25F6D738A5BA9CD095 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitActionButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97D15C36A06B1399EAC04C8A /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitActionButtonView.swift */; };
+		55A4869DF1D5E4DD89557A1D /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailPresentationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 431D37A2C5059760CA9637D5 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailPresentationSpec.swift */; };
+		55A68085778A4B9EA4FAC65D /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+FocusInsightsAndRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 704D674D0BE292CD679FE13E /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+FocusInsightsAndRouting.swift */; };
+		563FA0843C94B94146D0A715 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementView+BrowserAndTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F730ADFEFDF0357ECA49761 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementView+BrowserAndTree.swift */; };
+		5665C4C2C0BD133E3E4F59AA /* LifeBoard/Domain/Interfaces/AssistantActionRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 432D634291596A7CBBCFA76B /* LifeBoard/Domain/Interfaces/AssistantActionRepositoryProtocol.swift */; };
+		56DF97BE6987C2AFF6929D47 /* LifeBoard/Onboarding/Models/ManageProjectsUseCaseExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6F510C5BFB0D534AB441244 /* LifeBoard/Onboarding/Models/ManageProjectsUseCaseExtension.swift */; };
+		56E4DCAE5C1E65F706523538 /* LifeBoard/Presentation/ViewModels/Home/HomeReloadBatchTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917E928680EC00ECB792B118 /* LifeBoard/Presentation/ViewModels/Home/HomeReloadBatchTracker.swift */; };
+		57F03D79758CC9FB3B892D91 /* LifeBoard/Presentation/Home/Timeline/Surface/DailyTimelineCanvas+RailAndCanvas.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62AFC1C2CACBCE0FD8CD0EB9 /* LifeBoard/Presentation/Home/Timeline/Surface/DailyTimelineCanvas+RailAndCanvas.swift */; };
+		582890EBB89DC028C4FA8F9D /* LifeBoard/Onboarding/Services/OnboardingFlowModel+EvaActivationPreparation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 256FD8E6876C56256C606CBF /* LifeBoard/Onboarding/Services/OnboardingFlowModel+EvaActivationPreparation.swift */; };
+		58361669F430895FBF2918C5 /* LifeBoard/Presentation/ViewModels/Home/FocusPinResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8E82EED2FB2D349E9F3BE9 /* LifeBoard/Presentation/ViewModels/Home/FocusPinResult.swift */; };
+		58DE2299787427B905EC9D9E /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamGeometry+LaneLayoutAndPaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = 120C5DB7F91E3BDB4BF9580F /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamGeometry+LaneLayoutAndPaths.swift */; };
+		5986289E16E72070D526991E /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3CC802FBBE9AFA39AF7CCFA /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueStateMachine.swift */; };
+		599BA3DB81762830929CF142 /* LifeBoard/UseCases/Section/ManageSectionsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9334755BADE444C8A77BCA3E /* LifeBoard/UseCases/Section/ManageSectionsUseCase.swift */; };
 		59B3E6E34D642F3E46FC1C64 /* HomeTimelineViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFF75A05368C0CA0356AC4F7 /* HomeTimelineViewModel.swift */; };
-		59E0A865A7529C69B04F684A /* LocalNotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C94956D526284966A1EEDC /* LocalNotificationService.swift */; };
-		59FE36E7A9A47274A3D610FC /* OnboardingPressScaleButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78DF4503F0438173C6DC91B8 /* OnboardingPressScaleButtonStyle.swift */; };
-		5ABA1E0B75C50F023148D89F /* OnboardingHabitRecommendationCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DB65ADBF6B22879FF33FF66 /* OnboardingHabitRecommendationCard.swift */; };
-		5AC278B44C8BDF3A50E94379 /* TagMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D32B0321DD6413CCDC888416 /* TagMapper.swift */; };
-		5B0A4FDD9721341E85EF7093 /* OverdueRescueLargeStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70EF7AB518C2C6E6AB41487E /* OverdueRescueLargeStackView.swift */; };
+		59E0A865A7529C69B04F684A /* LifeBoard/Services/LocalNotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C94956D526284966A1EEDC /* LifeBoard/Services/LocalNotificationService.swift */; };
+		59FE36E7A9A47274A3D610FC /* LifeBoard/Onboarding/Components/OnboardingPressScaleButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78DF4503F0438173C6DC91B8 /* LifeBoard/Onboarding/Components/OnboardingPressScaleButtonStyle.swift */; };
+		5ABA1E0B75C50F023148D89F /* LifeBoard/Onboarding/Components/OnboardingHabitRecommendationCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DB65ADBF6B22879FF33FF66 /* LifeBoard/Onboarding/Components/OnboardingHabitRecommendationCard.swift */; };
+		5AC278B44C8BDF3A50E94379 /* LifeBoard/Domain/Mappers/TagMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D32B0321DD6413CCDC888416 /* LifeBoard/Domain/Mappers/TagMapper.swift */; };
+		5B0A4FDD9721341E85EF7093 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueLargeStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70EF7AB518C2C6E6AB41487E /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueLargeStackView.swift */; };
 		5B2FF1A96BA37ED09DE12FAB /* HomeDailySummaryModalSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3DFC4F80E1254139A27C0C5 /* HomeDailySummaryModalSupport.swift */; };
-		5B7BAB6078EBCDB6CC9F7B7E /* SunriseAppShellViewRoot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83540D1FFD9826270275D74A /* SunriseAppShellViewRoot.swift */; };
-		5C336D92A4C8046FB4291347 /* SunriseAppShellView+DerivedState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D27FF67FB1DB3066CA04D50 /* SunriseAppShellView+DerivedState.swift */; };
-		5D45628FA820FA3BEB7A97D3 /* ChatScaffoldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B36F56E947D18C0D1D111E0C /* ChatScaffoldView.swift */; };
-		5E49A6FCA0C096CB2B6EA054 /* StreakResilienceWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BBE8CE1B13AA2877F4BBCAE /* StreakResilienceWidget.swift */; };
-		5E62A1F6764E8C4158AE395D /* OnboardingEligibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF4E3B7EAAC54AE18553A302 /* OnboardingEligibility.swift */; };
-		5E7A10000000000000000001 /* SunriseInsightsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7A10000000000000000002 /* SunriseInsightsView.swift */; };
+		5B7BAB6078EBCDB6CC9F7B7E /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellViewRoot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83540D1FFD9826270275D74A /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellViewRoot.swift */; };
+		5C336D92A4C8046FB4291347 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+DerivedState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D27FF67FB1DB3066CA04D50 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+DerivedState.swift */; };
+		5D45628FA820FA3BEB7A97D3 /* LifeBoard/LLM/Views/Chat/Chrome/ChatScaffoldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B36F56E947D18C0D1D111E0C /* LifeBoard/LLM/Views/Chat/Chrome/ChatScaffoldView.swift */; };
+		5E49A6FCA0C096CB2B6EA054 /* LifeBoardWidgets/StreakResilienceWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BBE8CE1B13AA2877F4BBCAE /* LifeBoardWidgets/StreakResilienceWidget.swift */; };
+		5E62A1F6764E8C4158AE395D /* LifeBoard/Onboarding/Models/OnboardingEligibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF4E3B7EAAC54AE18553A302 /* LifeBoard/Onboarding/Models/OnboardingEligibility.swift */; };
+		5E7A10000000000000000001 /* LifeBoard/View/Insights/SunriseInsightsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7A10000000000000000002 /* LifeBoard/View/Insights/SunriseInsightsView.swift */; };
 		5E7A20000000000000000001 /* SunriseInsightsHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7A20000000000000000002 /* SunriseInsightsHeaderView.swift */; };
 		5E7A20000000000000000003 /* SunriseInsightsHeroCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7A20000000000000000004 /* SunriseInsightsHeroCard.swift */; };
-		5EA366582815849801B3F3F2 /* HomeViewModel+AnalyticsRefresh.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEB72F108D49DD4AE2B58A99 /* HomeViewModel+AnalyticsRefresh.swift */; };
-		5F143687250957A73D400A49 /* TimelineStreamInfluence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52AE529746E4CDD7FB4A8C95 /* TimelineStreamInfluence.swift */; };
+		5EA366582815849801B3F3F2 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+AnalyticsRefresh.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEB72F108D49DD4AE2B58A99 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+AnalyticsRefresh.swift */; };
+		5F143687250957A73D400A49 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamInfluence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52AE529746E4CDD7FB4A8C95 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamInfluence.swift */; };
 		5F230AF6BB3D9F989C5A6418 /* ColorTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = B812E7A0B879607C95C0571B /* ColorTokens.swift */; };
 		5F78F8516534FE34D60A090F /* LifeBoardWatchWidgets.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 7FA441E9098F3D735062B78C /* LifeBoardWatchWidgets.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		60077665EB3D3BDC56741ED6 /* HomeViewModel+TaskDetailMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9FBA211F8998587F17C8785 /* HomeViewModel+TaskDetailMetadata.swift */; };
+		60077665EB3D3BDC56741ED6 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+TaskDetailMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9FBA211F8998587F17C8785 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+TaskDetailMetadata.swift */; };
 		600B7F6D47A6091946016C7A /* GetHomeFilteredTasksUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C39FDE21811FCBE733038318 /* GetHomeFilteredTasksUseCaseTests.swift */; };
-		60200C66D978383E5757D92D /* OverdueRescueSunriseHero.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD7B0A79A3EE19D37B1FE1CA /* OverdueRescueSunriseHero.swift */; };
-		60756010B1F282A96E52851C /* TimelineTaskBlockRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2190A6A5BA73A78CB6CE64A /* TimelineTaskBlockRow.swift */; };
-		61C740CCAEA2AAD70648F5FB /* HomeViewModel+CompletionProjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3046F068EDB7B40DCD6825 /* HomeViewModel+CompletionProjection.swift */; };
-		61EAA0A5C594CBB9F626A7C1 /* TimelineCompletionRing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E5F5580FE6F9B4D29FFAA14 /* TimelineCompletionRing.swift */; };
+		60200C66D978383E5757D92D /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSunriseHero.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD7B0A79A3EE19D37B1FE1CA /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSunriseHero.swift */; };
+		60756010B1F282A96E52851C /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineTaskBlockRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2190A6A5BA73A78CB6CE64A /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineTaskBlockRow.swift */; };
+		61C740CCAEA2AAD70648F5FB /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+CompletionProjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3046F068EDB7B40DCD6825 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+CompletionProjection.swift */; };
+		61EAA0A5C594CBB9F626A7C1 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompletionRing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E5F5580FE6F9B4D29FFAA14 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompletionRing.swift */; };
 		6211D7BD7037AA1D03E6F90B /* TaskReadModelRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4C3F70CE989FCF07417B5EE /* TaskReadModelRepositoryProtocol.swift */; };
-		62DA1F2B6CF478CD9F07E040 /* OnboardingPrimaryCTAButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4811259E3F517E7F0E457DCD /* OnboardingPrimaryCTAButtonStyle.swift */; };
-		62E3C0A2BCA96C7A1DB01932 /* LifeManagementComposerInlineMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE19A169E4D9F72754B6E3E8 /* LifeManagementComposerInlineMessage.swift */; };
-		63578F35F6200B19F85FE9F0 /* MessageView+AssistantAndUserBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = E508CD28D9365DD6B35FE330 /* MessageView+AssistantAndUserBubble.swift */; };
-		6372B9063E39D08CCAF5A8C9 /* TimelineCurrentTimeRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB5C7F1C2483D8E113DBBA7 /* TimelineCurrentTimeRule.swift */; };
-		63D0ECF6FEB314DC1FD1AFAD /* ChatScaffoldView+NavigationChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = D974CDFA2F5A901967B485D2 /* ChatScaffoldView+NavigationChrome.swift */; };
-		63D15C0A35A7BF3479A69D30 /* OnboardingSelectableDetailCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50AA968766A5349A2BB45C61 /* OnboardingSelectableDetailCard.swift */; };
-		63F0A29CF92317D22F150D4B /* ReminderRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D0FFCDBD5039DB8EE185B5E /* ReminderRepositoryProtocol.swift */; };
-		64978B8A3598BEE330C5F52D /* LifeManagementViewRoot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4051577E3E4D5CC85DA57B2C /* LifeManagementViewRoot.swift */; };
-		653F0562A00EC4FD085B2436 /* TimelineNowBeadPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24A454E67411059893B17309 /* TimelineNowBeadPresentation.swift */; };
-		656AE33F845CFC0E1E317F5E /* TagRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D69B4ECB89C44E275D829577 /* TagRepositoryProtocol.swift */; };
+		62DA1F2B6CF478CD9F07E040 /* LifeBoard/Onboarding/Components/OnboardingPrimaryCTAButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4811259E3F517E7F0E457DCD /* LifeBoard/Onboarding/Components/OnboardingPrimaryCTAButtonStyle.swift */; };
+		62E3C0A2BCA96C7A1DB01932 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerInlineMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE19A169E4D9F72754B6E3E8 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerInlineMessage.swift */; };
+		63578F35F6200B19F85FE9F0 /* LifeBoard/LLM/Views/Chat/Conversation/MessageView+AssistantAndUserBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = E508CD28D9365DD6B35FE330 /* LifeBoard/LLM/Views/Chat/Conversation/MessageView+AssistantAndUserBubble.swift */; };
+		6372B9063E39D08CCAF5A8C9 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCurrentTimeRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB5C7F1C2483D8E113DBBA7 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCurrentTimeRule.swift */; };
+		63D0ECF6FEB314DC1FD1AFAD /* LifeBoard/LLM/Views/Chat/Chrome/ChatScaffoldView+NavigationChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = D974CDFA2F5A901967B485D2 /* LifeBoard/LLM/Views/Chat/Chrome/ChatScaffoldView+NavigationChrome.swift */; };
+		63D15C0A35A7BF3479A69D30 /* LifeBoard/Onboarding/Components/OnboardingSelectableDetailCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50AA968766A5349A2BB45C61 /* LifeBoard/Onboarding/Components/OnboardingSelectableDetailCard.swift */; };
+		63F0A29CF92317D22F150D4B /* LifeBoard/Domain/Interfaces/ReminderRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D0FFCDBD5039DB8EE185B5E /* LifeBoard/Domain/Interfaces/ReminderRepositoryProtocol.swift */; };
+		64978B8A3598BEE330C5F52D /* LifeBoard/Views/Settings/LifeManagement/LifeManagementViewRoot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4051577E3E4D5CC85DA57B2C /* LifeBoard/Views/Settings/LifeManagement/LifeManagementViewRoot.swift */; };
+		653F0562A00EC4FD085B2436 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineNowBeadPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24A454E67411059893B17309 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineNowBeadPresentation.swift */; };
+		656AE33F845CFC0E1E317F5E /* LifeBoard/Domain/Interfaces/TagRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D69B4ECB89C44E275D829577 /* LifeBoard/Domain/Interfaces/TagRepositoryProtocol.swift */; };
 		664B05702E92F236C487E1AD /* HomeQuickFilterDropdown.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82752F8BF563DB0673AB2770 /* HomeQuickFilterDropdown.swift */; };
-		66FBAD17B454FE9E6A36D30F /* OnboardingJourneySnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7163B97F4D083B9AB6B24476 /* OnboardingJourneySnapshot.swift */; };
-		671162B95889EABEC8DB6123 /* InlineToneBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3343BCF778595F2114EE830 /* InlineToneBadge.swift */; };
-		67A73E4B61D4A82E1336EA51 /* HomeViewModel+ProjectionInvalidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA4596A02DBC4C81BD5D267F /* HomeViewModel+ProjectionInvalidation.swift */; };
-		6868D7DE1D836622DADA12CD /* HomeViewModel+TaskCreationDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41E91E7B08A3DB7F6092C4D4 /* HomeViewModel+TaskCreationDependencies.swift */; };
-		686BD3F9EE58F613BD29E6C8 /* ProjectSummaryRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB8C1BB0D0F72004D8CD5497 /* ProjectSummaryRow.swift */; };
-		68910C38BADF060D09F81CE3 /* V2CoreDataRepositorySupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 836DC307393EA1752081FFEE /* V2CoreDataRepositorySupport.swift */; };
-		689BD052F12F388961F9C63C /* HomeNotificationNameExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4A9726955E0A1C39832E736 /* HomeNotificationNameExtension.swift */; };
-		69170C2AAEAA052519F64E78 /* CalendarIntegrationServiceExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20F2D4962594CB52DC1918C /* CalendarIntegrationServiceExtension.swift */; };
-		6958B671C35CEBA029BF084D /* gapPromptTint.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D2A8B1ED9E802D3D13F58F /* gapPromptTint.swift */; };
-		6A2E1305DB4B80D3BE0925F4 /* TimelineEmptyStateActionTone.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7334CB65043757E017D7AE4 /* TimelineEmptyStateActionTone.swift */; };
-		6A4B1EB5E3E85FE74AD7AEDC /* AssistantCommandExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8699B1ED0E60EAAE73AE2E3 /* AssistantCommandExecutor.swift */; };
-		6A59527C3E61ADE16A9C11AA /* AppGroupConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79E40B0ED12A11ACC6A161C8 /* AppGroupConstants.swift */; };
-		6A791794B107ED921F62EF41 /* OnboardingFloatingNextAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED9726B0BA993B4BD3887748 /* OnboardingFloatingNextAction.swift */; };
-		6AD96644B6458794736BA46D /* MessageView+DayOverviewAndProposalActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059D7229E32477D1B282E2A2 /* MessageView+DayOverviewAndProposalActions.swift */; };
-		6BDDCD87B9F9CF4256048C93 /* SunriseAppShellView+ObserversSearchAndBackdrop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 608542355F067EA88F7E716F /* SunriseAppShellView+ObserversSearchAndBackdrop.swift */; };
-		6BE216860D602F917606397C /* HomeTaskMutationEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA66AB0570744BB33285402E /* HomeTaskMutationEvent.swift */; };
+		66FBAD17B454FE9E6A36D30F /* LifeBoard/Onboarding/Models/OnboardingJourneySnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7163B97F4D083B9AB6B24476 /* LifeBoard/Onboarding/Models/OnboardingJourneySnapshot.swift */; };
+		671162B95889EABEC8DB6123 /* LifeBoard/Views/Settings/LifeManagement/InlineToneBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3343BCF778595F2114EE830 /* LifeBoard/Views/Settings/LifeManagement/InlineToneBadge.swift */; };
+		67A73E4B61D4A82E1336EA51 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+ProjectionInvalidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA4596A02DBC4C81BD5D267F /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+ProjectionInvalidation.swift */; };
+		6868D7DE1D836622DADA12CD /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+TaskCreationDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41E91E7B08A3DB7F6092C4D4 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+TaskCreationDependencies.swift */; };
+		686BD3F9EE58F613BD29E6C8 /* LifeBoard/Views/Settings/LifeManagement/ProjectSummaryRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB8C1BB0D0F72004D8CD5497 /* LifeBoard/Views/Settings/LifeManagement/ProjectSummaryRow.swift */; };
+		68910C38BADF060D09F81CE3 /* LifeBoard/State/Repositories/V2CoreDataRepositorySupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 836DC307393EA1752081FFEE /* LifeBoard/State/Repositories/V2CoreDataRepositorySupport.swift */; };
+		689BD052F12F388961F9C63C /* LifeBoard/Presentation/ViewModels/Home/HomeNotificationNameExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4A9726955E0A1C39832E736 /* LifeBoard/Presentation/ViewModels/Home/HomeNotificationNameExtension.swift */; };
+		69170C2AAEAA052519F64E78 /* LifeBoard/Onboarding/Services/CalendarIntegrationServiceExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20F2D4962594CB52DC1918C /* LifeBoard/Onboarding/Services/CalendarIntegrationServiceExtension.swift */; };
+		6958B671C35CEBA029BF084D /* LifeBoard/Presentation/Home/Timeline/Surface/gapPromptTint.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D2A8B1ED9E802D3D13F58F /* LifeBoard/Presentation/Home/Timeline/Surface/gapPromptTint.swift */; };
+		6A2E1305DB4B80D3BE0925F4 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineEmptyStateActionTone.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7334CB65043757E017D7AE4 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineEmptyStateActionTone.swift */; };
+		6A4B1EB5E3E85FE74AD7AEDC /* LifeBoard/UseCases/LLM/AssistantCommandExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8699B1ED0E60EAAE73AE2E3 /* LifeBoard/UseCases/LLM/AssistantCommandExecutor.swift */; };
+		6A59527C3E61ADE16A9C11AA /* Shared/AppGroupConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79E40B0ED12A11ACC6A161C8 /* Shared/AppGroupConstants.swift */; };
+		6A791794B107ED921F62EF41 /* LifeBoard/Onboarding/Models/OnboardingFloatingNextAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED9726B0BA993B4BD3887748 /* LifeBoard/Onboarding/Models/OnboardingFloatingNextAction.swift */; };
+		6AD96644B6458794736BA46D /* LifeBoard/LLM/Views/Chat/Conversation/MessageView+DayOverviewAndProposalActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059D7229E32477D1B282E2A2 /* LifeBoard/LLM/Views/Chat/Conversation/MessageView+DayOverviewAndProposalActions.swift */; };
+		6BDDCD87B9F9CF4256048C93 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+ObserversSearchAndBackdrop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 608542355F067EA88F7E716F /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+ObserversSearchAndBackdrop.swift */; };
+		6BE216860D602F917606397C /* LifeBoard/Presentation/ViewModels/Home/HomeTaskMutationEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA66AB0570744BB33285402E /* LifeBoard/Presentation/ViewModels/Home/HomeTaskMutationEvent.swift */; };
 		6BFABA2E6D0DFA253AEC67A9 /* UserDefaultsSavedHomeViewRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A365503F0A1EC71D5D159FC0 /* UserDefaultsSavedHomeViewRepository.swift */; };
-		6C361AE75951A20D4AA68C5B /* SunriseAppShellView+RescueOverlays.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FDA708D6EFE103BE7B725E0 /* SunriseAppShellView+RescueOverlays.swift */; };
-		6C55EB9AB6FB62999A3A710D /* HomeViewModel+DailyAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E88A3C9B5309D183423ACF8 /* HomeViewModel+DailyAnalytics.swift */; };
-		6CA88A6A8612FD806A55CEC5 /* HomeDataRevision.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EA22869E8CBC680A061ABAC /* HomeDataRevision.swift */; };
-		6CBA9A1192D4C0870A538CB6 /* HomeDerivedHabitRowsCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A06726F28B0B30E18CCF0D3B /* HomeDerivedHabitRowsCache.swift */; };
-		6D6E90ED524D19DBBBC00FD2 /* OnboardingChecklistRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83BA608636D6DB86CBE1DC83 /* OnboardingChecklistRow.swift */; };
-		6EDF2C884AFF7BC3644F93F7 /* OnboardingFocusTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E48DF58E65C9466AC4E2893 /* OnboardingFocusTimer.swift */; };
-		6EEA323B3C94CC3D3875A12A /* OverdueRescueMoveLaterResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 315FEE8A1F6EB8E3768FAEF0 /* OverdueRescueMoveLaterResolver.swift */; };
-		6F02A28B57E02ED09779EC11 /* AssistantAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = E78CA56E2EAD1B448EFED377 /* AssistantAction.swift */; };
-		6F0B5225F22BF0C2D1AEDFB5 /* TimelineRailLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953E5DF656076B7D7969E40B /* TimelineRailLabel.swift */; };
-		6F8AE9CBE66BD30649B53BF2 /* HomeReplanResolutionKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67726D5DDDEB64497FEB21C9 /* HomeReplanResolutionKind.swift */; };
-		6FB7164807B1BD76EEF6B571 /* HomeStaggerModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D3A6556C5C49F5516DB6ECC /* HomeStaggerModifier.swift */; };
+		6C361AE75951A20D4AA68C5B /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+RescueOverlays.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FDA708D6EFE103BE7B725E0 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+RescueOverlays.swift */; };
+		6C55EB9AB6FB62999A3A710D /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+DailyAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E88A3C9B5309D183423ACF8 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+DailyAnalytics.swift */; };
+		6CA88A6A8612FD806A55CEC5 /* LifeBoard/Presentation/ViewModels/Home/HomeDataRevision.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EA22869E8CBC680A061ABAC /* LifeBoard/Presentation/ViewModels/Home/HomeDataRevision.swift */; };
+		6CBA9A1192D4C0870A538CB6 /* LifeBoard/Presentation/ViewModels/Home/HomeDerivedHabitRowsCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A06726F28B0B30E18CCF0D3B /* LifeBoard/Presentation/ViewModels/Home/HomeDerivedHabitRowsCache.swift */; };
+		6D6E90ED524D19DBBBC00FD2 /* LifeBoard/Onboarding/Components/OnboardingChecklistRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83BA608636D6DB86CBE1DC83 /* LifeBoard/Onboarding/Components/OnboardingChecklistRow.swift */; };
+		6EDF2C884AFF7BC3644F93F7 /* LifeBoard/Onboarding/Models/OnboardingFocusTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E48DF58E65C9466AC4E2893 /* LifeBoard/Onboarding/Models/OnboardingFocusTimer.swift */; };
+		6EEA323B3C94CC3D3875A12A /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueMoveLaterResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 315FEE8A1F6EB8E3768FAEF0 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueMoveLaterResolver.swift */; };
+		6F02A28B57E02ED09779EC11 /* LifeBoard/Domain/Models/AssistantAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = E78CA56E2EAD1B448EFED377 /* LifeBoard/Domain/Models/AssistantAction.swift */; };
+		6F0B5225F22BF0C2D1AEDFB5 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953E5DF656076B7D7969E40B /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailLabel.swift */; };
+		6F8AE9CBE66BD30649B53BF2 /* LifeBoard/Presentation/ViewModels/Home/HomeReplanResolutionKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67726D5DDDEB64497FEB21C9 /* LifeBoard/Presentation/ViewModels/Home/HomeReplanResolutionKind.swift */; };
+		6FB7164807B1BD76EEF6B571 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeStaggerModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D3A6556C5C49F5516DB6ECC /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeStaggerModifier.swift */; };
 		70260539B2410072EEE5DF2C /* AddTaskTaskPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D01967BDAF0ABB45A855C29 /* AddTaskTaskPicker.swift */; };
-		703E14D9DE8D191C47A5150F /* lifeManagementAreaPaletteMatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0F0A3F8D6B8C5CB34F82DA0 /* lifeManagementAreaPaletteMatch.swift */; };
-		7051BB581E31CCD8EC76429E /* TimelineStreamAnchor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C1759A7E8DB0E5CE0E3384C /* TimelineStreamAnchor.swift */; };
-		7069388CBB2CDAEB362DA386 /* OnboardingWelcomeCinematicOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91DC2B1EAEE6DF2FDE3242F1 /* OnboardingWelcomeCinematicOverlay.swift */; };
-		70A9068D6C68CC20C0201150 /* OnboardingStarterHabitPreference.swift in Sources */ = {isa = PBXBuildFile; fileRef = C16F9565F3F8F2F079B9CE76 /* OnboardingStarterHabitPreference.swift */; };
-		71A922288848416DA81F7339 /* LifeManagementProjectColorPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FAC5C958944C25B7E561037 /* LifeManagementProjectColorPicker.swift */; };
-		7208997F226E7C45527E0F1D /* TimelineItemVisuals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DA154258145A6BBE62580E5 /* TimelineItemVisuals.swift */; };
-		7211B3D09FA27E8048BAF208 /* TimelineRailLabelKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F3897EC91C68C4A79F81A8 /* TimelineRailLabelKind.swift */; };
-		722536ED9234849F6B954FAF /* MaintainOccurrencesUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9251C0BF9A1E5D8BB7B9FC05 /* MaintainOccurrencesUseCase.swift */; };
+		703E14D9DE8D191C47A5150F /* LifeBoard/Views/Settings/LifeManagement/lifeManagementAreaPaletteMatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0F0A3F8D6B8C5CB34F82DA0 /* LifeBoard/Views/Settings/LifeManagement/lifeManagementAreaPaletteMatch.swift */; };
+		7051BB581E31CCD8EC76429E /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamAnchor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C1759A7E8DB0E5CE0E3384C /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamAnchor.swift */; };
+		7069388CBB2CDAEB362DA386 /* LifeBoard/Onboarding/Models/OnboardingWelcomeCinematicOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91DC2B1EAEE6DF2FDE3242F1 /* LifeBoard/Onboarding/Models/OnboardingWelcomeCinematicOverlay.swift */; };
+		70A9068D6C68CC20C0201150 /* LifeBoard/Onboarding/Models/OnboardingStarterHabitPreference.swift in Sources */ = {isa = PBXBuildFile; fileRef = C16F9565F3F8F2F079B9CE76 /* LifeBoard/Onboarding/Models/OnboardingStarterHabitPreference.swift */; };
+		71A922288848416DA81F7339 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementProjectColorPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FAC5C958944C25B7E561037 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementProjectColorPicker.swift */; };
+		7208997F226E7C45527E0F1D /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineItemVisuals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DA154258145A6BBE62580E5 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineItemVisuals.swift */; };
+		7211B3D09FA27E8048BAF208 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailLabelKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F3897EC91C68C4A79F81A8 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailLabelKind.swift */; };
+		722536ED9234849F6B954FAF /* LifeBoard/UseCases/Schedule/MaintainOccurrencesUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9251C0BF9A1E5D8BB7B9FC05 /* LifeBoard/UseCases/Schedule/MaintainOccurrencesUseCase.swift */; };
 		7225854435E82849B5E3C425 /* HomeQuickFilterTriggerButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A05E16369BC6D8B09B0D460 /* HomeQuickFilterTriggerButton.swift */; };
-		7241D3EE88E0D3355DDECF0D /* timelineStemColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AA18F175EDA0C022217BD98 /* timelineStemColor.swift */; };
-		73860C05746CA1B37767FA58 /* ChatStorageDegradedBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE50736401EDD2F9A73FC90 /* ChatStorageDegradedBanner.swift */; };
-		7445A553C6B57662C98F3C2C /* OnboardingSuccessSummaryRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13C9964C87A904A153CCAC6 /* OnboardingSuccessSummaryRow.swift */; };
-		7477D906A0AC312F3C4B3912 /* EvaChatNavigationChromeState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9929F28DF1EA53ABDB5CEE2B /* EvaChatNavigationChromeState.swift */; };
+		7241D3EE88E0D3355DDECF0D /* LifeBoard/Presentation/Home/Timeline/Surface/timelineStemColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AA18F175EDA0C022217BD98 /* LifeBoard/Presentation/Home/Timeline/Surface/timelineStemColor.swift */; };
+		73860C05746CA1B37767FA58 /* LifeBoard/LLM/Views/Chat/Chrome/ChatStorageDegradedBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE50736401EDD2F9A73FC90 /* LifeBoard/LLM/Views/Chat/Chrome/ChatStorageDegradedBanner.swift */; };
+		7445A553C6B57662C98F3C2C /* LifeBoard/Onboarding/Components/OnboardingSuccessSummaryRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13C9964C87A904A153CCAC6 /* LifeBoard/Onboarding/Components/OnboardingSuccessSummaryRow.swift */; };
+		7477D906A0AC312F3C4B3912 /* LifeBoard/LLM/Views/Chat/Chrome/EvaChatNavigationChromeState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9929F28DF1EA53ABDB5CEE2B /* LifeBoard/LLM/Views/Chat/Chrome/EvaChatNavigationChromeState.swift */; };
 		75018BBB2E8D0C7C00EA3D0D /* AnalyticsServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75018BB42E8D0C7C00EA3D0D /* AnalyticsServiceProtocol.swift */; };
 		75079DA69ABE1FCA5EE19B2B /* NotificationTypesCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1429E78D48CAF30D016B671 /* NotificationTypesCard.swift */; };
 		750894CC2E8D3C390037FACE /* AnalyticsRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 750894C92E8D3C390037FACE /* AnalyticsRepositoryProtocol.swift */; };
@@ -351,7 +351,7 @@
 		750F9EDC2685CC9F00C008C4 /* CloudKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 750F9EDB2685CC9F00C008C4 /* CloudKit.framework */; };
 		7513BA322687C40500F8CCE0 /* SettingsBackdrop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7513BA312687C40500F8CCE0 /* SettingsBackdrop.swift */; };
 		7524B71B2DE4EAC90026D865 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 7524B71A2DE4EAC90026D865 /* GoogleService-Info.plist */; };
-		7527F27DE6CAFC928FF07E85 /* timelineMetaText.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED51698C3FB7D6F725184D46 /* timelineMetaText.swift */; };
+		7527F27DE6CAFC928FF07E85 /* LifeBoard/Presentation/Home/Timeline/Surface/timelineMetaText.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED51698C3FB7D6F725184D46 /* LifeBoard/Presentation/Home/Timeline/Surface/timelineMetaText.swift */; };
 		7529F6F32DFDE9BC000CBE36 /* LLMDataController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7529F6F22DFDE9BC000CBE36 /* LLMDataController.swift */; };
 		7529F6F82DFDE9F0000CBE36 /* View+IfModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7529F6F62DFDE9F0000CBE36 /* View+IfModifier.swift */; };
 		7529F6FD2DFDEFB3000CBE36 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 7529F6FC2DFDEFB3000CBE36 /* Lottie */; };
@@ -459,7 +459,7 @@
 		75F0C70C2DE9E47C008F4460 /* ColoredPillBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75F0C70A2DE9E47C008F4460 /* ColoredPillBackgroundView.swift */; };
 		75F18102245C99CD004D9A69 /* TaskModelV3.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 75F18100245C99CD004D9A69 /* TaskModelV3.xcdatamodeld */; };
 		75F1810B245CA7DF004D9A69 /* TaskDefinitionEntity+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75F18109245CA7DF004D9A69 /* TaskDefinitionEntity+CoreDataClass.swift */; };
-		75F707F2E6238335515F2AAE /* TimelineSpineEndView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A061843E78EAF882FA911295 /* TimelineSpineEndView.swift */; };
+		75F707F2E6238335515F2AAE /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineSpineEndView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A061843E78EAF882FA911295 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineSpineEndView.swift */; };
 		75F89F452DFC44E6009EDD8F /* ModelsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75F89F3F2DFC44E6009EDD8F /* ModelsSettingsView.swift */; };
 		75F89F462DFC44E6009EDD8F /* ChatHostViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75F89F432DFC44E6009EDD8F /* ChatHostViewController.swift */; };
 		75F89F472DFC44E6009EDD8F /* OnboardingDownloadingModelProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75F89F382DFC44E6009EDD8F /* OnboardingDownloadingModelProgressView.swift */; };
@@ -482,131 +482,131 @@
 		75F89FB92DFC83EF009EDD8F /* PromptMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75F89FB72DFC83EF009EDD8F /* PromptMiddleware.swift */; };
 		75F9937E24859ADB00C340EB /* HomeBottomBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75F9937D24859ADB00C340EB /* HomeBottomBarView.swift */; };
 		75F993802485B04200C340EB /* Score.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75F9937F2485B04200C340EB /* Score.swift */; };
-		7669746360890A5F6BFF15B0 /* ProjectMoveSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C66EE511C59B0C5DAAAEA30 /* ProjectMoveSheet.swift */; };
-		76CEBFD41A570542EB212A69 /* GamificationEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C5FAE972A10C45BCDDB0142 /* GamificationEngine.swift */; };
+		7669746360890A5F6BFF15B0 /* LifeBoard/Views/Settings/LifeManagement/ProjectMoveSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C66EE511C59B0C5DAAAEA30 /* LifeBoard/Views/Settings/LifeManagement/ProjectMoveSheet.swift */; };
+		76CEBFD41A570542EB212A69 /* LifeBoard/UseCases/Gamification/GamificationEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C5FAE972A10C45BCDDB0142 /* LifeBoard/UseCases/Gamification/GamificationEngine.swift */; };
 		787A6452AED8916C4F5004B1 /* HomeSunriseFace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26EAC60DD5866D607F966D0E /* HomeSunriseFace.swift */; };
-		78824D15E7415EDE2EBA903C /* HabitRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEC0DEA9E6D02E2F991F11A1 /* HabitRepositoryProtocol.swift */; };
-		78A4D4DB20E3D0A3034A5E57 /* LifeManagementView+DetailsComposerAndOverlays.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F09F509547AC4BD86E3CC9A /* LifeManagementView+DetailsComposerAndOverlays.swift */; };
-		78D78EA96C40AD8462A19EC9 /* LifeManagementProjectIconPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A711DF246A39E6B7030180 /* LifeManagementProjectIconPicker.swift */; };
-		78DE25A4719C53B4CB4EA8E0 /* HomeViewModel+ReferenceDataLoading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 338615107E8C8B6C3389301D /* HomeViewModel+ReferenceDataLoading.swift */; };
-		79A0BA40A86AF0524E6A1802 /* SunriseAppShellView+CalendarFooterAndTrackingRail.swift in Sources */ = {isa = PBXBuildFile; fileRef = E98C6DC8C0DE10D010A97DC6 /* SunriseAppShellView+CalendarFooterAndTrackingRail.swift */; };
-		7A41D73D8C289095E3560DB5 /* TimelineCompactGapRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D60461249FA816620C956F /* TimelineCompactGapRow.swift */; };
-		7AB21ECF758F38938E8A5EE7 /* TimelineAgendaItemRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F98057DD16FA2790EB04A47 /* TimelineAgendaItemRow.swift */; };
+		78824D15E7415EDE2EBA903C /* LifeBoard/Domain/Interfaces/HabitRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEC0DEA9E6D02E2F991F11A1 /* LifeBoard/Domain/Interfaces/HabitRepositoryProtocol.swift */; };
+		78A4D4DB20E3D0A3034A5E57 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementView+DetailsComposerAndOverlays.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F09F509547AC4BD86E3CC9A /* LifeBoard/Views/Settings/LifeManagement/LifeManagementView+DetailsComposerAndOverlays.swift */; };
+		78D78EA96C40AD8462A19EC9 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementProjectIconPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A711DF246A39E6B7030180 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementProjectIconPicker.swift */; };
+		78DE25A4719C53B4CB4EA8E0 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+ReferenceDataLoading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 338615107E8C8B6C3389301D /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+ReferenceDataLoading.swift */; };
+		79A0BA40A86AF0524E6A1802 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+CalendarFooterAndTrackingRail.swift in Sources */ = {isa = PBXBuildFile; fileRef = E98C6DC8C0DE10D010A97DC6 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+CalendarFooterAndTrackingRail.swift */; };
+		7A41D73D8C289095E3560DB5 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompactGapRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D60461249FA816620C956F /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompactGapRow.swift */; };
+		7AB21ECF758F38938E8A5EE7 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineAgendaItemRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F98057DD16FA2790EB04A47 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineAgendaItemRow.swift */; };
 		7AF141A3F67EC19A0961D749 /* LifeBoardTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6442D619CAA8E6CA77B46126 /* LifeBoardTokens.swift */; };
 		7B3C9A7D2F2B0F1A00D4C113 /* FocusNowSimplificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3C9A7D2F2B0F1A00D4C112 /* FocusNowSimplificationTests.swift */; };
-		7B986AAE5765AADF671B17D9 /* OverdueRescueDeckCopy.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3B60B862E237D7380EE1948 /* OverdueRescueDeckCopy.swift */; };
-		7C4E89225AA28D69904278A9 /* HomeViewModel+SectionProjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1DE5B5363A7EED7AF42BC8 /* HomeViewModel+SectionProjection.swift */; };
-		7C907B3AC77B5CAD3A68E7C1 /* ChatComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5B152C46928DBD19C7ABC5 /* ChatComposerView.swift */; };
-		7CBC9FB5197011346A405CEA /* AppOnboardingJourneyView+LayoutWelcomeAndGoal.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD02F6BCA0F7A29431C308E2 /* AppOnboardingJourneyView+LayoutWelcomeAndGoal.swift */; };
-		7DBF73B54FC410E442F25A41 /* timelineAccessibilityLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BB26CD286E91AABB2ECF5B /* timelineAccessibilityLabel.swift */; };
-		7DDFA05C1E835A398268D1EF /* WeeklyScoreboardWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4599EE24B534345B7E5F063 /* WeeklyScoreboardWidget.swift */; };
-		7E4A49A2CC73B3C46AB49388 /* TimelinePlanningShelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0791A21C5814ADEF3277BAB1 /* TimelinePlanningShelf.swift */; };
+		7B986AAE5765AADF671B17D9 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDeckCopy.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3B60B862E237D7380EE1948 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDeckCopy.swift */; };
+		7C4E89225AA28D69904278A9 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+SectionProjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1DE5B5363A7EED7AF42BC8 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+SectionProjection.swift */; };
+		7C907B3AC77B5CAD3A68E7C1 /* LifeBoard/LLM/Views/Chat/Chrome/ChatComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5B152C46928DBD19C7ABC5 /* LifeBoard/LLM/Views/Chat/Chrome/ChatComposerView.swift */; };
+		7CBC9FB5197011346A405CEA /* LifeBoard/Onboarding/Views/AppOnboardingJourneyView+LayoutWelcomeAndGoal.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD02F6BCA0F7A29431C308E2 /* LifeBoard/Onboarding/Views/AppOnboardingJourneyView+LayoutWelcomeAndGoal.swift */; };
+		7DBF73B54FC410E442F25A41 /* LifeBoard/Presentation/Home/Timeline/Surface/timelineAccessibilityLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BB26CD286E91AABB2ECF5B /* LifeBoard/Presentation/Home/Timeline/Surface/timelineAccessibilityLabel.swift */; };
+		7DDFA05C1E835A398268D1EF /* LifeBoardWidgets/WeeklyScoreboardWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4599EE24B534345B7E5F063 /* LifeBoardWidgets/WeeklyScoreboardWidget.swift */; };
+		7E4A49A2CC73B3C46AB49388 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelinePlanningShelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0791A21C5814ADEF3277BAB1 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelinePlanningShelf.swift */; };
 		7EB9C6A5754FB5403C4D1F43 /* HomeViewModel+ViewState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E5E75330E627DA9E1626E6A /* HomeViewModel+ViewState.swift */; };
-		7EFC7582344FA582791827CA /* OverdueRescueShieldHero.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5A3E8C899A8C9FB0694171 /* OverdueRescueShieldHero.swift */; };
-		7F1B2C3D4E5F60718293A4B5 /* GamificationRemoteKillSwitchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F1B2C3D4E5F60718293A4B6 /* GamificationRemoteKillSwitchService.swift */; };
-		7F1B2C3D4E5F60718293A4B7 /* LiquidMetalCTARemoteConfigService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F1B2C3D4E5F60718293A4B8 /* LiquidMetalCTARemoteConfigService.swift */; };
-		7F217D39FE1F01D4E8731F64 /* LifeManagementIconTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E4273FD3FE15CC3F6892741 /* LifeManagementIconTile.swift */; };
+		7EFC7582344FA582791827CA /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueShieldHero.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5A3E8C899A8C9FB0694171 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueShieldHero.swift */; };
+		7F1B2C3D4E5F60718293A4B5 /* LifeBoard/Services/GamificationRemoteKillSwitchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F1B2C3D4E5F60718293A4B6 /* LifeBoard/Services/GamificationRemoteKillSwitchService.swift */; };
+		7F1B2C3D4E5F60718293A4B7 /* LifeBoard/Services/LiquidMetalCTARemoteConfigService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F1B2C3D4E5F60718293A4B8 /* LifeBoard/Services/LiquidMetalCTARemoteConfigService.swift */; };
+		7F217D39FE1F01D4E8731F64 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementIconTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E4273FD3FE15CC3F6892741 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementIconTile.swift */; };
 		7F23C3443025ADC4664A8AC2 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5DC4383109EA7E312BED57A /* Foundation.framework */; };
-		7F4CC1257A958D8992586922 /* FocusPromotionResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46D86472D55596A7E3DE5FED /* FocusPromotionResult.swift */; };
-		7F6F5E34FE261604F7D6BFD0 /* AreaSummaryRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = EED3244A5684CA3C412C1AA1 /* AreaSummaryRow.swift */; };
-		7F7D8255FC6F6CFC199943F2 /* LifeAreaMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECB224DA34C6529E86C73875 /* LifeAreaMapper.swift */; };
-		7FC722F1C850B171F2A2713E /* OnboardingFeedbackController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8037E33E14B5471548D66C82 /* OnboardingFeedbackController.swift */; };
-		7FD844573284EB98B015104F /* NotificationServiceProtocolExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7DB2D794295069B7EB073D1 /* NotificationServiceProtocolExtension.swift */; };
-		807193C0B8E13112AFE45388 /* Tombstone.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A9A2796943621DC66C4703 /* Tombstone.swift */; };
-		80AECAD4D9127F42BFAA8304 /* OnboardingFrictionSelectorWidthPreferenceKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2689E7BAE48C3D0915401020 /* OnboardingFrictionSelectorWidthPreferenceKey.swift */; };
-		8142FD6EB789DF1EED06EA7F /* FocusSeedWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3BCAD6C5A546608629F532 /* FocusSeedWidget.swift */; };
-		816AAF82986408293F48FA7C /* HabitDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A30108580052CC2C67D2058 /* HabitDefinition.swift */; };
-		81EB32FF0E69DB807E839151 /* OverdueRescueViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C58C70A0C8851CAB1139F1E7 /* OverdueRescueViewModel.swift */; };
-		821E0BCBE223961EAB4DC4BD /* TimelineStreamInfluenceExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 272F492CB5085884C2B03F16 /* TimelineStreamInfluenceExtension.swift */; };
-		82FB6DE938FB3650E891FC88 /* HomeDayNavigationDirection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4090E95CAD9BC75484267914 /* HomeDayNavigationDirection.swift */; };
-		83CBA72051A1B8A5580FB888 /* OnboardingPrimaryGoal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B03639156A8E2D31701235 /* OnboardingPrimaryGoal.swift */; };
-		83EFBFC4977B6ABACDEA352B /* CoreDataTaskDefinitionRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4687654CCFC97DCFDA3E695 /* CoreDataTaskDefinitionRepository.swift */; };
-		8455171FE035DD36178C82A1 /* EvaDayTaskActionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D934D251750D7055D55AD060 /* EvaDayTaskActionsView.swift */; };
-		84BE48061CC9D9603E1C2CFE /* WidgetSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21637D8476DC186EA285FB33 /* WidgetSnapshot.swift */; };
+		7F4CC1257A958D8992586922 /* LifeBoard/Presentation/ViewModels/Home/FocusPromotionResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46D86472D55596A7E3DE5FED /* LifeBoard/Presentation/ViewModels/Home/FocusPromotionResult.swift */; };
+		7F6F5E34FE261604F7D6BFD0 /* LifeBoard/Views/Settings/LifeManagement/AreaSummaryRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = EED3244A5684CA3C412C1AA1 /* LifeBoard/Views/Settings/LifeManagement/AreaSummaryRow.swift */; };
+		7F7D8255FC6F6CFC199943F2 /* LifeBoard/Domain/Mappers/LifeAreaMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECB224DA34C6529E86C73875 /* LifeBoard/Domain/Mappers/LifeAreaMapper.swift */; };
+		7FC722F1C850B171F2A2713E /* LifeBoard/Onboarding/Services/OnboardingFeedbackController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8037E33E14B5471548D66C82 /* LifeBoard/Onboarding/Services/OnboardingFeedbackController.swift */; };
+		7FD844573284EB98B015104F /* LifeBoard/Onboarding/Services/NotificationServiceProtocolExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7DB2D794295069B7EB073D1 /* LifeBoard/Onboarding/Services/NotificationServiceProtocolExtension.swift */; };
+		807193C0B8E13112AFE45388 /* LifeBoard/Domain/Models/Tombstone.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A9A2796943621DC66C4703 /* LifeBoard/Domain/Models/Tombstone.swift */; };
+		80AECAD4D9127F42BFAA8304 /* LifeBoard/Onboarding/Components/OnboardingFrictionSelectorWidthPreferenceKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2689E7BAE48C3D0915401020 /* LifeBoard/Onboarding/Components/OnboardingFrictionSelectorWidthPreferenceKey.swift */; };
+		8142FD6EB789DF1EED06EA7F /* LifeBoardWidgets/FocusSeedWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3BCAD6C5A546608629F532 /* LifeBoardWidgets/FocusSeedWidget.swift */; };
+		816AAF82986408293F48FA7C /* LifeBoard/Domain/Models/HabitDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A30108580052CC2C67D2058 /* LifeBoard/Domain/Models/HabitDefinition.swift */; };
+		81EB32FF0E69DB807E839151 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C58C70A0C8851CAB1139F1E7 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueViewModel.swift */; };
+		821E0BCBE223961EAB4DC4BD /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamInfluenceExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 272F492CB5085884C2B03F16 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamInfluenceExtension.swift */; };
+		82FB6DE938FB3650E891FC88 /* LifeBoard/Presentation/ViewModels/Home/HomeDayNavigationDirection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4090E95CAD9BC75484267914 /* LifeBoard/Presentation/ViewModels/Home/HomeDayNavigationDirection.swift */; };
+		83CBA72051A1B8A5580FB888 /* LifeBoard/Onboarding/Models/OnboardingPrimaryGoal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B03639156A8E2D31701235 /* LifeBoard/Onboarding/Models/OnboardingPrimaryGoal.swift */; };
+		83EFBFC4977B6ABACDEA352B /* LifeBoard/State/Repositories/CoreDataTaskDefinitionRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4687654CCFC97DCFDA3E695 /* LifeBoard/State/Repositories/CoreDataTaskDefinitionRepository.swift */; };
+		8455171FE035DD36178C82A1 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayTaskActionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D934D251750D7055D55AD060 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayTaskActionsView.swift */; };
+		84BE48061CC9D9603E1C2CFE /* Shared/WidgetSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21637D8476DC186EA285FB33 /* Shared/WidgetSnapshot.swift */; };
 		84F03ABBF9605F10AF9BB212 /* TimelinePhoneRenderModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25F3E0B9D00FA850EE9E8A9 /* TimelinePhoneRenderModel.swift */; };
-		84F7B021F3EAE4E07C455703 /* TimelineRailTypography.swift in Sources */ = {isa = PBXBuildFile; fileRef = 433D1B69B2B63A326822F611 /* TimelineRailTypography.swift */; };
-		858A4B4BBFF2BD3553D36F21 /* AssistantActionPipelineUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98955AE7E300D2E682AE486B /* AssistantActionPipelineUseCase.swift */; };
-		863B6B92EB0A96ED4BAB5BA6 /* CoreDataGamificationRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1134D09887CAA3CD8F14E808 /* CoreDataGamificationRepository.swift */; };
-		8689D743382AFB9679125174 /* AppOnboardingJourneyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030D7ED39864D654D71BF1CE /* AppOnboardingJourneyView.swift */; };
-		8693C29C9C7147AC903DA772 /* OverdueRescueSafeFixesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E8131362E7A314733E26CDF /* OverdueRescueSafeFixesView.swift */; };
-		86A6A4A15FEE67AF21983B22 /* OverdueRescueSwipeRevealKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BD3AB84121002B80128D5F3 /* OverdueRescueSwipeRevealKind.swift */; };
-		86A93997F7D4FD6F2D0E4D4F /* HomeTimelineCalendarSignature.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2FC9E261B9D943C48C8EEC4 /* HomeTimelineCalendarSignature.swift */; };
+		84F7B021F3EAE4E07C455703 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailTypography.swift in Sources */ = {isa = PBXBuildFile; fileRef = 433D1B69B2B63A326822F611 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailTypography.swift */; };
+		858A4B4BBFF2BD3553D36F21 /* LifeBoard/UseCases/LLM/AssistantActionPipelineUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98955AE7E300D2E682AE486B /* LifeBoard/UseCases/LLM/AssistantActionPipelineUseCase.swift */; };
+		863B6B92EB0A96ED4BAB5BA6 /* LifeBoard/State/Repositories/CoreDataGamificationRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1134D09887CAA3CD8F14E808 /* LifeBoard/State/Repositories/CoreDataGamificationRepository.swift */; };
+		8689D743382AFB9679125174 /* LifeBoard/Onboarding/Views/AppOnboardingJourneyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030D7ED39864D654D71BF1CE /* LifeBoard/Onboarding/Views/AppOnboardingJourneyView.swift */; };
+		8693C29C9C7147AC903DA772 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSafeFixesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E8131362E7A314733E26CDF /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSafeFixesView.swift */; };
+		86A6A4A15FEE67AF21983B22 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSwipeRevealKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BD3AB84121002B80128D5F3 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSwipeRevealKind.swift */; };
+		86A93997F7D4FD6F2D0E4D4F /* LifeBoard/Presentation/ViewModels/Home/HomeTimelineCalendarSignature.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2FC9E261B9D943C48C8EEC4 /* LifeBoard/Presentation/ViewModels/Home/HomeTimelineCalendarSignature.swift */; };
 		86E61B5C7E8F8DDAD3BAC7C9 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCD0B9C7DEE094DB1B55D5BD /* SettingsViewModel.swift */; };
-		86E90FFDD209E7304B7D5BBE /* HomeOnboardingGuidanceBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1D4A4EDAF6692D9D7819FF1 /* HomeOnboardingGuidanceBanner.swift */; };
-		876568AD4ACD09548D5F3199 /* LifeManagementComposerSectionCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7433F7F7707CF6A0DA1A58B2 /* LifeManagementComposerSectionCard.swift */; };
-		877BB428E2F289B2E71A9989 /* CoreDataHabitRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44CFBD9F581CA1A255A49A85 /* CoreDataHabitRepository.swift */; };
-		8790268063CEA1C833D51C7A /* OnboardingStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD40BE88D4061AEA79953253 /* OnboardingStep.swift */; };
-		8792E823650E54CA4E14AA8E /* AppOnboardingPromptSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B526F1E51EB6600E103374A /* AppOnboardingPromptSheetView.swift */; };
-		87A099A8CE32334354449960 /* LifeManagementTreeInteractionMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF3952602FF1A9D756382492 /* LifeManagementTreeInteractionMode.swift */; };
-		88F9D9D24093FC098261F935 /* MessageView+EvaProposalAndDayOverview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EEB0762BB49B5983079AF3 /* MessageView+EvaProposalAndDayOverview.swift */; };
-		8968A51E3DD681D2B360D98C /* HomeViewModel+NeedsReplanStateAndPlacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EEB4E98CFC74139C3D08E9 /* HomeViewModel+NeedsReplanStateAndPlacement.swift */; };
-		89F6DD86DEF66E5F787909B1 /* OnboardingEyebrowLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87FF3FCE748CD6D1CC8DD64D /* OnboardingEyebrowLabel.swift */; };
-		8B28B02DAA779156218510BB /* HomeCalendarEventDetailSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B6F00C3944DB39EBB0DDA55 /* HomeCalendarEventDetailSheet.swift */; };
+		86E90FFDD209E7304B7D5BBE /* LifeBoard/Onboarding/Components/HomeOnboardingGuidanceBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1D4A4EDAF6692D9D7819FF1 /* LifeBoard/Onboarding/Components/HomeOnboardingGuidanceBanner.swift */; };
+		876568AD4ACD09548D5F3199 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerSectionCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7433F7F7707CF6A0DA1A58B2 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerSectionCard.swift */; };
+		877BB428E2F289B2E71A9989 /* LifeBoard/State/Repositories/CoreDataHabitRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44CFBD9F581CA1A255A49A85 /* LifeBoard/State/Repositories/CoreDataHabitRepository.swift */; };
+		8790268063CEA1C833D51C7A /* LifeBoard/Onboarding/Models/OnboardingStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD40BE88D4061AEA79953253 /* LifeBoard/Onboarding/Models/OnboardingStep.swift */; };
+		8792E823650E54CA4E14AA8E /* LifeBoard/Onboarding/Views/AppOnboardingPromptSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B526F1E51EB6600E103374A /* LifeBoard/Onboarding/Views/AppOnboardingPromptSheetView.swift */; };
+		87A099A8CE32334354449960 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementTreeInteractionMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF3952602FF1A9D756382492 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementTreeInteractionMode.swift */; };
+		88F9D9D24093FC098261F935 /* LifeBoard/LLM/Views/Chat/Conversation/MessageView+EvaProposalAndDayOverview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EEB0762BB49B5983079AF3 /* LifeBoard/LLM/Views/Chat/Conversation/MessageView+EvaProposalAndDayOverview.swift */; };
+		8968A51E3DD681D2B360D98C /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+NeedsReplanStateAndPlacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EEB4E98CFC74139C3D08E9 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+NeedsReplanStateAndPlacement.swift */; };
+		89F6DD86DEF66E5F787909B1 /* LifeBoard/Onboarding/Models/OnboardingEyebrowLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87FF3FCE748CD6D1CC8DD64D /* LifeBoard/Onboarding/Models/OnboardingEyebrowLabel.swift */; };
+		8B28B02DAA779156218510BB /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeCalendarEventDetailSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B6F00C3944DB39EBB0DDA55 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeCalendarEventDetailSheet.swift */; };
 		8B3CA34519B5A28D8599A5B0 /* SwiftUI+TokenAdapters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 817A26FD3474A08EC2250BED /* SwiftUI+TokenAdapters.swift */; };
-		8B4908D385E24901840412E6 /* HomeViewModel+RescueUndo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7697952AC65F15B0B831D63 /* HomeViewModel+RescueUndo.swift */; };
-		8C023F1274CF5FC1D02A717C /* OnboardingAccessibilityMarkerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CB5F00E7099AA872CD49634 /* OnboardingAccessibilityMarkerView.swift */; };
-		8C6F6176F05C02D99369AB30 /* HomeViewModel+ReloadPipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5082229527A40A436284F69E /* HomeViewModel+ReloadPipeline.swift */; };
-		8C6F80184376D9187D2B39B9 /* timelineMetaColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85DF0433A9683E2365552FC2 /* timelineMetaColor.swift */; };
+		8B4908D385E24901840412E6 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+RescueUndo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7697952AC65F15B0B831D63 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+RescueUndo.swift */; };
+		8C023F1274CF5FC1D02A717C /* LifeBoard/Onboarding/Views/OnboardingAccessibilityMarkerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CB5F00E7099AA872CD49634 /* LifeBoard/Onboarding/Views/OnboardingAccessibilityMarkerView.swift */; };
+		8C6F6176F05C02D99369AB30 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+ReloadPipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5082229527A40A436284F69E /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+ReloadPipeline.swift */; };
+		8C6F80184376D9187D2B39B9 /* LifeBoard/Presentation/Home/Timeline/Surface/timelineMetaColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85DF0433A9683E2365552FC2 /* LifeBoard/Presentation/Home/Timeline/Surface/timelineMetaColor.swift */; };
 		8C817899D9F656D853E39B2C /* AddTaskRepeatEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A1F5E5105AE9585B4120F9F /* AddTaskRepeatEditor.swift */; };
-		8C9CDC17702E6AC04114BAE5 /* DailyTimelineCanvas.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41F67EC4C592FE8E37C3B456 /* DailyTimelineCanvas.swift */; };
+		8C9CDC17702E6AC04114BAE5 /* LifeBoard/Presentation/Home/Timeline/Surface/DailyTimelineCanvas.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41F67EC4C592FE8E37C3B456 /* LifeBoard/Presentation/Home/Timeline/Surface/DailyTimelineCanvas.swift */; };
 		8CEB7AF8EA56D5550356778F /* CoreDataProjectRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD631E2A2245F830BA92FA5 /* CoreDataProjectRepository.swift */; };
-		8CF22C53A483ED3E88E74656 /* CoreDataTaskReadModelRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95FD785F6B6001D9106C2B8 /* CoreDataTaskReadModelRepository.swift */; };
+		8CF22C53A483ED3E88E74656 /* LifeBoard/State/Repositories/CoreDataTaskReadModelRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95FD785F6B6001D9106C2B8 /* LifeBoard/State/Repositories/CoreDataTaskReadModelRepository.swift */; };
 		8D5E3D97FB21E273894B0B4D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C3D8D5167F9519588886C38B /* Foundation.framework */; };
-		8D7BDD59803F690867AC75C8 /* HomeViewModel+StateUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5495D17B3F94C89D74CD407E /* HomeViewModel+StateUtilities.swift */; };
-		8D7E0FDB18955B5CE76F16C6 /* OverdueRescueSessionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D1C89561D17B2073AFA6BC1 /* OverdueRescueSessionState.swift */; };
-		8D8A8C8983C91CD1372CA1EB /* AppOnboardingAccessibilityID.swift in Sources */ = {isa = PBXBuildFile; fileRef = B515F171FB9C556BBCA40366 /* AppOnboardingAccessibilityID.swift */; };
-		8DC9908CB24A163442B463FB /* CompleteTaskDefinitionUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1265EFBF270FC894A5FCA278 /* CompleteTaskDefinitionUseCase.swift */; };
-		8E7D7A391577BD986A03B7A9 /* TimelineNowBeadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB860C7A16B4805F8EC56AF7 /* TimelineNowBeadView.swift */; };
+		8D7BDD59803F690867AC75C8 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+StateUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5495D17B3F94C89D74CD407E /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+StateUtilities.swift */; };
+		8D7E0FDB18955B5CE76F16C6 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSessionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D1C89561D17B2073AFA6BC1 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSessionState.swift */; };
+		8D8A8C8983C91CD1372CA1EB /* LifeBoard/Onboarding/Models/AppOnboardingAccessibilityID.swift in Sources */ = {isa = PBXBuildFile; fileRef = B515F171FB9C556BBCA40366 /* LifeBoard/Onboarding/Models/AppOnboardingAccessibilityID.swift */; };
+		8DC9908CB24A163442B463FB /* LifeBoard/UseCases/Task/CompleteTaskDefinitionUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1265EFBF270FC894A5FCA278 /* LifeBoard/UseCases/Task/CompleteTaskDefinitionUseCase.swift */; };
+		8E7D7A391577BD986A03B7A9 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineNowBeadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB860C7A16B4805F8EC56AF7 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineNowBeadView.swift */; };
 		8E9F0A1B2C3D4E5F60718293 /* LifeBoardHexColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E9F0A1B2C3D4E5F60718292 /* LifeBoardHexColor.swift */; };
-		8ECE25D7C3266F62DF4D3888 /* TimelineCanvasLayoutPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF17DADC7AB95846135B2EE /* TimelineCanvasLayoutPlan.swift */; };
-		8FB82D17163DA0089635E128 /* XPCalculationEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = D115AC1607F718EC014575BE /* XPCalculationEngine.swift */; };
-		8FE784A4B9FCFA802CE95542 /* logOnboardingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FE2E5497D838BF7ACBA002 /* logOnboardingError.swift */; };
-		9092BD6AC3FACD1123284752 /* HomeViewModel+FocusSessions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82775C66CDC41F9E7034D949 /* HomeViewModel+FocusSessions.swift */; };
-		90C6619892CA88CDC07F0618 /* OnboardingTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04856A49C5F0944D2A558B4F /* OnboardingTheme.swift */; };
-		90D12F41EEB78A45B410CCDA /* CreateTaskDefinitionUseCaseExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2BF76CE760383A7CA3E84F4 /* CreateTaskDefinitionUseCaseExtension.swift */; };
-		910A98F48562792C6651F69A /* AppOnboardingJourneyView+DemoPermissionsAndDock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EE9804CB09C71523D27F9D /* AppOnboardingJourneyView+DemoPermissionsAndDock.swift */; };
+		8ECE25D7C3266F62DF4D3888 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCanvasLayoutPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF17DADC7AB95846135B2EE /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCanvasLayoutPlan.swift */; };
+		8FB82D17163DA0089635E128 /* LifeBoard/Domain/Models/XPCalculationEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = D115AC1607F718EC014575BE /* LifeBoard/Domain/Models/XPCalculationEngine.swift */; };
+		8FE784A4B9FCFA802CE95542 /* LifeBoard/Onboarding/Models/logOnboardingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FE2E5497D838BF7ACBA002 /* LifeBoard/Onboarding/Models/logOnboardingError.swift */; };
+		9092BD6AC3FACD1123284752 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+FocusSessions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82775C66CDC41F9E7034D949 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+FocusSessions.swift */; };
+		90C6619892CA88CDC07F0618 /* LifeBoard/Onboarding/Models/OnboardingTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04856A49C5F0944D2A558B4F /* LifeBoard/Onboarding/Models/OnboardingTheme.swift */; };
+		90D12F41EEB78A45B410CCDA /* LifeBoard/Onboarding/Models/CreateTaskDefinitionUseCaseExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2BF76CE760383A7CA3E84F4 /* LifeBoard/Onboarding/Models/CreateTaskDefinitionUseCaseExtension.swift */; };
+		910A98F48562792C6651F69A /* LifeBoard/Onboarding/Views/AppOnboardingJourneyView+DemoPermissionsAndDock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EE9804CB09C71523D27F9D /* LifeBoard/Onboarding/Views/AppOnboardingJourneyView+DemoPermissionsAndDock.swift */; };
 		9144D767D06263C679DE7827 /* HomeViewController+Reload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A846930F8CAB1E8403C68 /* HomeViewController+Reload.swift */; };
-		919FF9A13C8BB0FF98385DAA /* WidgetSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21637D8476DC186EA285FB33 /* WidgetSnapshot.swift */; };
-		91FD6A303660EEF5294F7902 /* HomeTimeIntervalExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D16CF764ED2CECF5A9AFDF3 /* HomeTimeIntervalExtension.swift */; };
-		91FD9F166D26C453EBA6BF67 /* TimelineMeetingBlockRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A09AAB294BC776DE3EEF7673 /* TimelineMeetingBlockRow.swift */; };
-		9251E3DBECB09B6DBC3F5E6A /* LifeManagementProjectComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C959E191431AD6350132F1D /* LifeManagementProjectComposerView.swift */; };
-		926138681C7DEC596E8C4F5D /* timelineRingColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05709BBC85C1A6062231609B /* timelineRingColor.swift */; };
-		92A6F2B715C2C0A1687DACE9 /* LifeAreaRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 107822EF572057FAE8E0EF37 /* LifeAreaRepositoryProtocol.swift */; };
-		92B41286923165E8B772C985 /* OverdueRescueCompletionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 583A0C544A5AEEE50CB3B870 /* OverdueRescueCompletionView.swift */; };
-		92ED5FEA6361F15C79382539 /* OverdueRescueEligibilityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09813915E7878C1392C791D0 /* OverdueRescueEligibilityService.swift */; };
-		937B562AC1B7C19DC318F1B1 /* OnboardingLoopingPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B37462636B49FEA555BA9E24 /* OnboardingLoopingPlayerView.swift */; };
-		9399E0A93BBEBA504BB0526D /* TimelineDayRelation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 439335894506149A6B79E4A7 /* TimelineDayRelation.swift */; };
+		919FF9A13C8BB0FF98385DAA /* Shared/WidgetSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21637D8476DC186EA285FB33 /* Shared/WidgetSnapshot.swift */; };
+		91FD6A303660EEF5294F7902 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeTimeIntervalExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D16CF764ED2CECF5A9AFDF3 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeTimeIntervalExtension.swift */; };
+		91FD9F166D26C453EBA6BF67 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineMeetingBlockRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A09AAB294BC776DE3EEF7673 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineMeetingBlockRow.swift */; };
+		9251E3DBECB09B6DBC3F5E6A /* LifeBoard/Views/Settings/LifeManagement/LifeManagementProjectComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C959E191431AD6350132F1D /* LifeBoard/Views/Settings/LifeManagement/LifeManagementProjectComposerView.swift */; };
+		926138681C7DEC596E8C4F5D /* LifeBoard/Presentation/Home/Timeline/Surface/timelineRingColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05709BBC85C1A6062231609B /* LifeBoard/Presentation/Home/Timeline/Surface/timelineRingColor.swift */; };
+		92A6F2B715C2C0A1687DACE9 /* LifeBoard/Domain/Interfaces/LifeAreaRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 107822EF572057FAE8E0EF37 /* LifeBoard/Domain/Interfaces/LifeAreaRepositoryProtocol.swift */; };
+		92B41286923165E8B772C985 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueCompletionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 583A0C544A5AEEE50CB3B870 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueCompletionView.swift */; };
+		92ED5FEA6361F15C79382539 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueEligibilityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09813915E7878C1392C791D0 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueEligibilityService.swift */; };
+		937B562AC1B7C19DC318F1B1 /* LifeBoard/Onboarding/Views/OnboardingLoopingPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B37462636B49FEA555BA9E24 /* LifeBoard/Onboarding/Views/OnboardingLoopingPlayerView.swift */; };
+		9399E0A93BBEBA504BB0526D /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineDayRelation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 439335894506149A6B79E4A7 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineDayRelation.swift */; };
 		93C5C68DC8EB7F633BA4DA05 /* Pods_LifeBoardTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 116F9AD2836EC304C14DF552 /* Pods_LifeBoardTests.framework */; };
-		94105F04150FE16142615C03 /* TimelineTaskMarkerRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9115CDED706EB4E49B732A6 /* TimelineTaskMarkerRow.swift */; };
+		94105F04150FE16142615C03 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineTaskMarkerRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9115CDED706EB4E49B732A6 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineTaskMarkerRow.swift */; };
 		94267763856319AD32C226B0 /* HomeViewController+Testing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0569FE829370226C7433FCAE /* HomeViewController+Testing.swift */; };
 		944EF9DE463A08CF93BA48F0 /* LifeBoardWatchWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2039197BDDBF221CD921D76 /* LifeBoardWatchWidgetBundle.swift */; };
-		94BE392CBEE903C8468E2899 /* TimelineFlockRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B59067D0E3C92CC8F6B5A1B /* TimelineFlockRowView.swift */; };
-		9529034A5040C4E7C31DC102 /* EvaChiefOfStaffGuideSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFD0A8DA9F2060C50BF6DA52 /* EvaChiefOfStaffGuideSection.swift */; };
-		96DB3A4F8D7B4B6FDF37EED5 /* TimelineOverlapClusterCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79F16587DB80654C936066F5 /* TimelineOverlapClusterCard.swift */; };
-		96E8DB75698F710B91E6C77D /* OverdueRescueCupHero.swift in Sources */ = {isa = PBXBuildFile; fileRef = F830E25037454377EFF1BF94 /* OverdueRescueCupHero.swift */; };
-		971C0B6E09B4E9AA9B0F3939 /* ManageHabitsUseCaseExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E3C7D35C2C5FC1FDEF0A89C /* ManageHabitsUseCaseExtension.swift */; };
-		973C96958E583C28BB9194A3 /* HomeTaskReloadNotificationEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8763CA6B0B62B52616869680 /* HomeTaskReloadNotificationEvent.swift */; };
-		974FDA7040049B93F737E5B9 /* onboardingNaturalLanguageList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C9C1DCD3D8D37AB96401D40 /* onboardingNaturalLanguageList.swift */; };
-		97503DD4CD8A6F7E1E6894B8 /* TimelineUtilityItemExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F5AC60FF99A3BFD8D843C7 /* TimelineUtilityItemExtension.swift */; };
-		980E67E8DC345CD40457C5BD /* OnboardingCinematicBackdrop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA802C6A00F24E4A28E8E77 /* OnboardingCinematicBackdrop.swift */; };
-		982DF7E1D0152A8257DDFCF5 /* OnboardingHomeDemoSnapshotFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D98632874AFDD2B129187E0 /* OnboardingHomeDemoSnapshotFactory.swift */; };
-		98327A7BB4DC3205D53A6D32 /* OnboardingConcentricTransitionLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE748EA399CF4D774ECEE086 /* OnboardingConcentricTransitionLayer.swift */; };
-		98394DA04DCC1FB307F8FA6C /* lifeManagementAreaAccentHex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6049AC20F10CEBF79F8BAD /* lifeManagementAreaAccentHex.swift */; };
+		94BE392CBEE903C8468E2899 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineFlockRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B59067D0E3C92CC8F6B5A1B /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineFlockRowView.swift */; };
+		9529034A5040C4E7C31DC102 /* LifeBoard/LLM/Views/Chat/Chrome/EvaChiefOfStaffGuideSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFD0A8DA9F2060C50BF6DA52 /* LifeBoard/LLM/Views/Chat/Chrome/EvaChiefOfStaffGuideSection.swift */; };
+		96DB3A4F8D7B4B6FDF37EED5 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineOverlapClusterCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79F16587DB80654C936066F5 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineOverlapClusterCard.swift */; };
+		96E8DB75698F710B91E6C77D /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueCupHero.swift in Sources */ = {isa = PBXBuildFile; fileRef = F830E25037454377EFF1BF94 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueCupHero.swift */; };
+		971C0B6E09B4E9AA9B0F3939 /* LifeBoard/Onboarding/Models/ManageHabitsUseCaseExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E3C7D35C2C5FC1FDEF0A89C /* LifeBoard/Onboarding/Models/ManageHabitsUseCaseExtension.swift */; };
+		973C96958E583C28BB9194A3 /* LifeBoard/Presentation/ViewModels/Home/HomeTaskReloadNotificationEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8763CA6B0B62B52616869680 /* LifeBoard/Presentation/ViewModels/Home/HomeTaskReloadNotificationEvent.swift */; };
+		974FDA7040049B93F737E5B9 /* LifeBoard/Onboarding/Models/onboardingNaturalLanguageList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C9C1DCD3D8D37AB96401D40 /* LifeBoard/Onboarding/Models/onboardingNaturalLanguageList.swift */; };
+		97503DD4CD8A6F7E1E6894B8 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineUtilityItemExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F5AC60FF99A3BFD8D843C7 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineUtilityItemExtension.swift */; };
+		980E67E8DC345CD40457C5BD /* LifeBoard/Onboarding/Components/OnboardingCinematicBackdrop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA802C6A00F24E4A28E8E77 /* LifeBoard/Onboarding/Components/OnboardingCinematicBackdrop.swift */; };
+		982DF7E1D0152A8257DDFCF5 /* LifeBoard/Onboarding/Models/OnboardingHomeDemoSnapshotFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D98632874AFDD2B129187E0 /* LifeBoard/Onboarding/Models/OnboardingHomeDemoSnapshotFactory.swift */; };
+		98327A7BB4DC3205D53A6D32 /* LifeBoard/Onboarding/Models/OnboardingConcentricTransitionLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE748EA399CF4D774ECEE086 /* LifeBoard/Onboarding/Models/OnboardingConcentricTransitionLayer.swift */; };
+		98394DA04DCC1FB307F8FA6C /* LifeBoard/Views/Settings/LifeManagement/lifeManagementAreaAccentHex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6049AC20F10CEBF79F8BAD /* LifeBoard/Views/Settings/LifeManagement/lifeManagementAreaAccentHex.swift */; };
 		988BCDE3365760394848B424 /* SettingsNavigationRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147B7C5EB48AC2259B009894 /* SettingsNavigationRow.swift */; };
-		9A7AA6C367FAD2093F16DB77 /* OnboardingTaskRecommendationCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77F82FC408C33F7C6D11BC93 /* OnboardingTaskRecommendationCard.swift */; };
-		9B356B21E02F7FF4F6D8A6E2 /* CreateHabitUseCaseExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27994B950A0F914CFEDC6740 /* CreateHabitUseCaseExtension.swift */; };
-		9B5D983BDED5F3B292E2920D /* CodingKeys2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75DD317FAC37A8674392A5B6 /* CodingKeys2.swift */; };
-		9BF910D455817C716D94F9D8 /* OnboardingEligibilityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 940BF66B5480A201F5424FC9 /* OnboardingEligibilityService.swift */; };
-		9E5BA6BF68993D536CEA3AC5 /* HomeViewModel+EvaRescueActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F9BFCCD7C709FF34D6E5824 /* HomeViewModel+EvaRescueActions.swift */; };
-		9EAAFEDF8331B11C56CDDA0F /* HabitRecoveryReflectionPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D84FC1284BCFE8A1BB020B5 /* HabitRecoveryReflectionPrompt.swift */; };
+		9A7AA6C367FAD2093F16DB77 /* LifeBoard/Onboarding/Components/OnboardingTaskRecommendationCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77F82FC408C33F7C6D11BC93 /* LifeBoard/Onboarding/Components/OnboardingTaskRecommendationCard.swift */; };
+		9B356B21E02F7FF4F6D8A6E2 /* LifeBoard/Onboarding/Models/CreateHabitUseCaseExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27994B950A0F914CFEDC6740 /* LifeBoard/Onboarding/Models/CreateHabitUseCaseExtension.swift */; };
+		9B5D983BDED5F3B292E2920D /* LifeBoard/Onboarding/Models/CodingKeys2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75DD317FAC37A8674392A5B6 /* LifeBoard/Onboarding/Models/CodingKeys2.swift */; };
+		9BF910D455817C716D94F9D8 /* LifeBoard/Onboarding/Services/OnboardingEligibilityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 940BF66B5480A201F5424FC9 /* LifeBoard/Onboarding/Services/OnboardingEligibilityService.swift */; };
+		9E5BA6BF68993D536CEA3AC5 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+EvaRescueActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F9BFCCD7C709FF34D6E5824 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+EvaRescueActions.swift */; };
+		9EAAFEDF8331B11C56CDDA0F /* LifeBoard/Presentation/ViewModels/Home/HabitRecoveryReflectionPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D84FC1284BCFE8A1BB020B5 /* LifeBoard/Presentation/ViewModels/Home/HabitRecoveryReflectionPrompt.swift */; };
 		9F8F96DA53998188FCCE898D /* HomeQuickFilterSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D233F155B6A87F62F52F845 /* HomeQuickFilterSummary.swift */; };
-		9FCA8998FEF6F2B292163FB1 /* OverdueRescueDeckView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB037D639903A5E22295113F /* OverdueRescueDeckView.swift */; };
+		9FCA8998FEF6F2B292163FB1 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDeckView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB037D639903A5E22295113F /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDeckView.swift */; };
 		A11B22C42F10000100ABCDEF /* TaskNotificationDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11B22C32F10000100ABCDEF /* TaskNotificationDispatcher.swift */; };
 		A11D5A110000000000000011 /* SunriseDaySwipeSide.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11D5A110000000000000001 /* SunriseDaySwipeSide.swift */; };
 		A11D5A110000000000000012 /* SunriseDaySwipeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11D5A110000000000000002 /* SunriseDaySwipeData.swift */; };
 		A11D5A110000000000000013 /* SunriseDaySwipeWaveShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11D5A110000000000000003 /* SunriseDaySwipeWaveShape.swift */; };
 		A11D5A110000000000000014 /* SunriseDaySwipeOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11D5A110000000000000004 /* SunriseDaySwipeOverlay.swift */; };
-		A195295E32A95E537E16AF8A /* ResolveOccurrenceUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9EF3524C96CA56E66C86177 /* ResolveOccurrenceUseCase.swift */; };
+		A195295E32A95E537E16AF8A /* LifeBoard/UseCases/Schedule/ResolveOccurrenceUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9EF3524C96CA56E66C86177 /* LifeBoard/UseCases/Schedule/ResolveOccurrenceUseCase.swift */; };
 		A1B2C3D42F90000100AA1001 /* TaskEditorSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D62F90000100AA1001 /* TaskEditorSection.swift */; };
 		A1B2C3D4E5F607080910AB01 /* GradientTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F607080910AB02 /* GradientTokens.swift */; };
 		A1B2C3D52EAA11BB00CCDDEE /* LLMModelRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42EAA11BB00CCDDEE /* LLMModelRegistryTests.swift */; };
@@ -614,10 +614,10 @@
 		A1C2D3E4F5A60718293B4C5D /* AssistantPlannerServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C2D3E4F5A60718293B4C5C /* AssistantPlannerServiceTests.swift */; };
 		A1C2D3E4F5A60718293B4C5E /* AssistantEnvelopeValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C2D3E4F5A60718293B4C5F /* AssistantEnvelopeValidatorTests.swift */; };
 		A1C3D4E5F6A7B8C9D0E1F2A3 /* KeyboardShortcutsCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2D4E5F6A7B8C9D0E1F2A3B4 /* KeyboardShortcutsCard.swift */; };
-		A1D100012F90000100AA2001 /* ShortcutHandoffStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D100032F90000100AA2001 /* ShortcutHandoffStore.swift */; };
-		A1D100022F90000100AA2001 /* LifeBoardPersistentStoreBootstrapService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D100042F90000100AA2001 /* LifeBoardPersistentStoreBootstrapService.swift */; };
-		A1E5C40F2F1A4B9D9C1E8A10 /* AppleRemindersProviderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E5C40F2F1A4B9D9C1E8A12 /* AppleRemindersProviderProtocol.swift */; };
-		A1E5C40F2F1A4B9D9C1E8A11 /* EventKitAppleRemindersProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E5C40F2F1A4B9D9C1E8A13 /* EventKitAppleRemindersProvider.swift */; };
+		A1D100012F90000100AA2001 /* Shared/ShortcutHandoffStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D100032F90000100AA2001 /* Shared/ShortcutHandoffStore.swift */; };
+		A1D100022F90000100AA2001 /* LifeBoard/State/DI/LifeBoardPersistentStoreBootstrapService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D100042F90000100AA2001 /* LifeBoard/State/DI/LifeBoardPersistentStoreBootstrapService.swift */; };
+		A1E5C40F2F1A4B9D9C1E8A10 /* LifeBoard/Domain/Interfaces/AppleRemindersProviderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E5C40F2F1A4B9D9C1E8A12 /* LifeBoard/Domain/Interfaces/AppleRemindersProviderProtocol.swift */; };
+		A1E5C40F2F1A4B9D9C1E8A11 /* LifeBoard/State/Services/EventKitAppleRemindersProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E5C40F2F1A4B9D9C1E8A13 /* LifeBoard/State/Services/EventKitAppleRemindersProvider.swift */; };
 		A1F0D0B22F5A100100ABC001 /* AppOnboarding.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F0D0B12F5A100100ABC001 /* AppOnboarding.swift */; };
 		A1F0D0B52F5A100100ABC001 /* AppOnboardingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F0D0B42F5A100100ABC001 /* AppOnboardingTests.swift */; };
 		A1F0D0B72F5A100100ABC001 /* OnboardingUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F0D0B62F5A100100ABC001 /* OnboardingUITests.swift */; };
@@ -627,21 +627,21 @@
 		A20000000000000000000004 /* UrgencyBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000004 /* UrgencyBadge.swift */; };
 		A20000000000000000000005 /* XPBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000005 /* XPBadge.swift */; };
 		A20000000000000000000007 /* CelebrationEffects.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000007 /* CelebrationEffects.swift */; };
-		A2181FC3974A81C3FB7BEDFF /* MarkDailyReflectionCompleteUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C63740651E231116AA556D8F /* MarkDailyReflectionCompleteUseCase.swift */; };
+		A2181FC3974A81C3FB7BEDFF /* LifeBoard/UseCases/Gamification/MarkDailyReflectionCompleteUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C63740651E231116AA556D8F /* LifeBoard/UseCases/Gamification/MarkDailyReflectionCompleteUseCase.swift */; };
 		A2538173786D1C9268A5495A /* SettingsProfileHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBF5FA356354C0F76959A4CF /* SettingsProfileHeaderView.swift */; };
-		A25DA7AE7D00020D26A9EBC7 /* InsightsTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C915FFCD3814E051A506B72 /* InsightsTabView.swift */; };
-		A2A1CBE7757AA1C9B5EA668E /* OverdueRescueDragResolution.swift in Sources */ = {isa = PBXBuildFile; fileRef = 175B3F0CAAFBA0E5E38D57EE /* OverdueRescueDragResolution.swift */; };
+		A25DA7AE7D00020D26A9EBC7 /* LifeBoard/View/Insights/InsightsTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C915FFCD3814E051A506B72 /* LifeBoard/View/Insights/InsightsTabView.swift */; };
+		A2A1CBE7757AA1C9B5EA668E /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDragResolution.swift in Sources */ = {isa = PBXBuildFile; fileRef = 175B3F0CAAFBA0E5E38D57EE /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDragResolution.swift */; };
 		A3A6DF9571AB7FEB410EB861 /* SunriseAdvancedFilterSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594ECD331C0135DA36357314 /* SunriseAdvancedFilterSheetView.swift */; };
-		A457B085A9BC111253AADA8E /* AppGroupConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79E40B0ED12A11ACC6A161C8 /* AppGroupConstants.swift */; };
-		A48DB3A40E4B91F10D54B6B3 /* OverdueRescueLauncherOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA0626EE55DAF0FA5CD8995 /* OverdueRescueLauncherOverlayView.swift */; };
-		A4C2E9F12B7D4C5581AA0001 /* HomeTaskMutationPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4C2E9F12B7D4C5581AA0003 /* HomeTaskMutationPayload.swift */; };
+		A457B085A9BC111253AADA8E /* Shared/AppGroupConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79E40B0ED12A11ACC6A161C8 /* Shared/AppGroupConstants.swift */; };
+		A48DB3A40E4B91F10D54B6B3 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/OverdueRescueLauncherOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA0626EE55DAF0FA5CD8995 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/OverdueRescueLauncherOverlayView.swift */; };
+		A4C2E9F12B7D4C5581AA0001 /* LifeBoard/Domain/Models/HomeTaskMutationPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4C2E9F12B7D4C5581AA0003 /* LifeBoard/Domain/Models/HomeTaskMutationPayload.swift */; };
 		A4C2E9F12B7D4C5581AA0002 /* HomeTaskMutationPayloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4C2E9F12B7D4C5581AA0004 /* HomeTaskMutationPayloadTests.swift */; };
-		A4E8C9D12F9A4C3600A1B2C3 /* LifeAreaIdentityRepair.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4E8C9D22F9A4C3600A1B2C3 /* LifeAreaIdentityRepair.swift */; };
-		A516ABAD2F7D26235B44C3A1 /* AppOnboardingCoordinator+Presentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB9D4FD3A636968AEBF5DB7 /* AppOnboardingCoordinator+Presentation.swift */; };
-		A523362EF6446433532CC824 /* OverdueRescueRevealPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E3E682A3285FAAED37BACB0 /* OverdueRescueRevealPanel.swift */; };
-		A5857BBC75940D4FC8CFF13E /* EvaDayTaskHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B72A4F99B2064E4A639A6264 /* EvaDayTaskHeaderView.swift */; };
-		A647A4ACDED4835C9EA6C0D6 /* TimelineAgendaAnchorRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C701CAA6DB1096F5F422F9AC /* TimelineAgendaAnchorRow.swift */; };
-		A68140FD4222813E17094331 /* timelineDisplayedNow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 884AE8F47B1E2B1F9D346956 /* timelineDisplayedNow.swift */; };
+		A4E8C9D12F9A4C3600A1B2C3 /* LifeBoard/State/Integrity/LifeAreaIdentityRepair.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4E8C9D22F9A4C3600A1B2C3 /* LifeBoard/State/Integrity/LifeAreaIdentityRepair.swift */; };
+		A516ABAD2F7D26235B44C3A1 /* LifeBoard/Onboarding/Coordinator/AppOnboardingCoordinator+Presentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB9D4FD3A636968AEBF5DB7 /* LifeBoard/Onboarding/Coordinator/AppOnboardingCoordinator+Presentation.swift */; };
+		A523362EF6446433532CC824 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueRevealPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E3E682A3285FAAED37BACB0 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueRevealPanel.swift */; };
+		A5857BBC75940D4FC8CFF13E /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayTaskHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B72A4F99B2064E4A639A6264 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayTaskHeaderView.swift */; };
+		A647A4ACDED4835C9EA6C0D6 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineAgendaAnchorRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C701CAA6DB1096F5F422F9AC /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineAgendaAnchorRow.swift */; };
+		A68140FD4222813E17094331 /* LifeBoard/Presentation/Home/Timeline/Surface/timelineDisplayedNow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 884AE8F47B1E2B1F9D346956 /* LifeBoard/Presentation/Home/Timeline/Surface/timelineDisplayedNow.swift */; };
 		A6D5E0EA942DF95EA0C175B8 /* GamificationTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = D48E4DB12D2E1FE5A90FC97D /* GamificationTokens.swift */; };
 		A6E1D3F42F3C100100B1C2D3 /* AISuggestionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E1D3F52F3C100100B1C2D3 /* AISuggestionService.swift */; };
 		A6E1D3F62F3C100100B1C2D3 /* AssistantCardPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E1D3F72F3C100100B1C2D3 /* AssistantCardPayload.swift */; };
@@ -660,73 +660,73 @@
 		A6E1D4192F3C120100B1C2D3 /* EvaProposalCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E1D41A2F3C120100B1C2D3 /* EvaProposalCard.swift */; };
 		A6E1D41C2F3C120100B1C2D3 /* EvaDayOverview.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E1D41B2F3C120100B1C2D3 /* EvaDayOverview.swift */; };
 		A6E1D42B2F3C120100B1C2D3 /* TaskSemanticRetrievalServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E1D42A2F3C120100B1C2D3 /* TaskSemanticRetrievalServiceTests.swift */; };
-		A6E41D973B02F8BBF91E0666 /* LifeBoardCancellableDispatchWorkItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = F51E8DFC25DB5CED3BB58615 /* LifeBoardCancellableDispatchWorkItem.swift */; };
-		A72AC20CB4A49927EC98D3C6 /* TimelineTaskMarkerLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FAA78F353FFECD73FA8011A /* TimelineTaskMarkerLayout.swift */; };
+		A6E41D973B02F8BBF91E0666 /* LifeBoard/Presentation/ViewModels/Home/LifeBoardCancellableDispatchWorkItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = F51E8DFC25DB5CED3BB58615 /* LifeBoard/Presentation/ViewModels/Home/LifeBoardCancellableDispatchWorkItem.swift */; };
+		A72AC20CB4A49927EC98D3C6 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineTaskMarkerLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FAA78F353FFECD73FA8011A /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineTaskMarkerLayout.swift */; };
 		A7B8C9D0E1F20123456789A2 /* HabitBoardPresentationBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7B8C9D0E1F20123456789A1 /* HabitBoardPresentationBuilderTests.swift */; };
 		A7B8C9D0E1F20123456789A4 /* HomeHabitLastCellInteractionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7B8C9D0E1F20123456789A3 /* HomeHabitLastCellInteractionTests.swift */; };
 		A7B8C9D0E1F20123456789A6 /* HabitLastCellRuntimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7B8C9D0E1F20123456789A5 /* HabitLastCellRuntimeTests.swift */; };
 		A7B8C9D0E1F20123456789A8 /* QuietTrackingRailPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7B8C9D0E1F20123456789A7 /* QuietTrackingRailPresentationTests.swift */; };
 		A7B8C9D22F13D806009162CD /* TaskDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7B8C9D12F13D806009162CD /* TaskDetailViewModel.swift */; };
-		A7CA2FCA1F9D09173330EAA2 /* TimelineStreamGlintPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3A4158C229844DD97182926 /* TimelineStreamGlintPresentation.swift */; };
+		A7CA2FCA1F9D09173330EAA2 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamGlintPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3A4158C229844DD97182926 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamGlintPresentation.swift */; };
 		A81985165D5E3A5F46B5A5FB /* WeeklyCalendarStripView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFF019E9E7D0253D5D139030 /* WeeklyCalendarStripView.swift */; };
-		A8595F3EF93E3431E8562A05 /* ScheduleTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAF2AECE194CB6DF20940C57 /* ScheduleTemplate.swift */; };
-		A88F93F1E4769FB8D7640E3E /* AppOnboardingHostAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABDC5FDB10DF919EB7B94CC4 /* AppOnboardingHostAdapter.swift */; };
+		A8595F3EF93E3431E8562A05 /* LifeBoard/Domain/Models/ScheduleTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAF2AECE194CB6DF20940C57 /* LifeBoard/Domain/Models/ScheduleTemplate.swift */; };
+		A88F93F1E4769FB8D7640E3E /* LifeBoard/Onboarding/Coordinator/AppOnboardingHostAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABDC5FDB10DF919EB7B94CC4 /* LifeBoard/Onboarding/Coordinator/AppOnboardingHostAdapter.swift */; };
 		A8F1D2015E9C44A100112233 /* LifeBoardLayoutContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8F1D2045E9C44A100112233 /* LifeBoardLayoutContext.swift */; };
 		A8F1D2025E9C44A100112233 /* DeviceOrientationPolicyResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8F1D2055E9C44A100112233 /* DeviceOrientationPolicyResolver.swift */; };
 		A8F1D2035E9C44A100112233 /* DeviceOrientationPolicyResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8F1D2065E9C44A100112233 /* DeviceOrientationPolicyResolverTests.swift */; };
-		A912CB15A1588398C547FCE3 /* SunriseFocusSessionSummaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D63FBA200D736491232884A /* SunriseFocusSessionSummaryView.swift */; };
+		A912CB15A1588398C547FCE3 /* LifeBoard/View/SunriseFocusSessionSummaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D63FBA200D736491232884A /* LifeBoard/View/SunriseFocusSessionSummaryView.swift */; };
 		A91F8E112F44420100AB11C1 /* LifeManagementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A91F8E132F44420100AB11C1 /* LifeManagementView.swift */; };
 		A91F8E122F44420100AB11C1 /* LifeManagementViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A91F8E142F44420100AB11C1 /* LifeManagementViewModel.swift */; };
 		A91F8E162F44420100AB11C1 /* LifeManagementFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A91F8E152F44420100AB11C1 /* LifeManagementFeatureTests.swift */; };
-		A97A6E7A7869366C7EF25D0E /* TimelineStemSegments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E2736E49AF3234FCB39F354 /* TimelineStemSegments.swift */; };
+		A97A6E7A7869366C7EF25D0E /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStemSegments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E2736E49AF3234FCB39F354 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStemSegments.swift */; };
 		AA8998042C8A124CBA384F20 /* WatchSnapshotReceiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20E51E01323F68DC0F47205 /* WatchSnapshotReceiver.swift */; };
-		AAB000000000000000000002 /* HomeRenderState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB000000000000000000001 /* HomeRenderState.swift */; };
-		AAB000000000000000000004 /* HomeStores.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB000000000000000000003 /* HomeStores.swift */; };
-		AAB000000000000000000009 /* HomeShellTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB000000000000000000008 /* HomeShellTypes.swift */; };
-		AAB00000000000000000000D /* OnboardingTaskDetailDismissBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB00000000000000000000C /* OnboardingTaskDetailDismissBridge.swift */; };
-		AAB00000000000000000000F /* RescheduleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB00000000000000000000E /* RescheduleViewController.swift */; };
-		AAB000000000000000000011 /* HomeDailySummaryModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB000000000000000000010 /* HomeDailySummaryModalView.swift */; };
-		AAB000000000000000000013 /* SunriseRecurringTaskDeleteConfirmationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB000000000000000000012 /* SunriseRecurringTaskDeleteConfirmationView.swift */; };
-		AAB000000000000000000015 /* HomeUITestWorkspaceSeeder.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB000000000000000000014 /* HomeUITestWorkspaceSeeder.swift */; };
-		AAB000000000000000000019 /* NeedsReplanTrayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB000000000000000000018 /* NeedsReplanTrayView.swift */; };
-		AAB00000000000000000001B /* NeedsReplanLauncherSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB00000000000000000001A /* NeedsReplanLauncherSheet.swift */; };
-		AAB00000000000000000001D /* NeedsReplanCardOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB00000000000000000001C /* NeedsReplanCardOverlay.swift */; };
-		AAB00000000000000000001F /* NeedsReplanSummaryOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB00000000000000000001E /* NeedsReplanSummaryOverlay.swift */; };
-		AAB000000000000000000021 /* HomePrimaryWidgetRail.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB000000000000000000020 /* HomePrimaryWidgetRail.swift */; };
-		AAB000000000000000000024 /* EvaOverdueRescueSheetV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB000000000000000000023 /* EvaOverdueRescueSheetV2.swift */; };
-		AAB000000000000000000026 /* HomeiPadShell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB000000000000000000025 /* HomeiPadShell.swift */; };
-		AAB000000000000000000029 /* HomeTimelineSnapshotRenderCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB000000000000000000028 /* HomeTimelineSnapshotRenderCache.swift */; };
-		AAB00000000000000000002B /* HomeTimelineColumnLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB00000000000000000002A /* HomeTimelineColumnLayout.swift */; };
-		AAB00000000000000000002D /* HomeSunriseLayoutSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB00000000000000000002C /* HomeSunriseLayoutSupport.swift */; };
-		AAB00000000000000000002F /* HomeDaySwipeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB00000000000000000002E /* HomeDaySwipeResolver.swift */; };
-		AAB000000000000000000031 /* HomeSearchState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB000000000000000000030 /* HomeSearchState.swift */; };
+		AAB000000000000000000002 /* LifeBoard/Presentation/Home/RenderState/HomeRenderState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB000000000000000000001 /* LifeBoard/Presentation/Home/RenderState/HomeRenderState.swift */; };
+		AAB000000000000000000004 /* LifeBoard/Presentation/Home/Stores/HomeStores.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB000000000000000000003 /* LifeBoard/Presentation/Home/Stores/HomeStores.swift */; };
+		AAB000000000000000000009 /* LifeBoard/Presentation/Home/Shell/HomeShellTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB000000000000000000008 /* LifeBoard/Presentation/Home/Shell/HomeShellTypes.swift */; };
+		AAB00000000000000000000D /* LifeBoard/Presentation/Home/Modals/OnboardingTaskDetailDismissBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB00000000000000000000C /* LifeBoard/Presentation/Home/Modals/OnboardingTaskDetailDismissBridge.swift */; };
+		AAB00000000000000000000F /* LifeBoard/Presentation/Home/Modals/RescheduleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB00000000000000000000E /* LifeBoard/Presentation/Home/Modals/RescheduleViewController.swift */; };
+		AAB000000000000000000011 /* LifeBoard/Presentation/Home/Modals/HomeDailySummaryModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB000000000000000000010 /* LifeBoard/Presentation/Home/Modals/HomeDailySummaryModalView.swift */; };
+		AAB000000000000000000013 /* LifeBoard/Presentation/Home/Modals/SunriseRecurringTaskDeleteConfirmationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB000000000000000000012 /* LifeBoard/Presentation/Home/Modals/SunriseRecurringTaskDeleteConfirmationView.swift */; };
+		AAB000000000000000000015 /* LifeBoard/TestingSupport/HomeUITestWorkspaceSeeder.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB000000000000000000014 /* LifeBoard/TestingSupport/HomeUITestWorkspaceSeeder.swift */; };
+		AAB000000000000000000019 /* LifeBoard/Presentation/Home/Replan/NeedsReplanTrayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB000000000000000000018 /* LifeBoard/Presentation/Home/Replan/NeedsReplanTrayView.swift */; };
+		AAB00000000000000000001B /* LifeBoard/Presentation/Home/Replan/NeedsReplanLauncherSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB00000000000000000001A /* LifeBoard/Presentation/Home/Replan/NeedsReplanLauncherSheet.swift */; };
+		AAB00000000000000000001D /* LifeBoard/Presentation/Home/Replan/NeedsReplanCardOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB00000000000000000001C /* LifeBoard/Presentation/Home/Replan/NeedsReplanCardOverlay.swift */; };
+		AAB00000000000000000001F /* LifeBoard/Presentation/Home/Replan/NeedsReplanSummaryOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB00000000000000000001E /* LifeBoard/Presentation/Home/Replan/NeedsReplanSummaryOverlay.swift */; };
+		AAB000000000000000000021 /* LifeBoard/Presentation/Home/Widgets/HomePrimaryWidgetRail.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB000000000000000000020 /* LifeBoard/Presentation/Home/Widgets/HomePrimaryWidgetRail.swift */; };
+		AAB000000000000000000024 /* LifeBoard/Presentation/Home/Modals/EvaOverdueRescueSheetV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB000000000000000000023 /* LifeBoard/Presentation/Home/Modals/EvaOverdueRescueSheetV2.swift */; };
+		AAB000000000000000000026 /* LifeBoard/Presentation/Home/Shell/HomeiPadShell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB000000000000000000025 /* LifeBoard/Presentation/Home/Shell/HomeiPadShell.swift */; };
+		AAB000000000000000000029 /* LifeBoard/Presentation/Home/Timeline/HomeTimelineSnapshotRenderCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB000000000000000000028 /* LifeBoard/Presentation/Home/Timeline/HomeTimelineSnapshotRenderCache.swift */; };
+		AAB00000000000000000002B /* LifeBoard/Presentation/Home/Timeline/HomeTimelineColumnLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB00000000000000000002A /* LifeBoard/Presentation/Home/Timeline/HomeTimelineColumnLayout.swift */; };
+		AAB00000000000000000002D /* LifeBoard/Presentation/Home/Shell/HomeSunriseLayoutSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB00000000000000000002C /* LifeBoard/Presentation/Home/Shell/HomeSunriseLayoutSupport.swift */; };
+		AAB00000000000000000002F /* LifeBoard/Presentation/Home/Shell/HomeDaySwipeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB00000000000000000002E /* LifeBoard/Presentation/Home/Shell/HomeDaySwipeResolver.swift */; };
+		AAB000000000000000000031 /* LifeBoard/Presentation/Home/Search/HomeSearchState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB000000000000000000030 /* LifeBoard/Presentation/Home/Search/HomeSearchState.swift */; };
 		AB12CD34EF5607891234ABCE /* CoverFlipTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB12CD34EF5607891234ABCD /* CoverFlipTransition.swift */; };
 		AB5F19766B9E8B7A003B9B1E /* LifeBoardSnackbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C5BD9B9BA76D61F7F044BD /* LifeBoardSnackbar.swift */; };
-		ABB8A81FC820F8057D7D0BB1 /* TaskDefinitionRepositoryProtocolExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 871E14455069188F7847E1DB /* TaskDefinitionRepositoryProtocolExtension.swift */; };
+		ABB8A81FC820F8057D7D0BB1 /* LifeBoard/Onboarding/Models/TaskDefinitionRepositoryProtocolExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 871E14455069188F7847E1DB /* LifeBoard/Onboarding/Models/TaskDefinitionRepositoryProtocolExtension.swift */; };
 		ABCD00000000000000000011 /* AddHabitViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCD00000000000000000021 /* AddHabitViewModel.swift */; };
-		ABCD00000000000000000013 /* HabitIconCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCD00000000000000000023 /* HabitIconCatalog.swift */; };
+		ABCD00000000000000000013 /* LifeBoard/Presentation/Habits/HabitIconCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCD00000000000000000023 /* LifeBoard/Presentation/Habits/HabitIconCatalog.swift */; };
 		ABCD00000000000000000014 /* SunriseHabitLibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCD00000000000000000024 /* SunriseHabitLibraryView.swift */; };
 		AC7C0E8C304EF31908A6EA90 /* DailyRitualsCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47ED06CE7EC4F74A9E373158 /* DailyRitualsCard.swift */; };
 		ACE5DE19204D2D1CDBF3A053 /* TaskReadQueries.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2856D1EE26429146B60B6633 /* TaskReadQueries.swift */; };
-		ACF0BB7B85C9268CD15869B1 /* SunriseAppShellView+FacesAndSearchChat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 855AD3CAAA08B951BDD134FD /* SunriseAppShellView+FacesAndSearchChat.swift */; };
-		AD8804130CE2160E653414FD /* OnboardingEntryContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9632B2C3609C7092AB65BFF4 /* OnboardingEntryContext.swift */; };
-		AE2B20F87AC525CF7E27B3C0 /* LLMContextProjectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88EAC5F41DAFB21D34E6790E /* LLMContextProjectionService.swift */; };
-		AEF06D3B80CB5D968535DDE5 /* LifeArea.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34288F9F2CB1DADA41F1673D /* LifeArea.swift */; };
-		AF46E4534CA58DD946E8AF43 /* OnboardingSectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5776D8C36FD7BB8FC91DA6 /* OnboardingSectionHeader.swift */; };
-		AF5A65D3A0CB556B850BFC01 /* InsightsActionIntentExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B010C6D75FA3187BE754B3BF /* InsightsActionIntentExtension.swift */; };
-		AF82520CAEE921B7BE04E017 /* OnboardingFlowModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F66EEF4F24A54CD971C9612A /* OnboardingFlowModel.swift */; };
-		AFA64782BED04A879157E2A8 /* SectionRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E46838AD356183D58300A941 /* SectionRepositoryProtocol.swift */; };
-		B0045AC9A4CD19C619A2E2F1 /* EvaLiveWorkingStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDED467BEDE45453B0C91BEF /* EvaLiveWorkingStatusView.swift */; };
-		B07988E6375D66CC8CDB8D47 /* EvaDaySunriseTaskRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B33EB5C978F76DF3A6A735C /* EvaDaySunriseTaskRowView.swift */; };
-		B07A5646DA7E6D9AC7739710 /* ManageLifeAreasUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E06E18805C2401359A9B0F5B /* ManageLifeAreasUseCase.swift */; };
-		B10B1C2D3E4F506172839401 /* StateLifeAreaMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10B1C2D3E4F506172839401 /* StateLifeAreaMapper.swift */; };
-		B10B1C2D3E4F506172839402 /* StateSectionMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10B1C2D3E4F506172839402 /* StateSectionMapper.swift */; };
-		B10B1C2D3E4F506172839403 /* StateTagMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10B1C2D3E4F506172839403 /* StateTagMapper.swift */; };
-		B10B1C2D3E4F506172839404 /* StateTombstoneMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10B1C2D3E4F506172839404 /* StateTombstoneMapper.swift */; };
-		B10B1C2D3E4F506172839405 /* StateHabitDefinitionMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10B1C2D3E4F506172839405 /* StateHabitDefinitionMapper.swift */; };
-		B10B1C2D3E4F506172839407 /* StateTaskDefinitionMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10B1C2D3E4F506172839407 /* StateTaskDefinitionMapper.swift */; };
-		B10B1C2D3E4F506172839408 /* StateProjectMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10B1C2D3E4F506172839408 /* StateProjectMapper.swift */; };
-		B15275C8511EAB14F4112515 /* OnboardingFrictionSelectorLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE642CCFDAF7BBFD6AD34B98 /* OnboardingFrictionSelectorLayout.swift */; };
+		ACF0BB7B85C9268CD15869B1 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+FacesAndSearchChat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 855AD3CAAA08B951BDD134FD /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+FacesAndSearchChat.swift */; };
+		AD8804130CE2160E653414FD /* LifeBoard/Onboarding/Models/OnboardingEntryContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9632B2C3609C7092AB65BFF4 /* LifeBoard/Onboarding/Models/OnboardingEntryContext.swift */; };
+		AE2B20F87AC525CF7E27B3C0 /* LifeBoard/LLM/Models/LLMContextProjectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88EAC5F41DAFB21D34E6790E /* LifeBoard/LLM/Models/LLMContextProjectionService.swift */; };
+		AEF06D3B80CB5D968535DDE5 /* LifeBoard/Domain/Models/LifeArea.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34288F9F2CB1DADA41F1673D /* LifeBoard/Domain/Models/LifeArea.swift */; };
+		AF46E4534CA58DD946E8AF43 /* LifeBoard/Onboarding/Models/OnboardingSectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5776D8C36FD7BB8FC91DA6 /* LifeBoard/Onboarding/Models/OnboardingSectionHeader.swift */; };
+		AF5A65D3A0CB556B850BFC01 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/InsightsActionIntentExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B010C6D75FA3187BE754B3BF /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/InsightsActionIntentExtension.swift */; };
+		AF82520CAEE921B7BE04E017 /* LifeBoard/Onboarding/Services/OnboardingFlowModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F66EEF4F24A54CD971C9612A /* LifeBoard/Onboarding/Services/OnboardingFlowModel.swift */; };
+		AFA64782BED04A879157E2A8 /* LifeBoard/Domain/Interfaces/SectionRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E46838AD356183D58300A941 /* LifeBoard/Domain/Interfaces/SectionRepositoryProtocol.swift */; };
+		B0045AC9A4CD19C619A2E2F1 /* LifeBoard/LLM/Views/Chat/Conversation/EvaLiveWorkingStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDED467BEDE45453B0C91BEF /* LifeBoard/LLM/Views/Chat/Conversation/EvaLiveWorkingStatusView.swift */; };
+		B07988E6375D66CC8CDB8D47 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDaySunriseTaskRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B33EB5C978F76DF3A6A735C /* LifeBoard/LLM/Views/Chat/Conversation/EvaDaySunriseTaskRowView.swift */; };
+		B07A5646DA7E6D9AC7739710 /* LifeBoard/UseCases/LifeArea/ManageLifeAreasUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E06E18805C2401359A9B0F5B /* LifeBoard/UseCases/LifeArea/ManageLifeAreasUseCase.swift */; };
+		B10B1C2D3E4F506172839401 /* LifeBoard/State/Mappers/StateLifeAreaMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10B1C2D3E4F506172839401 /* LifeBoard/State/Mappers/StateLifeAreaMapper.swift */; };
+		B10B1C2D3E4F506172839402 /* LifeBoard/State/Mappers/StateSectionMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10B1C2D3E4F506172839402 /* LifeBoard/State/Mappers/StateSectionMapper.swift */; };
+		B10B1C2D3E4F506172839403 /* LifeBoard/State/Mappers/StateTagMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10B1C2D3E4F506172839403 /* LifeBoard/State/Mappers/StateTagMapper.swift */; };
+		B10B1C2D3E4F506172839404 /* LifeBoard/State/Mappers/StateTombstoneMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10B1C2D3E4F506172839404 /* LifeBoard/State/Mappers/StateTombstoneMapper.swift */; };
+		B10B1C2D3E4F506172839405 /* LifeBoard/State/Mappers/StateHabitDefinitionMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10B1C2D3E4F506172839405 /* LifeBoard/State/Mappers/StateHabitDefinitionMapper.swift */; };
+		B10B1C2D3E4F506172839407 /* LifeBoard/State/Mappers/StateTaskDefinitionMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10B1C2D3E4F506172839407 /* LifeBoard/State/Mappers/StateTaskDefinitionMapper.swift */; };
+		B10B1C2D3E4F506172839408 /* LifeBoard/State/Mappers/StateProjectMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10B1C2D3E4F506172839408 /* LifeBoard/State/Mappers/StateProjectMapper.swift */; };
+		B15275C8511EAB14F4112515 /* LifeBoard/Onboarding/Components/OnboardingFrictionSelectorLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE642CCFDAF7BBFD6AD34B98 /* LifeBoard/Onboarding/Components/OnboardingFrictionSelectorLayout.swift */; };
 		B1A000000000000000000001 /* LifeBoardFilterComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1A000000000000000000011 /* LifeBoardFilterComponents.swift */; };
 		B1A000000000000000000002 /* LifeBoardSearchChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1A000000000000000000012 /* LifeBoardSearchChrome.swift */; };
 		B1A000000000000000000003 /* HomeChromeComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1A000000000000000000013 /* HomeChromeComponents.swift */; };
@@ -737,32 +737,33 @@
 		B1A000000000000000000008 /* FocusCardFlipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1A000000000000000000018 /* FocusCardFlipView.swift */; };
 		B1A1C1D1E1F1020304050612 /* BootstrapFailureViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1A1C1D1E1F1020304050602 /* BootstrapFailureViewController.swift */; };
 		B1A1C1D1E1F1020304050615 /* ProjectSelectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1A1C1D1E1F1020304050605 /* ProjectSelectionViewModel.swift */; };
-		B1C2D3E42F90000100AA1001 /* TaskWidgetFoundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3E72F90000100AA1001 /* TaskWidgetFoundation.swift */; };
-		B1C2D3E52F90000100AA1001 /* TaskWidgetHomeViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3E82F90000100AA1001 /* TaskWidgetHomeViews.swift */; };
-		B1C2D3E62F90000100AA1001 /* TaskWidgetAccessoryViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3E92F90000100AA1001 /* TaskWidgetAccessoryViews.swift */; };
-		B1C2D3EA2F90000100AA1001 /* TaskWidgetDesignSystemCompat.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3EB2F90000100AA1001 /* TaskWidgetDesignSystemCompat.swift */; };
-		B1C2D3EC2F90000100AA1001 /* HomeCalendarWidgetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3ED2F90000100AA1001 /* HomeCalendarWidgetView.swift */; };
-		B1C2D3EF2F90000100AA1001 /* HomeTimelineWidgetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3F02F90000100AA1001 /* HomeTimelineWidgetView.swift */; };
-		B2621FA8D6DFC6D96F027AA1 /* lifeManagementHabitCadenceLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 286C6F6CD6B150C5152666E2 /* lifeManagementHabitCadenceLabel.swift */; };
-		B2E100000000000000000201 /* BuildHomeAgendaUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E100000000000000000103 /* BuildHomeAgendaUseCase.swift */; };
-		B2E100000000000000000202 /* HomeTodayRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E100000000000000000101 /* HomeTodayRow.swift */; };
-		B2E100000000000000000203 /* HomeHabitRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E100000000000000000102 /* HomeHabitRow.swift */; };
-		B2E100000000000000000204 /* HomeHabitRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E100000000000000000104 /* HomeHabitRowView.swift */; };
-		B2E100000000000000000205 /* HomeSectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E100000000000000000105 /* HomeSectionState.swift */; };
-		B2E100000000000000000206 /* HomeHabitLastCellInteraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E100000000000000000106 /* HomeHabitLastCellInteraction.swift */; };
-		B2E100000000000000000207 /* HomeTaskTintResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E100000000000000000107 /* HomeTaskTintResolver.swift */; };
-		B2E10000000000000000020B /* BuildNeedsReplanCandidatesUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E10000000000000000010B /* BuildNeedsReplanCandidatesUseCase.swift */; };
-		B2E10000000000000000020C /* HomeTimelineProjectionBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E10000000000000000010C /* HomeTimelineProjectionBuilder.swift */; };
-		B3002EA7B07545C684BF2B16 /* HabitRepositoryProtocolExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E4A4DA88B81666171B5808 /* HabitRepositoryProtocolExtension.swift */; };
-		B344A818A99590F452C10FC9 /* TimelineDayPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E09A984D40ECCC16F14B36F /* TimelineDayPresentation.swift */; };
+		B1C2D3E42F90000100AA1001 /* LifeBoardWidgets/TaskWidgetFoundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3E72F90000100AA1001 /* LifeBoardWidgets/TaskWidgetFoundation.swift */; };
+		B1C2D3E52F90000100AA1001 /* LifeBoardWidgets/TaskWidgetHomeViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3E82F90000100AA1001 /* LifeBoardWidgets/TaskWidgetHomeViews.swift */; };
+		B1C2D3E62F90000100AA1001 /* LifeBoardWidgets/TaskWidgetAccessoryViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3E92F90000100AA1001 /* LifeBoardWidgets/TaskWidgetAccessoryViews.swift */; };
+		B1C2D3EA2F90000100AA1001 /* LifeBoardWidgets/TaskWidgetDesignSystemCompat.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3EB2F90000100AA1001 /* LifeBoardWidgets/TaskWidgetDesignSystemCompat.swift */; };
+		B1C2D3EC2F90000100AA1001 /* LifeBoardWidgets/HomeCalendarWidgetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3ED2F90000100AA1001 /* LifeBoardWidgets/HomeCalendarWidgetView.swift */; };
+		B1C2D3EF2F90000100AA1001 /* LifeBoardWidgets/HomeTimelineWidgetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3F02F90000100AA1001 /* LifeBoardWidgets/HomeTimelineWidgetView.swift */; };
+		B2621FA8D6DFC6D96F027AA1 /* LifeBoard/Views/Settings/LifeManagement/lifeManagementHabitCadenceLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 286C6F6CD6B150C5152666E2 /* LifeBoard/Views/Settings/LifeManagement/lifeManagementHabitCadenceLabel.swift */; };
+		B2E100000000000000000201 /* LifeBoard/UseCases/Home/BuildHomeAgendaUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E100000000000000000103 /* LifeBoard/UseCases/Home/BuildHomeAgendaUseCase.swift */; };
+		B2E100000000000000000202 /* LifeBoard/Presentation/Models/HomeTodayRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E100000000000000000101 /* LifeBoard/Presentation/Models/HomeTodayRow.swift */; };
+		B2E100000000000000000203 /* LifeBoard/Presentation/Models/HomeHabitRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E100000000000000000102 /* LifeBoard/Presentation/Models/HomeHabitRow.swift */; };
+		B2E100000000000000000204 /* LifeBoard/View/HomeHabitRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E100000000000000000104 /* LifeBoard/View/HomeHabitRowView.swift */; };
+		B2E100000000000000000205 /* LifeBoard/Presentation/Models/HomeSectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E100000000000000000105 /* LifeBoard/Presentation/Models/HomeSectionState.swift */; };
+		B2E100000000000000000206 /* LifeBoard/Presentation/Models/HomeHabitLastCellInteraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E100000000000000000106 /* LifeBoard/Presentation/Models/HomeHabitLastCellInteraction.swift */; };
+		B2E100000000000000000207 /* LifeBoard/Presentation/Models/HomeTaskTintResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E100000000000000000107 /* LifeBoard/Presentation/Models/HomeTaskTintResolver.swift */; };
+		B2E10000000000000000020B /* LifeBoard/UseCases/Home/BuildNeedsReplanCandidatesUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E10000000000000000010B /* LifeBoard/UseCases/Home/BuildNeedsReplanCandidatesUseCase.swift */; };
+		B2E10000000000000000020C /* LifeBoard/UseCases/Home/HomeTimelineProjectionBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E10000000000000000010C /* LifeBoard/UseCases/Home/HomeTimelineProjectionBuilder.swift */; };
+		B3002EA7B07545C684BF2B16 /* LifeBoard/Onboarding/Models/HabitRepositoryProtocolExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E4A4DA88B81666171B5808 /* LifeBoard/Onboarding/Models/HabitRepositoryProtocolExtension.swift */; };
+		B344A818A99590F452C10FC9 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineDayPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E09A984D40ECCC16F14B36F /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineDayPresentation.swift */; };
 		B426403E6996E2CE8BE66FB6 /* EnhancedDependencyContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 017ECAA6FA89C9A7825A3E8A /* EnhancedDependencyContainer.swift */; };
-		B430108C7AE1B927B9B1FB58 /* OnboardingEvaStatusCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E16263361281852BA8E5B7F /* OnboardingEvaStatusCard.swift */; };
+		B430108C7AE1B927B9B1FB58 /* LifeBoard/Onboarding/Components/OnboardingEvaStatusCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E16263361281852BA8E5B7F /* LifeBoard/Onboarding/Components/OnboardingEvaStatusCard.swift */; };
 		B4D7E8213A4F5C6D7E8F9012 /* V3TestHarness.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D7E8213A4F5C6D7E8F9011 /* V3TestHarness.swift */; };
+		B4D7E8213A4F5C6D7E8F9014 /* SharedColorTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D7E8213A4F5C6D7E8F9015 /* SharedColorTestHelpers.swift */; };
 		B578F682B59B5EE5ADB3FB30 /* AppIntents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 35E5A3CA91F06A962F9FF9FA /* AppIntents.framework */; };
-		B5A18D04B79585D76C0CE5D9 /* HomeHabitMutationFeedbackHaptic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F47DE38B051783EAE99853E /* HomeHabitMutationFeedbackHaptic.swift */; };
-		B696207D77139D62369E4954 /* OnboardingConcentricColorField.swift in Sources */ = {isa = PBXBuildFile; fileRef = F280FDE93AC86C0D82E9C51E /* OnboardingConcentricColorField.swift */; };
+		B5A18D04B79585D76C0CE5D9 /* LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationFeedbackHaptic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F47DE38B051783EAE99853E /* LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationFeedbackHaptic.swift */; };
+		B696207D77139D62369E4954 /* LifeBoard/Onboarding/Models/OnboardingConcentricColorField.swift in Sources */ = {isa = PBXBuildFile; fileRef = F280FDE93AC86C0D82E9C51E /* LifeBoard/Onboarding/Models/OnboardingConcentricColorField.swift */; };
 		B77B0891A4A5B4BF8D6162DC /* TaskDetailComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52E1464E13744427AAFDF824 /* TaskDetailComponents.swift */; };
-		B7B914D911EA894F24D58E27 /* CelebrationPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 875713F2747185071D35BDF9 /* CelebrationPresentation.swift */; };
+		B7B914D911EA894F24D58E27 /* LifeBoard/Presentation/ViewModels/Home/CelebrationPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 875713F2747185071D35BDF9 /* LifeBoard/Presentation/ViewModels/Home/CelebrationPresentation.swift */; };
 		B7C8D9E02F6A100100ABC123 /* ChatPlanApplyUndoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C8D9E12F6A100100ABC123 /* ChatPlanApplyUndoTests.swift */; };
 		B7C8D9E0F1A2233445566779 /* OverdueAgeFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C8D9E0F1A2233445566778 /* OverdueAgeFormatter.swift */; };
 		B7C8D9E0F1A223344556677B /* OverdueAgeFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C8D9E0F1A223344556677A /* OverdueAgeFormatterTests.swift */; };
@@ -770,33 +771,33 @@
 		B7C8D9E0F1A223344556677F /* SunriseFocusZonePresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C8D9E0F1A223344556677E /* SunriseFocusZonePresentationTests.swift */; };
 		B7C8D9E0F1A2233445566791 /* OverdueTriageServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C8D9E0F1A2233445566790 /* OverdueTriageServiceTests.swift */; };
 		B7C8D9E22F6A100100ABC123 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = B7C8D9E32F6A100100ABC123 /* Localizable.xcstrings */; };
-		B8A0777F2A0301936C76BAE4 /* EvaDayTaskOverlayState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34C247867FBCFF10E376C692 /* EvaDayTaskOverlayState.swift */; };
+		B8A0777F2A0301936C76BAE4 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayTaskOverlayState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34C247867FBCFF10E376C692 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayTaskOverlayState.swift */; };
 		B8E100012F70000100A0A001 /* LifeBoardCTABezel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8E100002F70000100A0A001 /* LifeBoardCTABezel.swift */; };
-		B8E100032F70000100A0A001 /* LifeBoardCTABezel.metal in Sources */ = {isa = PBXBuildFile; fileRef = B8E100022F70000100A0A001 /* LifeBoardCTABezel.metal */; };
+		B8E100032F70000100A0A001 /* Effects/LifeBoardCTABezel.metal in Sources */ = {isa = PBXBuildFile; fileRef = B8E100022F70000100A0A001 /* Effects/LifeBoardCTABezel.metal */; };
 		B8E100052F70000100A0A001 /* LifeBoardCTABezelResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8E100042F70000100A0A001 /* LifeBoardCTABezelResolverTests.swift */; };
 		B8F9A0B1C2D3E4F506172839 /* LLMPersonalMemoryStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F9A0B1C2D3E4F506172838 /* LLMPersonalMemoryStoreTests.swift */; };
-		B901CF64B494992760AE96FB /* EvaDayTaskMetadataView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41FF5D1F1BC2347D454A7768 /* EvaDayTaskMetadataView.swift */; };
-		B93F762182E74294AC55C6CB /* TaskDefinitionRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA45AF6FFE4463E49D8FEA68 /* TaskDefinitionRepositoryProtocol.swift */; };
-		BA046E8ED5086F9E39ACB225 /* SunriseDailyReflectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BA3F253548BE9F1EE2AB4B /* SunriseDailyReflectionView.swift */; };
-		BA1DA60A9EB08E7E655CD957 /* OverdueRescueSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 571642516EA3BF4BB335B24A /* OverdueRescueSessionStore.swift */; };
+		B901CF64B494992760AE96FB /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayTaskMetadataView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41FF5D1F1BC2347D454A7768 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayTaskMetadataView.swift */; };
+		B93F762182E74294AC55C6CB /* LifeBoard/Domain/Interfaces/TaskDefinitionRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA45AF6FFE4463E49D8FEA68 /* LifeBoard/Domain/Interfaces/TaskDefinitionRepositoryProtocol.swift */; };
+		BA046E8ED5086F9E39ACB225 /* LifeBoard/View/SunriseDailyReflectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BA3F253548BE9F1EE2AB4B /* LifeBoard/View/SunriseDailyReflectionView.swift */; };
+		BA1DA60A9EB08E7E655CD957 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 571642516EA3BF4BB335B24A /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSessionStore.swift */; };
 		BD300CBF97B95F0D2A2CA092 /* WatchWidgetSnapshotSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B2B9CCE514C217DC9C76773 /* WatchWidgetSnapshotSync.swift */; };
-		BD46BE503829CCD15E61E839 /* HomeViewModel+HabitMutationPatching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B303E46398ACDB321C2EC64 /* HomeViewModel+HabitMutationPatching.swift */; };
+		BD46BE503829CCD15E61E839 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+HabitMutationPatching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B303E46398ACDB321C2EC64 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+HabitMutationPatching.swift */; };
 		BD8C64B243D148C623D1B023 /* HomeViewModel+Timeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2687D1B80519E0EB4CB71E2F /* HomeViewModel+Timeline.swift */; };
-		BDAFA3BFCD791B15C8DB9A9D /* HomeViewModel+HabitReconciliation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7BD248BA8AC069F8261EE8 /* HomeViewModel+HabitReconciliation.swift */; };
-		BE3795CCDFC49D30531F1016 /* OnboardingHomeDemoPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F244B959C35562023B24390 /* OnboardingHomeDemoPreview.swift */; };
-		BE57DA6C896F7EF32A6C3D87 /* TimelineWeekDayCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F01E2761C0C86CBDFA7BB9 /* TimelineWeekDayCell.swift */; };
-		BEB8BC780A4A962C58A77BC4 /* V2FeatureFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34CC91CCAA408A3ADB2D8693 /* V2FeatureFlags.swift */; };
-		BF2F6F85EA92C566A31BB5D4 /* OnboardingCustomEntryRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F9262E57D935FD98FFDE2C /* OnboardingCustomEntryRow.swift */; };
-		BF85F977D5CE48A00E45CB52 /* OverdueRescueViewModel+CardActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96EA41B0CDC25339F1E726E /* OverdueRescueViewModel+CardActions.swift */; };
-		BFE43C633C4F5FD1C5ED3D91 /* OnboardingPastelPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2BC103F549E15D1F888996A /* OnboardingPastelPalette.swift */; };
-		C017F11E0720B026D1DC1692 /* ResolvedProjectSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A81F8713DDE19EF4F956288 /* ResolvedProjectSelection.swift */; };
-		C01EF007CBD4512099E412AF /* QuietTrackingRailStreakWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525792156B7DB238F8089667 /* QuietTrackingRailStreakWidget.swift */; };
+		BDAFA3BFCD791B15C8DB9A9D /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+HabitReconciliation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7BD248BA8AC069F8261EE8 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+HabitReconciliation.swift */; };
+		BE3795CCDFC49D30531F1016 /* LifeBoard/Onboarding/Components/OnboardingHomeDemoPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F244B959C35562023B24390 /* LifeBoard/Onboarding/Components/OnboardingHomeDemoPreview.swift */; };
+		BE57DA6C896F7EF32A6C3D87 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineWeekDayCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F01E2761C0C86CBDFA7BB9 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineWeekDayCell.swift */; };
+		BEB8BC780A4A962C58A77BC4 /* LifeBoard/Services/V2FeatureFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34CC91CCAA408A3ADB2D8693 /* LifeBoard/Services/V2FeatureFlags.swift */; };
+		BF2F6F85EA92C566A31BB5D4 /* LifeBoard/Onboarding/Components/OnboardingCustomEntryRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F9262E57D935FD98FFDE2C /* LifeBoard/Onboarding/Components/OnboardingCustomEntryRow.swift */; };
+		BF85F977D5CE48A00E45CB52 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueViewModel+CardActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96EA41B0CDC25339F1E726E /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueViewModel+CardActions.swift */; };
+		BFE43C633C4F5FD1C5ED3D91 /* LifeBoard/Onboarding/Models/OnboardingPastelPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2BC103F549E15D1F888996A /* LifeBoard/Onboarding/Models/OnboardingPastelPalette.swift */; };
+		C017F11E0720B026D1DC1692 /* LifeBoard/Onboarding/Models/ResolvedProjectSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A81F8713DDE19EF4F956288 /* LifeBoard/Onboarding/Models/ResolvedProjectSelection.swift */; };
+		C01EF007CBD4512099E412AF /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/QuietTrackingRailStreakWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525792156B7DB238F8089667 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/QuietTrackingRailStreakWidget.swift */; };
 		C03666F6116B077DFA194278 /* SyncMergeState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A7A039AC9CA38845D1E44F /* SyncMergeState.swift */; };
-		C158FF33EA33FDAD9E137F25 /* OnboardingNetworkClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4934047F3DBEA1EF645AC1 /* OnboardingNetworkClass.swift */; };
-		C1A100000000000000000101 /* HabitRuntimeReadRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A100000000000000000001 /* HabitRuntimeReadRepositoryProtocol.swift */; };
-		C1A100000000000000000102 /* HabitTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A100000000000000000002 /* HabitTypes.swift */; };
-		C1A100000000000000000103 /* HabitRuntimeUseCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A100000000000000000003 /* HabitRuntimeUseCases.swift */; };
-		C1A100000000000000000104 /* CoreDataHabitRuntimeReadRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A100000000000000000004 /* CoreDataHabitRuntimeReadRepository.swift */; };
+		C158FF33EA33FDAD9E137F25 /* LifeBoard/Onboarding/Models/OnboardingNetworkClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4934047F3DBEA1EF645AC1 /* LifeBoard/Onboarding/Models/OnboardingNetworkClass.swift */; };
+		C1A100000000000000000101 /* LifeBoard/Domain/Interfaces/HabitRuntimeReadRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A100000000000000000001 /* LifeBoard/Domain/Interfaces/HabitRuntimeReadRepositoryProtocol.swift */; };
+		C1A100000000000000000102 /* LifeBoard/Domain/Models/HabitTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A100000000000000000002 /* LifeBoard/Domain/Models/HabitTypes.swift */; };
+		C1A100000000000000000103 /* LifeBoard/UseCases/Habit/HabitRuntimeUseCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A100000000000000000003 /* LifeBoard/UseCases/Habit/HabitRuntimeUseCases.swift */; };
+		C1A100000000000000000104 /* LifeBoard/State/Repositories/CoreDataHabitRuntimeReadRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A100000000000000000004 /* LifeBoard/State/Repositories/CoreDataHabitRuntimeReadRepository.swift */; };
 		C1A2B3C4D5E6F70011223344 /* LLMRuntimeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A2B3C4D5E6F70011223345 /* LLMRuntimeCoordinator.swift */; };
 		C1A2B3C4D5E6F70011223346 /* LLMProjectionTimeout.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A2B3C4D5E6F70011223347 /* LLMProjectionTimeout.swift */; };
 		C1A2B3C4D5E6F70011223348 /* LLMRuntimeCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A2B3C4D5E6F70011223349 /* LLMRuntimeCoordinatorTests.swift */; };
@@ -804,26 +805,26 @@
 		C1A2B3C4D5E6F70011223350 /* LLMInferenceEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A2B3C4D5E6F70011223351 /* LLMInferenceEngine.swift */; };
 		C1A2B3C4D5E6F70011223352 /* ChatTranscriptSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A2B3C4D5E6F70011223353 /* ChatTranscriptSnapshot.swift */; };
 		C1A2B3C4D5E6F70011223354 /* ChatTranscriptSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A2B3C4D5E6F70011223355 /* ChatTranscriptSnapshotTests.swift */; };
-		C1B100000000000000000102 /* HabitBoardPresentationBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B100000000000000000101 /* HabitBoardPresentationBuilder.swift */; };
-		C1B100000000000000000104 /* HabitBoardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B100000000000000000103 /* HabitBoardViewModel.swift */; };
-		C1B100000000000000000106 /* HabitBoardViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B100000000000000000105 /* HabitBoardViews.swift */; };
+		C1B100000000000000000102 /* LifeBoard/Presentation/Habits/HabitBoardPresentationBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B100000000000000000101 /* LifeBoard/Presentation/Habits/HabitBoardPresentationBuilder.swift */; };
+		C1B100000000000000000104 /* LifeBoard/Presentation/ViewModels/HabitBoardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B100000000000000000103 /* LifeBoard/Presentation/ViewModels/HabitBoardViewModel.swift */; };
+		C1B100000000000000000106 /* LifeBoard/View/HabitBoardViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B100000000000000000105 /* LifeBoard/View/HabitBoardViews.swift */; };
 		C1B2C3D4E5F60718293A4B5D /* LifeManagementDestructiveFlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B2C3D4E5F60718293A4B5C /* LifeManagementDestructiveFlowCoordinator.swift */; };
-		C2421458D3A338445B13FBE6 /* OnboardingInlineActionRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E8BC7F87ABDAD6C5B79CE0 /* OnboardingInlineActionRow.swift */; };
-		C27DED3B1AE919A68A5FA783 /* OverdueRescueDeckState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20400B4B017F188A0F00344 /* OverdueRescueDeckState.swift */; };
-		C280C01585D08BFD8692758E /* HomeHabitRowPlacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = F21D047990188A6B02C70A9F /* HomeHabitRowPlacement.swift */; };
+		C2421458D3A338445B13FBE6 /* LifeBoard/Onboarding/Components/OnboardingInlineActionRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E8BC7F87ABDAD6C5B79CE0 /* LifeBoard/Onboarding/Components/OnboardingInlineActionRow.swift */; };
+		C27DED3B1AE919A68A5FA783 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDeckState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20400B4B017F188A0F00344 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDeckState.swift */; };
+		C280C01585D08BFD8692758E /* LifeBoard/Presentation/ViewModels/Home/HomeHabitRowPlacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = F21D047990188A6B02C70A9F /* LifeBoard/Presentation/ViewModels/Home/HomeHabitRowPlacement.swift */; };
 		C2D3E4F5061728394A5B6C7D /* DeleteTaskDefinitionUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2D3E4F5061728394A5B6C7C /* DeleteTaskDefinitionUseCaseTests.swift */; };
 		C2D804681AC165ADEAD7D906 /* SavedHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F7676A13058C4757D1E2718 /* SavedHomeView.swift */; };
-		C2FD7479882454D6E58D05D5 /* OnboardingPromptTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D9FE88AEA020FF9DA3791C7 /* OnboardingPromptTheme.swift */; };
-		C3AC86F4BE2832B4E90C8467 /* HomeDueTodayAgendaLoadState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F92AEE830976A394F39CC8ED /* HomeDueTodayAgendaLoadState.swift */; };
-		C3B88D39DA52634C915E96AE /* OnboardingSuccessHero.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D63CF8E5D155F2AF44EF2A /* OnboardingSuccessHero.swift */; };
-		C3D50B7B0090C88C8F837DA5 /* OnboardingFlowModel+NavigationPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7FAC655E04AFF0711F5AD2 /* OnboardingFlowModel+NavigationPersistence.swift */; };
-		C3FB1D92DD198DC445CB8DB7 /* TimelineStreamLayerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEB129D0203ADC132EE57051 /* TimelineStreamLayerSpec.swift */; };
-		C4B2E3D5F6A70819 /* AchievementCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A1F2C4D5E6F708 /* AchievementCatalog.swift */; };
-		C4B2E3D5F6A7081A /* BadgeGalleryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A1F2C4D5E6F709 /* BadgeGalleryView.swift */; };
-		C4B2E3D5F6A7081B /* LevelUpCelebrationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A1F2C4D5E6F70A /* LevelUpCelebrationView.swift */; };
-		C4B2E3D5F6A7081C /* MilestoneCelebrationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A1F2C4D5E6F70B /* MilestoneCelebrationView.swift */; };
-		C4B2E3D5F6A7081D /* BadgeDetailSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A1F2C4D5E6F70C /* BadgeDetailSheet.swift */; };
-		C4BB75857943B70FDC94219A /* TimelineCanvasLayoutPlan+VisualTimeMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = A66619E14C36928EAAFD471F /* TimelineCanvasLayoutPlan+VisualTimeMapping.swift */; };
+		C2FD7479882454D6E58D05D5 /* LifeBoard/Onboarding/Models/OnboardingPromptTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D9FE88AEA020FF9DA3791C7 /* LifeBoard/Onboarding/Models/OnboardingPromptTheme.swift */; };
+		C3AC86F4BE2832B4E90C8467 /* LifeBoard/Presentation/ViewModels/Home/HomeDueTodayAgendaLoadState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F92AEE830976A394F39CC8ED /* LifeBoard/Presentation/ViewModels/Home/HomeDueTodayAgendaLoadState.swift */; };
+		C3B88D39DA52634C915E96AE /* LifeBoard/Onboarding/Components/OnboardingSuccessHero.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D63CF8E5D155F2AF44EF2A /* LifeBoard/Onboarding/Components/OnboardingSuccessHero.swift */; };
+		C3D50B7B0090C88C8F837DA5 /* LifeBoard/Onboarding/Services/OnboardingFlowModel+NavigationPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7FAC655E04AFF0711F5AD2 /* LifeBoard/Onboarding/Services/OnboardingFlowModel+NavigationPersistence.swift */; };
+		C3FB1D92DD198DC445CB8DB7 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamLayerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEB129D0203ADC132EE57051 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamLayerSpec.swift */; };
+		C4B2E3D5F6A70819 /* LifeBoard/Domain/Models/AchievementCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A1F2C4D5E6F708 /* LifeBoard/Domain/Models/AchievementCatalog.swift */; };
+		C4B2E3D5F6A7081A /* LifeBoard/View/BadgeGalleryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A1F2C4D5E6F709 /* LifeBoard/View/BadgeGalleryView.swift */; };
+		C4B2E3D5F6A7081B /* LifeBoard/View/LevelUpCelebrationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A1F2C4D5E6F70A /* LifeBoard/View/LevelUpCelebrationView.swift */; };
+		C4B2E3D5F6A7081C /* LifeBoard/View/MilestoneCelebrationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A1F2C4D5E6F70B /* LifeBoard/View/MilestoneCelebrationView.swift */; };
+		C4B2E3D5F6A7081D /* LifeBoard/View/BadgeDetailSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A1F2C4D5E6F70C /* LifeBoard/View/BadgeDetailSheet.swift */; };
+		C4BB75857943B70FDC94219A /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCanvasLayoutPlan+VisualTimeMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = A66619E14C36928EAAFD471F /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCanvasLayoutPlan+VisualTimeMapping.swift */; };
 		C4D5E6F70891A2B3C4D5E701 /* TaskScheduleEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D5E6F70891A2B3C4D5E700 /* TaskScheduleEditor.swift */; };
 		C4D5E6F70891A2B3C4D5E702 /* SunriseTaskDetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D5E6F70891A2B3C4D5E703 /* SunriseTaskDetailScreen.swift */; };
 		C4D5E6F70891A2B3C4D5E704 /* SunriseHabitDetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D5E6F70891A2B3C4D5E705 /* SunriseHabitDetailScreen.swift */; };
@@ -832,48 +833,48 @@
 		C4D5E6F70891A2B3C4D5E709 /* TimelineAnchorRitualModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D5E6F70891A2B3C4D5E70D /* TimelineAnchorRitualModel.swift */; };
 		C4D5E6F70891A2B3C4D5E70A /* TimelineAnchorWaveShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D5E6F70891A2B3C4D5E70E /* TimelineAnchorWaveShape.swift */; };
 		C4D5E6F70891A2B3C4D5E70B /* TimelineAnchorRitualSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D5E6F70891A2B3C4D5E70F /* TimelineAnchorRitualSheetView.swift */; };
-		C537950FC6FD78BB996E7CA5 /* HomeXPHeroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17DC0A5BC84D9C6C792B2AB6 /* HomeXPHeroView.swift */; };
+		C537950FC6FD78BB996E7CA5 /* LifeBoard/View/HomeXPHeroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17DC0A5BC84D9C6C792B2AB6 /* LifeBoard/View/HomeXPHeroView.swift */; };
 		C5E24F11E95F5281AFA4E8DD /* UIKit+TokenAdapters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A94E5E4F9BB3AA846B56A72 /* UIKit+TokenAdapters.swift */; };
-		C5F044673340D4322E0821B9 /* HabitListRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 903BFF6DB72A0D515603C771 /* HabitListRow.swift */; };
+		C5F044673340D4322E0821B9 /* LifeBoard/Views/Settings/LifeManagement/HabitListRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 903BFF6DB72A0D515603C771 /* LifeBoard/Views/Settings/LifeManagement/HabitListRow.swift */; };
 		C6182C050AFE59B731DAD798 /* LifeBoardWidgets.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = F9A8B91DCC93833939CAE3C6 /* LifeBoardWidgets.appex */; platformFilter = ios; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		C6763538C5D158A7E8967D88 /* TimelineStreamSegment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F4D92143BA2F3C1FE24BFFE /* TimelineStreamSegment.swift */; };
-		C68012797DEDCF3D065BBA45 /* InsightsLaunchRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54D0BEA667E2738CDF713A68 /* InsightsLaunchRequest.swift */; };
-		C6D12F2061A8EBCCFD6346DA /* OnboardingFrictionOptionCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA49A78931E2752ADDE59CA /* OnboardingFrictionOptionCard.swift */; };
+		C6763538C5D158A7E8967D88 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamSegment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F4D92143BA2F3C1FE24BFFE /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamSegment.swift */; };
+		C68012797DEDCF3D065BBA45 /* LifeBoard/Presentation/ViewModels/Home/InsightsLaunchRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54D0BEA667E2738CDF713A68 /* LifeBoard/Presentation/ViewModels/Home/InsightsLaunchRequest.swift */; };
+		C6D12F2061A8EBCCFD6346DA /* LifeBoard/Onboarding/Components/OnboardingFrictionOptionCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA49A78931E2752ADDE59CA /* LifeBoard/Onboarding/Components/OnboardingFrictionOptionCard.swift */; };
 		C7A200000000000000000001 /* ChatGenerationCancellationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A200000000000000000002 /* ChatGenerationCancellationPolicy.swift */; };
 		C7A200000000000000000003 /* ChatCancellationPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A200000000000000000004 /* ChatCancellationPolicyTests.swift */; };
 		C7A200000000000000000005 /* LockedResultAccumulator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A200000000000000000006 /* LockedResultAccumulator.swift */; };
 		C7A200000000000000000007 /* HomeTriageAndTop3Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A200000000000000000008 /* HomeTriageAndTop3Tests.swift */; };
-		C7E4C6E991D23697752D8D6C /* EvaDayHabitActionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A37591A5FBC6DAD9309A0E /* EvaDayHabitActionsView.swift */; };
+		C7E4C6E991D23697752D8D6C /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitActionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A37591A5FBC6DAD9309A0E /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitActionsView.swift */; };
 		C8A4F1023D6E4B7A91C2D302 /* HabitBoardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8A4F1023D6E4B7A91C2D301 /* HabitBoardViewModelTests.swift */; };
 		C8A4F1023D6E4B7A91C2D304 /* HabitBoardUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8A4F1023D6E4B7A91C2D303 /* HabitBoardUITests.swift */; };
-		C97CA61FED91A0C2BE4E3AB1 /* HomeDerivedTaskRowsCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB92AF0F70C629B9BB0501F5 /* HomeDerivedTaskRowsCache.swift */; };
-		C9F2A10C3D4E5F60718293AA /* WriteClosedRepositoryAdapters.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9F2A10C3D4E5F60718293AA /* WriteClosedRepositoryAdapters.swift */; };
-		CA1A10000000000000000001 /* CalendarEventsProviderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1A20000000000000000001 /* CalendarEventsProviderProtocol.swift */; };
-		CA1A10000000000000000002 /* CalendarIntegrationModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1A20000000000000000002 /* CalendarIntegrationModels.swift */; };
-		CA1A10000000000000000003 /* CalendarComputationUseCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1A20000000000000000003 /* CalendarComputationUseCases.swift */; };
-		CA1A10000000000000000004 /* EventKitCalendarEventsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1A20000000000000000004 /* EventKitCalendarEventsProvider.swift */; };
-		CA1A10000000000000000005 /* CalendarIntegrationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1A20000000000000000005 /* CalendarIntegrationService.swift */; };
-		CA1A10000000000000000006 /* EventKitCalendarChooserSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1A20000000000000000006 /* EventKitCalendarChooserSheet.swift */; };
-		CA1A10000000000000000007 /* EventKitEventDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1A20000000000000000007 /* EventKitEventDetailView.swift */; };
+		C97CA61FED91A0C2BE4E3AB1 /* LifeBoard/Presentation/ViewModels/Home/HomeDerivedTaskRowsCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB92AF0F70C629B9BB0501F5 /* LifeBoard/Presentation/ViewModels/Home/HomeDerivedTaskRowsCache.swift */; };
+		C9F2A10C3D4E5F60718293AA /* LifeBoard/State/Sync/WriteClosedRepositoryAdapters.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9F2A10C3D4E5F60718293AA /* LifeBoard/State/Sync/WriteClosedRepositoryAdapters.swift */; };
+		CA1A10000000000000000001 /* LifeBoard/Domain/Interfaces/CalendarEventsProviderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1A20000000000000000001 /* LifeBoard/Domain/Interfaces/CalendarEventsProviderProtocol.swift */; };
+		CA1A10000000000000000002 /* LifeBoard/Domain/Models/CalendarIntegrationModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1A20000000000000000002 /* LifeBoard/Domain/Models/CalendarIntegrationModels.swift */; };
+		CA1A10000000000000000003 /* LifeBoard/UseCases/Calendar/CalendarComputationUseCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1A20000000000000000003 /* LifeBoard/UseCases/Calendar/CalendarComputationUseCases.swift */; };
+		CA1A10000000000000000004 /* LifeBoard/State/Services/EventKitCalendarEventsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1A20000000000000000004 /* LifeBoard/State/Services/EventKitCalendarEventsProvider.swift */; };
+		CA1A10000000000000000005 /* LifeBoard/State/Services/CalendarIntegrationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1A20000000000000000005 /* LifeBoard/State/Services/CalendarIntegrationService.swift */; };
+		CA1A10000000000000000006 /* LifeBoard/View/Calendar/EventKitCalendarChooserSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1A20000000000000000006 /* LifeBoard/View/Calendar/EventKitCalendarChooserSheet.swift */; };
+		CA1A10000000000000000007 /* LifeBoard/View/Calendar/EventKitEventDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1A20000000000000000007 /* LifeBoard/View/Calendar/EventKitEventDetailView.swift */; };
 		CA1A10000000000000000009 /* CalendarComputationUseCasesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1A20000000000000000009 /* CalendarComputationUseCasesTests.swift */; };
 		CA1A1000000000000000000A /* CalendarIntegrationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1A2000000000000000000A /* CalendarIntegrationServiceTests.swift */; };
 		CA1A1000000000000000000B /* HomeCalendarIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1A2000000000000000000B /* HomeCalendarIntegrationTests.swift */; };
 		CA1A1000000000000000000C /* CalendarTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1A2000000000000000000C /* CalendarTestSupport.swift */; };
 		CA1A1000000000000000000D /* HomeCalendarModuleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1A2000000000000000000D /* HomeCalendarModuleUITests.swift */; };
-		CA588F0C88CA2D9300D59E10 /* AppOnboardingStateStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9762A762CB36A9A40F919329 /* AppOnboardingStateStore.swift */; };
-		CABA353295DF444EC908D3CC /* TimelineCompactItemRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4033ABAF3ABB94CB6771C4CC /* TimelineCompactItemRow.swift */; };
-		CAE86C460FCB7CB9FA6C9AE2 /* OnboardingAccessibilityMarker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B274BA1A3D3146A9178FFC7 /* OnboardingAccessibilityMarker.swift */; };
-		CB0E20CDE17573CE6A56AEFF /* OnboardingCompactHabitRail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29564FDC651771ED4BB94446 /* OnboardingCompactHabitRail.swift */; };
-		CB2585384EDD36506A08BC39 /* EvaChatSunriseGlass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6406FAAF5EBC202BFD7F2588 /* EvaChatSunriseGlass.swift */; };
-		CB80F340473A31AFE8CF162A /* OnboardingHeroMediaAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98FB866510908516712F3407 /* OnboardingHeroMediaAsset.swift */; };
-		CD7AADFB07AFA97B5C0D6452 /* HomeViewModel+RecurringTopUp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89E23AC0E5DF84E0125F5845 /* HomeViewModel+RecurringTopUp.swift */; };
-		CD83FC6E516299A8FB19F781 /* TodayXPWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A74DF0E9DCAEB8A8179F375 /* TodayXPWidget.swift */; };
-		CDFF51674BB1F653FF14260A /* OnboardingMascotCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B4B8D198A7243A6496C809 /* OnboardingMascotCarousel.swift */; };
-		CE101A5DFCA6C30A72A5CE61 /* PendingOnboardingPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D09C9507B3C691C73DA808A /* PendingOnboardingPresentation.swift */; };
-		CE266F5395572A3FFC2150D1 /* HomeHabitSectionCardHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 425B8A685EE2C485783B0578 /* HomeHabitSectionCardHost.swift */; };
-		CEA4FD3F132804749E69A4B3 /* SectionMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6956BC00E9F0B0BC847DD7AA /* SectionMapper.swift */; };
-		CEBD06B0323F598F2C11A5DC /* CelebrationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B95AB168FC420F7EE412CB09 /* CelebrationRouter.swift */; };
-		D1855A230115C554ADB92AEA /* DailyXPAggregateDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4AF3952DBA8C2ACE185FEF0 /* DailyXPAggregateDefinition.swift */; };
+		CA588F0C88CA2D9300D59E10 /* LifeBoard/Onboarding/Services/AppOnboardingStateStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9762A762CB36A9A40F919329 /* LifeBoard/Onboarding/Services/AppOnboardingStateStore.swift */; };
+		CABA353295DF444EC908D3CC /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompactItemRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4033ABAF3ABB94CB6771C4CC /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompactItemRow.swift */; };
+		CAE86C460FCB7CB9FA6C9AE2 /* LifeBoard/Onboarding/Models/OnboardingAccessibilityMarker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B274BA1A3D3146A9178FFC7 /* LifeBoard/Onboarding/Models/OnboardingAccessibilityMarker.swift */; };
+		CB0E20CDE17573CE6A56AEFF /* LifeBoard/Onboarding/Models/OnboardingCompactHabitRail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29564FDC651771ED4BB94446 /* LifeBoard/Onboarding/Models/OnboardingCompactHabitRail.swift */; };
+		CB2585384EDD36506A08BC39 /* LifeBoard/LLM/Views/Chat/Chrome/EvaChatSunriseGlass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6406FAAF5EBC202BFD7F2588 /* LifeBoard/LLM/Views/Chat/Chrome/EvaChatSunriseGlass.swift */; };
+		CB80F340473A31AFE8CF162A /* LifeBoard/Onboarding/Components/OnboardingHeroMediaAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98FB866510908516712F3407 /* LifeBoard/Onboarding/Components/OnboardingHeroMediaAsset.swift */; };
+		CD7AADFB07AFA97B5C0D6452 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+RecurringTopUp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89E23AC0E5DF84E0125F5845 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+RecurringTopUp.swift */; };
+		CD83FC6E516299A8FB19F781 /* LifeBoardWidgets/TodayXPWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A74DF0E9DCAEB8A8179F375 /* LifeBoardWidgets/TodayXPWidget.swift */; };
+		CDFF51674BB1F653FF14260A /* LifeBoard/Onboarding/Models/OnboardingMascotCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B4B8D198A7243A6496C809 /* LifeBoard/Onboarding/Models/OnboardingMascotCarousel.swift */; };
+		CE101A5DFCA6C30A72A5CE61 /* LifeBoard/Onboarding/Models/PendingOnboardingPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D09C9507B3C691C73DA808A /* LifeBoard/Onboarding/Models/PendingOnboardingPresentation.swift */; };
+		CE266F5395572A3FFC2150D1 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeHabitSectionCardHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 425B8A685EE2C485783B0578 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeHabitSectionCardHost.swift */; };
+		CEA4FD3F132804749E69A4B3 /* LifeBoard/Domain/Mappers/SectionMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6956BC00E9F0B0BC847DD7AA /* LifeBoard/Domain/Mappers/SectionMapper.swift */; };
+		CEBD06B0323F598F2C11A5DC /* LifeBoard/Presentation/ViewModels/Home/CelebrationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B95AB168FC420F7EE412CB09 /* LifeBoard/Presentation/ViewModels/Home/CelebrationRouter.swift */; };
+		D1855A230115C554ADB92AEA /* LifeBoard/Domain/Models/DailyXPAggregateDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4AF3952DBA8C2ACE185FEF0 /* LifeBoard/Domain/Models/DailyXPAggregateDefinition.swift */; };
 		D1A200000000000000000001 /* HomeChromeSnapshot+Presentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A100000000000000000001 /* HomeChromeSnapshot+Presentation.swift */; };
 		D1A200000000000000000002 /* HomeScopeSummaryButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A100000000000000000002 /* HomeScopeSummaryButtonView.swift */; };
 		D1A200000000000000000003 /* HomeBackToTodayButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A100000000000000000003 /* HomeBackToTodayButtonView.swift */; };
@@ -884,25 +885,25 @@
 		D1A200000000000000000008 /* HomeMomentumProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A100000000000000000008 /* HomeMomentumProgressBar.swift */; };
 		D1A200000000000000000009 /* HomeEvaChatTopChromeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A100000000000000000009 /* HomeEvaChatTopChromeView.swift */; };
 		D206E9E48E0AEB00D02CED2D /* SlashCommandCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0633BF8BACC2D4FBC9508866 /* SlashCommandCatalog.swift */; };
-		D2A100000000000000000002 /* QuietTrackingComposerSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A100000000000000000001 /* QuietTrackingComposerSnapshot.swift */; };
-		D2A100000000000000000004 /* SunriseQuietTrackingComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A100000000000000000003 /* SunriseQuietTrackingComposerView.swift */; };
+		D2A100000000000000000002 /* LifeBoard/Presentation/Models/QuietTrackingComposerSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A100000000000000000001 /* LifeBoard/Presentation/Models/QuietTrackingComposerSnapshot.swift */; };
+		D2A100000000000000000004 /* LifeBoard/View/SunriseQuietTrackingComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A100000000000000000003 /* LifeBoard/View/SunriseQuietTrackingComposerView.swift */; };
 		D2A100000000000000000006 /* QuietTrackingUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A100000000000000000005 /* QuietTrackingUITests.swift */; };
-		D2D43D1D68EDFA8B61A9D766 /* HomeReloadScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = F98E00AF77E03AB54CB0D948 /* HomeReloadScope.swift */; };
+		D2D43D1D68EDFA8B61A9D766 /* LifeBoard/Presentation/ViewModels/Home/HomeReloadScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = F98E00AF77E03AB54CB0D948 /* LifeBoard/Presentation/ViewModels/Home/HomeReloadScope.swift */; };
 		D2E850DDFA592D3CFAA9C922 /* NotificationPermissionBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 919DB5CEED1B1E1906FF474C /* NotificationPermissionBanner.swift */; };
-		D336A787C8DCE1322AB8ADAB /* Section.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D70DF5D3C4DE407EF935B48 /* Section.swift */; };
+		D336A787C8DCE1322AB8ADAB /* LifeBoard/Domain/Models/Section.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D70DF5D3C4DE407EF935B48 /* LifeBoard/Domain/Models/Section.swift */; };
 		D361862502EE5A7C61FAEDB8 /* HomeViewController+Presentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE5DC87E5EFAD171634D5F0A /* HomeViewController+Presentation.swift */; };
-		D38314D027D0FAD3E8DBD55A /* AppOnboardingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D9D661B4914CE34AEA2DD30 /* AppOnboardingCoordinator.swift */; };
+		D38314D027D0FAD3E8DBD55A /* LifeBoard/Onboarding/Coordinator/AppOnboardingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D9D661B4914CE34AEA2DD30 /* LifeBoard/Onboarding/Coordinator/AppOnboardingCoordinator.swift */; };
 		D43DC96C4F8B4B199F09A64D /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 7524B71A2DE4EAC90026D865 /* GoogleService-Info.plist */; };
-		D4ABAC9936B71C3DEB673B49 /* TimelineCompactAnchorRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6492AC4EA233D9F3AA0FAA30 /* TimelineCompactAnchorRow.swift */; };
-		D4E0D80A4976DADBFEC9F159 /* onboardingLogLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12B9F0A506329D6FA33A3932 /* onboardingLogLine.swift */; };
+		D4ABAC9936B71C3DEB673B49 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompactAnchorRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6492AC4EA233D9F3AA0FAA30 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompactAnchorRow.swift */; };
+		D4E0D80A4976DADBFEC9F159 /* LifeBoard/Onboarding/Models/onboardingLogLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12B9F0A506329D6FA33A3932 /* LifeBoard/Onboarding/Models/onboardingLogLine.swift */; };
 		D4F200000000000000000101 /* TaskPlanningBucket.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F100000000000000000101 /* TaskPlanningBucket.swift */; };
 		D4F200000000000000000102 /* WeeklyPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F100000000000000000102 /* WeeklyPlan.swift */; };
 		D4F200000000000000000103 /* WeeklyOutcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F100000000000000000103 /* WeeklyOutcome.swift */; };
 		D4F200000000000000000104 /* WeeklyReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F100000000000000000104 /* WeeklyReview.swift */; };
 		D4F200000000000000000105 /* ReflectionNote.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F100000000000000000105 /* ReflectionNote.swift */; };
 		D4F200000000000000000106 /* WeeklyMomentumSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F100000000000000000106 /* WeeklyMomentumSummary.swift */; };
-		D4F200000000000000000107 /* CoreDataWeeklyRepositories.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F100000000000000000107 /* CoreDataWeeklyRepositories.swift */; };
-		D4F200000000000000000108 /* WeeklyOperatingUseCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F100000000000000000108 /* WeeklyOperatingUseCases.swift */; };
+		D4F200000000000000000107 /* LifeBoard/State/Repositories/CoreDataWeeklyRepositories.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F100000000000000000107 /* LifeBoard/State/Repositories/CoreDataWeeklyRepositories.swift */; };
+		D4F200000000000000000108 /* LifeBoard/UseCases/Weekly/WeeklyOperatingUseCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F100000000000000000108 /* LifeBoard/UseCases/Weekly/WeeklyOperatingUseCases.swift */; };
 		D4F200000000000000000109 /* WeeklyPlannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F100000000000000000109 /* WeeklyPlannerViewModel.swift */; };
 		D4F20000000000000000010A /* WeeklyReviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F10000000000000000010A /* WeeklyReviewViewModel.swift */; };
 		D4F20000000000000000010B /* HomeWeeklySummaryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F10000000000000000010B /* HomeWeeklySummaryCard.swift */; };
@@ -915,9 +916,9 @@
 		D4F200000000000000000122 /* HomeAIActionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F200000000000000000120 /* HomeAIActionCoordinatorTests.swift */; };
 		D4F200000000000000000123 /* XPCalculationEngineWeeklyCategoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F200000000000000000121 /* XPCalculationEngineWeeklyCategoryTests.swift */; };
 		D4F200000000000000000125 /* WeeklyOperatingLayerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F200000000000000000124 /* WeeklyOperatingLayerViewModelTests.swift */; };
-		D4F300000000000000000130 /* DailyReflectionLoadCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F300000000000000000131 /* DailyReflectionLoadCoordinator.swift */; };
-		D4F400000000000000000201 /* SunriseTimelineSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F400000000000000000202 /* SunriseTimelineSurface.swift */; };
-		D57A320DF8A2202069F711FB /* TimelineBackdropWeekView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C95AF729D85C65D636AF500A /* TimelineBackdropWeekView.swift */; };
+		D4F300000000000000000130 /* LifeBoard/UseCases/Gamification/DailyReflectionLoadCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F300000000000000000131 /* LifeBoard/UseCases/Gamification/DailyReflectionLoadCoordinator.swift */; };
+		D4F400000000000000000201 /* LifeBoard/View/SunriseTimelineSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F400000000000000000202 /* LifeBoard/View/SunriseTimelineSurface.swift */; };
+		D57A320DF8A2202069F711FB /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineBackdropWeekView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C95AF729D85C65D636AF500A /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineBackdropWeekView.swift */; };
 		D5A200000000000000000001 /* ReflectPlanStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A100000000000000000001 /* ReflectPlanStyle.swift */; };
 		D5A200000000000000000002 /* SunriseReflectPlanScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A100000000000000000002 /* SunriseReflectPlanScreen.swift */; };
 		D5A200000000000000000003 /* ReflectPlanHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A100000000000000000003 /* ReflectPlanHeader.swift */; };
@@ -935,9 +936,9 @@
 		D5A20000000000000000000F /* StickySaveButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A10000000000000000000F /* StickySaveButton.swift */; };
 		D5A200000000000000000010 /* SwapTaskPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A100000000000000000010 /* SwapTaskPicker.swift */; };
 		D5E7A8BA2F3C4D5E0067A1B2 /* DailySummaryModalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5E7A8B92F3C4D5E0067A1B2 /* DailySummaryModalTests.swift */; };
-		D65596F60D499A8BB32EFBD4 /* OnboardingWelcomeIntroLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 377436A41D3BA36DD06E3C58 /* OnboardingWelcomeIntroLine.swift */; };
-		D697AD981C87D4D7D84A6EF0 /* SunriseAppShellView+FocusTimersAndReflection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB45FAF57431067D93F59BA3 /* SunriseAppShellView+FocusTimersAndReflection.swift */; };
-		D6988674F7729285A707C98C /* CodingKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB8BC6F60B76437F2E6148F7 /* CodingKeys.swift */; };
+		D65596F60D499A8BB32EFBD4 /* LifeBoard/Onboarding/Models/OnboardingWelcomeIntroLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 377436A41D3BA36DD06E3C58 /* LifeBoard/Onboarding/Models/OnboardingWelcomeIntroLine.swift */; };
+		D697AD981C87D4D7D84A6EF0 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+FocusTimersAndReflection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB45FAF57431067D93F59BA3 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+FocusTimersAndReflection.swift */; };
+		D6988674F7729285A707C98C /* LifeBoard/Onboarding/Models/CodingKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB8BC6F60B76437F2E6148F7 /* LifeBoard/Onboarding/Models/CodingKeys.swift */; };
 		D6A192319732E9758B2D14B9 /* SavedHomeViewRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55C5A46909EF46C27D7B84E3 /* SavedHomeViewRepositoryProtocol.swift */; };
 		D6B2E31F4A5C7890BCDEF012 /* AddTaskCreateButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5A1D20E3F4B6789ABCDEF01 /* AddTaskCreateButton.swift */; };
 		D6B2E31F4A5C7890BCDEF023 /* AddTaskDescriptionField.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5A1D20E3F4B6789ABCDEF02 /* AddTaskDescriptionField.swift */; };
@@ -955,35 +956,35 @@
 		D6B2E31F4A5C7890BCDEF0F0 /* CreationPresentationContracts.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5A1D20E3F4B6789ABCDEF0F /* CreationPresentationContracts.swift */; };
 		D6B2E31F4A5C7890BCDEF0F1 /* CreationSharedComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5A1D20E3F4B6789ABCDEF10 /* CreationSharedComponents.swift */; };
 		D6BD60E5C38CC9087DD53FC6 /* SlashCommandExecutionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1371F4BC6B6BB7BF68747A7F /* SlashCommandExecutionService.swift */; };
-		D705016D0D6D308050273D76 /* TimelineCompactConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = C869F0E1F0337702AD2AF780 /* TimelineCompactConnector.swift */; };
+		D705016D0D6D308050273D76 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompactConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = C869F0E1F0337702AD2AF780 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompactConnector.swift */; };
 		D7A500000000000000000102 /* LifeBoardLaunchSplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7A500000000000000000101 /* LifeBoardLaunchSplashView.swift */; };
 		D7A500000000000000000202 /* HomeViewControllerLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7A500000000000000000201 /* HomeViewControllerLifecycleTests.swift */; };
-		D86B5C7DF619A7A577D4874F /* OnboardingMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37DD8CAB8F66109195DD8D31 /* OnboardingMode.swift */; };
-		D92AC2EBBC4D507DE7D45C8F /* ConversationView+LiveOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6243658CCD3FA73A97B58600 /* ConversationView+LiveOutput.swift */; };
+		D86B5C7DF619A7A577D4874F /* LifeBoard/Onboarding/Models/OnboardingMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37DD8CAB8F66109195DD8D31 /* LifeBoard/Onboarding/Models/OnboardingMode.swift */; };
+		D92AC2EBBC4D507DE7D45C8F /* LifeBoard/LLM/Views/Chat/Conversation/ConversationView+LiveOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6243658CCD3FA73A97B58600 /* LifeBoard/LLM/Views/Chat/Conversation/ConversationView+LiveOutput.swift */; };
 		D9A0B1C2D3E4F506172839AC /* InsightsModuleVisibilityPlannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9A0B1C2D3E4F506172839AB /* InsightsModuleVisibilityPlannerTests.swift */; };
-		D9A0B1C2D3E4F506172839AD /* InsightsModuleVisibilityPlanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9A0B1C2D3E4F506172839AE /* InsightsModuleVisibilityPlanner.swift */; };
-		DA083B470E02C697ADD728B8 /* timelineGapPromptText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55440275F14F44B2492C3CAC /* timelineGapPromptText.swift */; };
-		DA50FEA644495EB466054A2B /* OnboardingSelectableCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A93FE62F2A34CD25059D4950 /* OnboardingSelectableCard.swift */; };
-		DA81A406247E701A8EE98417 /* OnboardingMiniMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144D7D155E9471F5D9E1CD62 /* OnboardingMiniMetric.swift */; };
+		D9A0B1C2D3E4F506172839AD /* LifeBoard/Presentation/Models/InsightsModuleVisibilityPlanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9A0B1C2D3E4F506172839AE /* LifeBoard/Presentation/Models/InsightsModuleVisibilityPlanner.swift */; };
+		DA083B470E02C697ADD728B8 /* LifeBoard/Presentation/Home/Timeline/Surface/timelineGapPromptText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55440275F14F44B2492C3CAC /* LifeBoard/Presentation/Home/Timeline/Surface/timelineGapPromptText.swift */; };
+		DA50FEA644495EB466054A2B /* LifeBoard/Onboarding/Components/OnboardingSelectableCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A93FE62F2A34CD25059D4950 /* LifeBoard/Onboarding/Components/OnboardingSelectableCard.swift */; };
+		DA81A406247E701A8EE98417 /* LifeBoard/Onboarding/Models/OnboardingMiniMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144D7D155E9471F5D9E1CD62 /* LifeBoard/Onboarding/Models/OnboardingMiniMetric.swift */; };
 		DAD2A078D60094864EB53934 /* HomeViewController+Snackbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1EF5E391342B1FBE7864081 /* HomeViewController+Snackbar.swift */; };
-		DB20D31BAB145922299137A0 /* HomeTimelineWorkspacePreferencesSignature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5CCCB595F2AED7845487FD /* HomeTimelineWorkspacePreferencesSignature.swift */; };
-		DB6DB22472BF68C888913F37 /* EvaDayStatusChipsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C81997132A898566B3451D49 /* EvaDayStatusChipsView.swift */; };
-		DB875C16F1B99BF79F3B4D6C /* LifeManagementComposerMetricTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = EED5CBC96B81618B5D5B1C6D /* LifeManagementComposerMetricTile.swift */; };
-		DB95AC7DC5F9BE77042C3290 /* EvaDayHabitRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E411E9CDB93D4BE9EDC7EF0 /* EvaDayHabitRowView.swift */; };
-		DC1DB2042D99A4C779FADDCA /* OnboardingPromptValueCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABA8BBA9B91A5587A8389B33 /* OnboardingPromptValueCard.swift */; };
-		DC90B81FA56C3F8715AD26A1 /* SunriseAppShellView+SearchSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = C041D826927F12B5D4A445BA /* SunriseAppShellView+SearchSurface.swift */; };
-		DC94FAFADB950991425D291B /* HomeViewModel+DateNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0864533C56B27765DDB7A4 /* HomeViewModel+DateNavigation.swift */; };
-		DC9F1811662585E9D53AA8FA /* SunriseHomeDatePickerPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6425309F28BBC7C61C9C58F3 /* SunriseHomeDatePickerPopover.swift */; };
-		DCC82F690B379131E60A69DA /* LifeBoardWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1256A6FF63A60FC9D9E82C2 /* LifeBoardWidgetBundle.swift */; };
+		DB20D31BAB145922299137A0 /* LifeBoard/Presentation/ViewModels/Home/HomeTimelineWorkspacePreferencesSignature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5CCCB595F2AED7845487FD /* LifeBoard/Presentation/ViewModels/Home/HomeTimelineWorkspacePreferencesSignature.swift */; };
+		DB6DB22472BF68C888913F37 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayStatusChipsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C81997132A898566B3451D49 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayStatusChipsView.swift */; };
+		DB875C16F1B99BF79F3B4D6C /* LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerMetricTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = EED5CBC96B81618B5D5B1C6D /* LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerMetricTile.swift */; };
+		DB95AC7DC5F9BE77042C3290 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E411E9CDB93D4BE9EDC7EF0 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitRowView.swift */; };
+		DC1DB2042D99A4C779FADDCA /* LifeBoard/Onboarding/Components/OnboardingPromptValueCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABA8BBA9B91A5587A8389B33 /* LifeBoard/Onboarding/Components/OnboardingPromptValueCard.swift */; };
+		DC90B81FA56C3F8715AD26A1 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+SearchSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = C041D826927F12B5D4A445BA /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+SearchSurface.swift */; };
+		DC94FAFADB950991425D291B /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+DateNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0864533C56B27765DDB7A4 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+DateNavigation.swift */; };
+		DC9F1811662585E9D53AA8FA /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseHomeDatePickerPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6425309F28BBC7C61C9C58F3 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseHomeDatePickerPopover.swift */; };
+		DCC82F690B379131E60A69DA /* LifeBoardWidgets/LifeBoardWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1256A6FF63A60FC9D9E82C2 /* LifeBoardWidgets/LifeBoardWidgetBundle.swift */; };
 		DE2C698360236D910D116D07 /* LifeBoardTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB9BE07CCB7761E186498D8C /* LifeBoardTheme.swift */; };
-		DF045C31DEEDEEFC1A5F26EA /* OverdueRescueSessionScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44367A0F426BE6D78CC89655 /* OverdueRescueSessionScope.swift */; };
+		DF045C31DEEDEEFC1A5F26EA /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSessionScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44367A0F426BE6D78CC89655 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSessionScope.swift */; };
 		DF485C08DA03A3AC98CA4941 /* AddTaskSecondaryDetailsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E3F56B4B6E3DA6111B5E513 /* AddTaskSecondaryDetailsSection.swift */; };
-		DF610ABA86EAF98C49C6278A /* HomeViewModel+HabitActionShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1EA03651FCE790FF4C8E5EB /* HomeViewModel+HabitActionShortcuts.swift */; };
-		DF7287CB7D22A27B0D68A9AD /* TimelineShelfItemCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BA91AA8F90D4C022C4E890E /* TimelineShelfItemCard.swift */; };
-		DF8962905A29B85F26BDA46D /* SunriseAppShellView+TaskListAndDaySwipe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2113ED4006493C0B58760C99 /* SunriseAppShellView+TaskListAndDaySwipe.swift */; };
-		DFF1C01087EA0CE41AF85876 /* ReconcileExternalRemindersUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22B025D510428B62C47FBE05 /* ReconcileExternalRemindersUseCase.swift */; };
-		E01C6D15AED947A29929589A /* HomeViewModel+FocusRankingAndWidgetSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30956B2414E9EE5EACA5A60 /* HomeViewModel+FocusRankingAndWidgetSnapshot.swift */; };
-		E06D2A329E5E510A206A8EC9 /* HabitDefinitionMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F22284F558A304A7D18F56C1 /* HabitDefinitionMapper.swift */; };
+		DF610ABA86EAF98C49C6278A /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+HabitActionShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1EA03651FCE790FF4C8E5EB /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+HabitActionShortcuts.swift */; };
+		DF7287CB7D22A27B0D68A9AD /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineShelfItemCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BA91AA8F90D4C022C4E890E /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineShelfItemCard.swift */; };
+		DF8962905A29B85F26BDA46D /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+TaskListAndDaySwipe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2113ED4006493C0B58760C99 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+TaskListAndDaySwipe.swift */; };
+		DFF1C01087EA0CE41AF85876 /* LifeBoard/UseCases/Sync/ReconcileExternalRemindersUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22B025D510428B62C47FBE05 /* LifeBoard/UseCases/Sync/ReconcileExternalRemindersUseCase.swift */; };
+		E01C6D15AED947A29929589A /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+FocusRankingAndWidgetSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30956B2414E9EE5EACA5A60 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+FocusRankingAndWidgetSnapshot.swift */; };
+		E06D2A329E5E510A206A8EC9 /* LifeBoard/Domain/Mappers/HabitDefinitionMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F22284F558A304A7D18F56C1 /* LifeBoard/Domain/Mappers/HabitDefinitionMapper.swift */; };
 		E0A100000000000000000001 /* EvaActivationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0A100000000000000000101 /* EvaActivationCoordinator.swift */; };
 		E0A100000000000000000002 /* EvaActivationIntroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0A100000000000000000102 /* EvaActivationIntroView.swift */; };
 		E0A100000000000000000003 /* EvaActivationRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0A100000000000000000103 /* EvaActivationRootView.swift */; };
@@ -1001,24 +1002,24 @@
 		E0A100000000000000000301 /* EvaActivationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0A100000000000000000302 /* EvaActivationTests.swift */; };
 		E0A100000000000000000401 /* SettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0A100000000000000000402 /* SettingsViewModelTests.swift */; };
 		E0A100000000000000000501 /* EvaHomeIntelligenceUseCasesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0A100000000000000000502 /* EvaHomeIntelligenceUseCasesTests.swift */; };
-		E15729081BE877C1AF53C8C8 /* ExternalSyncModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CAA3A6573B0FE5C495C67AC /* ExternalSyncModels.swift */; };
+		E15729081BE877C1AF53C8C8 /* LifeBoard/Domain/Models/ExternalSyncModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CAA3A6573B0FE5C495C67AC /* LifeBoard/Domain/Models/ExternalSyncModels.swift */; };
 		E19F74D16FD5238F2C77D32A /* TimelineTimeBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60A322E21AF97D46F076D5C8 /* TimelineTimeBlock.swift */; };
 		E1A100000000000000000001 /* HomeReplanDayUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A200000000000000000001 /* HomeReplanDayUITests.swift */; };
-		E1C5A4B1D2E3F40123456789 /* UpdateTaskDefinitionUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C5A4B1D2E3F4012345678C /* UpdateTaskDefinitionUseCase.swift */; };
-		E1C5A4B1D2E3F4012345678A /* DeleteTaskDefinitionUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C5A4B1D2E3F4012345678D /* DeleteTaskDefinitionUseCase.swift */; };
-		E1C5A4B1D2E3F4012345678B /* RescheduleTaskDefinitionUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C5A4B1D2E3F4012345678E /* RescheduleTaskDefinitionUseCase.swift */; };
+		E1C5A4B1D2E3F40123456789 /* LifeBoard/UseCases/Task/UpdateTaskDefinitionUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C5A4B1D2E3F4012345678C /* LifeBoard/UseCases/Task/UpdateTaskDefinitionUseCase.swift */; };
+		E1C5A4B1D2E3F4012345678A /* LifeBoard/UseCases/Task/DeleteTaskDefinitionUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C5A4B1D2E3F4012345678D /* LifeBoard/UseCases/Task/DeleteTaskDefinitionUseCase.swift */; };
+		E1C5A4B1D2E3F4012345678B /* LifeBoard/UseCases/Task/RescheduleTaskDefinitionUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C5A4B1D2E3F4012345678E /* LifeBoard/UseCases/Task/RescheduleTaskDefinitionUseCase.swift */; };
 		E22FFCA4100E738724F608E3 /* AddTaskAdvancedPlanningSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 464A3B785BB4CE8EB48AB804 /* AddTaskAdvancedPlanningSection.swift */; };
-		E27B1B656A0E3808DD252E18 /* LifeManagementAreaDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFAECD01C463CF2E65F669CB /* LifeManagementAreaDetailView.swift */; };
-		E2B058A2C6F1249FA0248124 /* StarterProjectTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782F77DA4E5822C3A8AF4305 /* StarterProjectTemplate.swift */; };
+		E27B1B656A0E3808DD252E18 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementAreaDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFAECD01C463CF2E65F669CB /* LifeBoard/Views/Settings/LifeManagement/LifeManagementAreaDetailView.swift */; };
+		E2B058A2C6F1249FA0248124 /* LifeBoard/Onboarding/Models/StarterProjectTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782F77DA4E5822C3A8AF4305 /* LifeBoard/Onboarding/Models/StarterProjectTemplate.swift */; };
 		E30DEBE0065B162D16CFE54C /* Pods_LifeBoard_LifeBoardUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A2D7A866EC5053C29F5AE6F /* Pods_LifeBoard_LifeBoardUITests.framework */; };
-		E322491389C9B239A6D3BA57 /* HomeTimelineReplanPhaseSignature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13E7DC8765CCB903348B7B91 /* HomeTimelineReplanPhaseSignature.swift */; };
-		E3553D65476C93716D966319 /* HomeTaskDetailRelationshipMetadataState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3674205CDE72EB0BA59F05D4 /* HomeTaskDetailRelationshipMetadataState.swift */; };
-		E36C6117443BE8E4989A930C /* AppOnboardingJourneyView+SetupSteps.swift in Sources */ = {isa = PBXBuildFile; fileRef = F65EA7E811D99F9A2999C0D5 /* AppOnboardingJourneyView+SetupSteps.swift */; };
-		E39BA7BC60FB71563853AE5F /* HomeViewModel+RefreshEntryPoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF9AEF356D3B2242580C561 /* HomeViewModel+RefreshEntryPoints.swift */; };
-		E428ECADD6A89C0B1D7F174B /* OnboardingEvaPreparationPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D16AF9130E446C22AB65042 /* OnboardingEvaPreparationPhase.swift */; };
-		E47B01A4B384D82C914661A4 /* OverdueRescueErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152A62EA1C5CBB8557A37E7 /* OverdueRescueErrorView.swift */; };
-		E4DF33BE9BD8B06FF928DA81 /* LifeBoardProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400A0C43B52E9F1509D5EC4C /* LifeBoardProgressBar.swift */; };
-		E4EE09FF5DA5E3D7530F0D94 /* SunriseTimelineBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CF79ECF04752304C36B28F8 /* SunriseTimelineBar.swift */; };
+		E322491389C9B239A6D3BA57 /* LifeBoard/Presentation/ViewModels/Home/HomeTimelineReplanPhaseSignature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13E7DC8765CCB903348B7B91 /* LifeBoard/Presentation/ViewModels/Home/HomeTimelineReplanPhaseSignature.swift */; };
+		E3553D65476C93716D966319 /* LifeBoard/Presentation/ViewModels/Home/HomeTaskDetailRelationshipMetadataState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3674205CDE72EB0BA59F05D4 /* LifeBoard/Presentation/ViewModels/Home/HomeTaskDetailRelationshipMetadataState.swift */; };
+		E36C6117443BE8E4989A930C /* LifeBoard/Onboarding/Views/AppOnboardingJourneyView+SetupSteps.swift in Sources */ = {isa = PBXBuildFile; fileRef = F65EA7E811D99F9A2999C0D5 /* LifeBoard/Onboarding/Views/AppOnboardingJourneyView+SetupSteps.swift */; };
+		E39BA7BC60FB71563853AE5F /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+RefreshEntryPoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF9AEF356D3B2242580C561 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+RefreshEntryPoints.swift */; };
+		E428ECADD6A89C0B1D7F174B /* LifeBoard/Onboarding/Models/OnboardingEvaPreparationPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D16AF9130E446C22AB65042 /* LifeBoard/Onboarding/Models/OnboardingEvaPreparationPhase.swift */; };
+		E47B01A4B384D82C914661A4 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152A62EA1C5CBB8557A37E7 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueErrorView.swift */; };
+		E4DF33BE9BD8B06FF928DA81 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/LifeBoardProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400A0C43B52E9F1509D5EC4C /* LifeBoard/Presentation/Home/Modals/OverdueRescue/LifeBoardProgressBar.swift */; };
+		E4EE09FF5DA5E3D7530F0D94 /* LifeBoard/Presentation/Home/Timeline/Surface/SunriseTimelineBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CF79ECF04752304C36B28F8 /* LifeBoard/Presentation/Home/Timeline/Surface/SunriseTimelineBar.swift */; };
 		E50000000000000000000001 /* LBSunriseHeroArtwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = E50000000000000000000000 /* LBSunriseHeroArtwork.swift */; };
 		E50000000000000000000003 /* SunriseHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E50000000000000000000002 /* SunriseHeaderView.swift */; };
 		E50000000000000000000005 /* TimeOfDayHeaderAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = E50000000000000000000004 /* TimeOfDayHeaderAsset.swift */; };
@@ -1050,102 +1051,102 @@
 		E50000000000000000000039 /* SunriseScheduleScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = E50000000000000000000038 /* SunriseScheduleScreen.swift */; };
 		E5F000000000000000000002 /* SunriseImages in Resources */ = {isa = PBXBuildFile; fileRef = E5F000000000000000000001 /* SunriseImages */; };
 		E6A100000000000000000002 /* SunriseHeaderAssetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A100000000000000000001 /* SunriseHeaderAssetTests.swift */; };
-		E74EA3C46BB64BDD2E97F053 /* TimelineStreamInfluenceKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = D76C10CD61388AF076BFDDB5 /* TimelineStreamInfluenceKind.swift */; };
-		E7526D26F32780AEE900BAFA /* OverdueRescuePauseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29787A3C205793132F924985 /* OverdueRescuePauseView.swift */; };
-		E776248C1D58F4223BE929E3 /* TimelineDayCurrentState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01EE7EB5F53129BCEE1A8679 /* TimelineDayCurrentState.swift */; };
-		E7CF89A56979F3789A7ED0E0 /* HomeViewModel+InitialLoading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FC11A075C9E37AF0A3A64C8 /* HomeViewModel+InitialLoading.swift */; };
-		E7DE591D7ACDB8FF504008CA /* OnboardingNotificationNameExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70CF1C88BCCEBC000C9FEC38 /* OnboardingNotificationNameExtension.swift */; };
-		E7E382F8167672FCEB4D0B60 /* lifeManagementAreaIconLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533CCDBADB8997DD528CFE0A /* lifeManagementAreaIconLabel.swift */; };
-		E7F919BAE9F8CABAE8F00BE6 /* lifeManagementResolvedHex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F0354062DD8AECC3D1B17C4 /* lifeManagementResolvedHex.swift */; };
-		E83889CA9BD741CA471800E8 /* ChatHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35FFAEB5937CA521A5C5C4DC /* ChatHeaderView.swift */; };
-		E86FFAEB786065858AD5DFD4 /* SunriseAppShellView+TimelineSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40C44F474B7E5FCB7349186 /* SunriseAppShellView+TimelineSurface.swift */; };
-		E9479027EA89BB78EAD282EF /* FocusSessionDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD2798DFE7058AA45DECE737 /* FocusSessionDefinition.swift */; };
-		E9974C1A3AC57A1E1E5B60CA /* WelcomeIntroPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A07B9FA858B4AFC05615FCFA /* WelcomeIntroPhase.swift */; };
-		EA9B4B976075D91EAB6902EB /* TimelineInboxPlanningCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD85FEB40E7B6C3538EA14A /* TimelineInboxPlanningCard.swift */; };
-		EAB76D638082DDE00237973C /* StarterLifeAreaTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BD2CC14C16ACDED405C7814 /* StarterLifeAreaTemplate.swift */; };
-		EACA938DF5FA7C9EDE59A3E9 /* AccentIconBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E67C5C94F45D6D66D5E526 /* AccentIconBadge.swift */; };
-		EB9FD2ECFB4D4AD697D091F3 /* OnboardingInlineBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 598CD23D633F1DA652C429A5 /* OnboardingInlineBadge.swift */; };
-		EBEBD8815DECEEB6E6A67CAC /* EvaDayHabitOverlayState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5669D5D0E7B125A137EBF66 /* EvaDayHabitOverlayState.swift */; };
-		EC45E6BBD381E86DD65D5EDF /* HomeTimelineReplanCandidateSignature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ABDFA484783D44FCE389CA8 /* HomeTimelineReplanCandidateSignature.swift */; };
-		ECF7EF4565293CE7F54AD9E8 /* OverdueRescueSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8332C14C05A3610EB0ECA84B /* OverdueRescueSummary.swift */; };
-		ED47AF6B2834E824484A40C5 /* OverdueRescueDeckLayoutMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = F85C5DBA19B19B9611E7B283 /* OverdueRescueDeckLayoutMetrics.swift */; };
-		ED97E21547C8335D58370530 /* TypingIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38AE057025E85DF89448752B /* TypingIndicator.swift */; };
-		EDD64897FAC96F1B85BDA5F7 /* Occurrence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 208608AB50F4EA01C74D2758 /* Occurrence.swift */; };
-		EE1B64C0721BCF43D9599B65 /* OnboardingReminderPromptState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A391C151F9BE79B12EAF441 /* OnboardingReminderPromptState.swift */; };
+		E74EA3C46BB64BDD2E97F053 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamInfluenceKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = D76C10CD61388AF076BFDDB5 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamInfluenceKind.swift */; };
+		E7526D26F32780AEE900BAFA /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescuePauseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29787A3C205793132F924985 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescuePauseView.swift */; };
+		E776248C1D58F4223BE929E3 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineDayCurrentState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01EE7EB5F53129BCEE1A8679 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineDayCurrentState.swift */; };
+		E7CF89A56979F3789A7ED0E0 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+InitialLoading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FC11A075C9E37AF0A3A64C8 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+InitialLoading.swift */; };
+		E7DE591D7ACDB8FF504008CA /* LifeBoard/Onboarding/Models/OnboardingNotificationNameExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70CF1C88BCCEBC000C9FEC38 /* LifeBoard/Onboarding/Models/OnboardingNotificationNameExtension.swift */; };
+		E7E382F8167672FCEB4D0B60 /* LifeBoard/Views/Settings/LifeManagement/lifeManagementAreaIconLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533CCDBADB8997DD528CFE0A /* LifeBoard/Views/Settings/LifeManagement/lifeManagementAreaIconLabel.swift */; };
+		E7F919BAE9F8CABAE8F00BE6 /* LifeBoard/Views/Settings/LifeManagement/lifeManagementResolvedHex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F0354062DD8AECC3D1B17C4 /* LifeBoard/Views/Settings/LifeManagement/lifeManagementResolvedHex.swift */; };
+		E83889CA9BD741CA471800E8 /* LifeBoard/LLM/Views/Chat/Chrome/ChatHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35FFAEB5937CA521A5C5C4DC /* LifeBoard/LLM/Views/Chat/Chrome/ChatHeaderView.swift */; };
+		E86FFAEB786065858AD5DFD4 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+TimelineSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40C44F474B7E5FCB7349186 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+TimelineSurface.swift */; };
+		E9479027EA89BB78EAD282EF /* LifeBoard/Domain/Models/FocusSessionDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD2798DFE7058AA45DECE737 /* LifeBoard/Domain/Models/FocusSessionDefinition.swift */; };
+		E9974C1A3AC57A1E1E5B60CA /* LifeBoard/Onboarding/Models/WelcomeIntroPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A07B9FA858B4AFC05615FCFA /* LifeBoard/Onboarding/Models/WelcomeIntroPhase.swift */; };
+		EA9B4B976075D91EAB6902EB /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineInboxPlanningCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD85FEB40E7B6C3538EA14A /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineInboxPlanningCard.swift */; };
+		EAB76D638082DDE00237973C /* LifeBoard/Onboarding/Models/StarterLifeAreaTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BD2CC14C16ACDED405C7814 /* LifeBoard/Onboarding/Models/StarterLifeAreaTemplate.swift */; };
+		EACA938DF5FA7C9EDE59A3E9 /* LifeBoard/Views/Settings/LifeManagement/AccentIconBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E67C5C94F45D6D66D5E526 /* LifeBoard/Views/Settings/LifeManagement/AccentIconBadge.swift */; };
+		EB9FD2ECFB4D4AD697D091F3 /* LifeBoard/Onboarding/Models/OnboardingInlineBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 598CD23D633F1DA652C429A5 /* LifeBoard/Onboarding/Models/OnboardingInlineBadge.swift */; };
+		EBEBD8815DECEEB6E6A67CAC /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitOverlayState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5669D5D0E7B125A137EBF66 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitOverlayState.swift */; };
+		EC45E6BBD381E86DD65D5EDF /* LifeBoard/Presentation/ViewModels/Home/HomeTimelineReplanCandidateSignature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ABDFA484783D44FCE389CA8 /* LifeBoard/Presentation/ViewModels/Home/HomeTimelineReplanCandidateSignature.swift */; };
+		ECF7EF4565293CE7F54AD9E8 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8332C14C05A3610EB0ECA84B /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSummary.swift */; };
+		ED47AF6B2834E824484A40C5 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDeckLayoutMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = F85C5DBA19B19B9611E7B283 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDeckLayoutMetrics.swift */; };
+		ED97E21547C8335D58370530 /* LifeBoard/LLM/Views/Chat/Conversation/TypingIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38AE057025E85DF89448752B /* LifeBoard/LLM/Views/Chat/Conversation/TypingIndicator.swift */; };
+		EDD64897FAC96F1B85BDA5F7 /* LifeBoard/Domain/Models/Occurrence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 208608AB50F4EA01C74D2758 /* LifeBoard/Domain/Models/Occurrence.swift */; };
+		EE1B64C0721BCF43D9599B65 /* LifeBoard/Onboarding/Models/OnboardingReminderPromptState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A391C151F9BE79B12EAF441 /* LifeBoard/Onboarding/Models/OnboardingReminderPromptState.swift */; };
 		EE358DD82842FD4D23921CB5 /* HomeViewController+RenderPipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9F0161DC62BDB27BEE93C1D /* HomeViewController+RenderPipeline.swift */; };
-		EE3E0D5AF58CB2AD95219EB6 /* CreateTaskDefinitionUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC4ABAA08D90818447AA6D03 /* CreateTaskDefinitionUseCase.swift */; };
-		EE9035C0B9F8F991433E9826 /* lifeManagementNormalizedHex.swift in Sources */ = {isa = PBXBuildFile; fileRef = D07E18D71C702586CD89133E /* lifeManagementNormalizedHex.swift */; };
+		EE3E0D5AF58CB2AD95219EB6 /* LifeBoard/UseCases/Task/CreateTaskDefinitionUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC4ABAA08D90818447AA6D03 /* LifeBoard/UseCases/Task/CreateTaskDefinitionUseCase.swift */; };
+		EE9035C0B9F8F991433E9826 /* LifeBoard/Views/Settings/LifeManagement/lifeManagementNormalizedHex.swift in Sources */ = {isa = PBXBuildFile; fileRef = D07E18D71C702586CD89133E /* LifeBoard/Views/Settings/LifeManagement/lifeManagementNormalizedHex.swift */; };
 		EF1769B605BF09BDBF28186D /* AddTaskDurationPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 316921199F513341A93BD753 /* AddTaskDurationPicker.swift */; };
-		EF8AD806AA6D1C9D47FA2BDE /* HomePerformanceSignposts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1160613FFDAE3936EA841FD2 /* HomePerformanceSignposts.swift */; };
-		F008F091A6B8DB39893BDF07 /* EvaDayTaskActionButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3528CDE2C353B77B8CC4EB35 /* EvaDayTaskActionButtonView.swift */; };
+		EF8AD806AA6D1C9D47FA2BDE /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomePerformanceSignposts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1160613FFDAE3936EA841FD2 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomePerformanceSignposts.swift */; };
+		F008F091A6B8DB39893BDF07 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayTaskActionButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3528CDE2C353B77B8CC4EB35 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayTaskActionButtonView.swift */; };
 		F00D00000000000000001002 /* TaskDetailPresentationContracts.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00D00000000000000001001 /* TaskDetailPresentationContracts.swift */; };
-		F00D00000000000000001006 /* CalendarSchedulePresentationContracts.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00D00000000000000001005 /* CalendarSchedulePresentationContracts.swift */; };
-		F00D00000000000000001008 /* CalendarTimelinePresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00D00000000000000001007 /* CalendarTimelinePresentation.swift */; };
-		F00D8D326BF77E4E42597083 /* HabitSummaryRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AE36332DC107A6F5A9A4AF2 /* HabitSummaryRow.swift */; };
-		F078AE75786C51F7F4F78ABA /* TimelineStreamGeometry+MassClustering.swift in Sources */ = {isa = PBXBuildFile; fileRef = 549A929D15B98C035C74BD90 /* TimelineStreamGeometry+MassClustering.swift */; };
+		F00D00000000000000001006 /* LifeBoard/View/Calendar/CalendarSchedulePresentationContracts.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00D00000000000000001005 /* LifeBoard/View/Calendar/CalendarSchedulePresentationContracts.swift */; };
+		F00D00000000000000001008 /* LifeBoard/View/Calendar/CalendarTimelinePresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00D00000000000000001007 /* LifeBoard/View/Calendar/CalendarTimelinePresentation.swift */; };
+		F00D8D326BF77E4E42597083 /* LifeBoard/Views/Settings/LifeManagement/HabitSummaryRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AE36332DC107A6F5A9A4AF2 /* LifeBoard/Views/Settings/LifeManagement/HabitSummaryRow.swift */; };
+		F078AE75786C51F7F4F78ABA /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamGeometry+MassClustering.swift in Sources */ = {isa = PBXBuildFile; fileRef = 549A929D15B98C035C74BD90 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamGeometry+MassClustering.swift */; };
 		F0A100000000000000000101 /* SeededFeaturePages.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A100000000000000000102 /* SeededFeaturePages.swift */; };
 		F0A100000000000000000201 /* OverdueRescueSeededUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A100000000000000000202 /* OverdueRescueSeededUITests.swift */; };
 		F0A100000000000000000301 /* ReflectPlanSeededUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A100000000000000000302 /* ReflectPlanSeededUITests.swift */; };
 		F0A100000000000000000401 /* FocusNowSeededUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A100000000000000000402 /* FocusNowSeededUITests.swift */; };
-		F0A15BDE3E582D2E951E98F4 /* HomeViewControllerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFFC54215415EB867E73F6BC /* HomeViewControllerExtension.swift */; };
+		F0A15BDE3E582D2E951E98F4 /* LifeBoard/Onboarding/Components/HomeViewControllerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFFC54215415EB867E73F6BC /* LifeBoard/Onboarding/Components/HomeViewControllerExtension.swift */; };
 		F0A1B2C3D4E5F60718293B4B /* HomeProjectGroupingMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A1B2C3D4E5F60718293A4B /* HomeProjectGroupingMode.swift */; };
 		F0A1B2C3D4E5F60718293B4C /* HomeTaskSectionBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A1B2C3D4E5F60718293A4C /* HomeTaskSectionBuilder.swift */; };
 		F0A1B2C3D4E5F60718293B4D /* HomeFilterStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A1B2C3D4E5F60718293A4D /* HomeFilterStateTests.swift */; };
 		F0A1B2C3D4E5F60718293B4E /* HomeTaskSectionBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A1B2C3D4E5F60718293A4E /* HomeTaskSectionBuilderTests.swift */; };
 		F0A1B2C3D4E5F60718293B4F /* HomeViewModelPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A1B2C3D4E5F60718293A4F /* HomeViewModelPersistenceTests.swift */; };
-		F0D4A5D3F940D3BD0B515BEF /* ConversationViewRoot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 045B754842BE69FA3CC11368 /* ConversationViewRoot.swift */; };
+		F0D4A5D3F940D3BD0B515BEF /* LifeBoard/LLM/Views/Chat/Conversation/ConversationViewRoot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 045B754842BE69FA3CC11368 /* LifeBoard/LLM/Views/Chat/Conversation/ConversationViewRoot.swift */; };
 		F10A00000000000000000001 /* TimelineRoutineAnchorVisualStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10A00000000000000000002 /* TimelineRoutineAnchorVisualStyle.swift */; };
 		F10A00000000000000000003 /* TimelineRoutineAnchorCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10A00000000000000000004 /* TimelineRoutineAnchorCard.swift */; };
-		F14217E9721A35DF328C2F66 /* SunriseAppShellView+HomeScreenComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8641383368773B407AE249 /* SunriseAppShellView+HomeScreenComposition.swift */; };
-		F1A2B3C4D5E6F708192A3B4C /* WidgetBrand.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C4D5E6F708192A3B4D /* WidgetBrand.swift */; };
+		F14217E9721A35DF328C2F66 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+HomeScreenComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8641383368773B407AE249 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+HomeScreenComposition.swift */; };
+		F1A2B3C4D5E6F708192A3B4C /* LifeBoardWidgets/WidgetBrand.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C4D5E6F708192A3B4D /* LifeBoardWidgets/WidgetBrand.swift */; };
 		F1A2B3C4D5E6F7A8B9C0D1E3 /* LifeBoardTheme+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C4D5E6F7A8B9C0D1E2 /* LifeBoardTheme+SwiftUI.swift */; };
 		F1A2B3C4D5E6F7A8B9C0D1E5 /* LifeBoardAnimations.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C4D5E6F7A8B9C0D1E4 /* LifeBoardAnimations.swift */; };
-		F1BBC7AE7656181142FE5487 /* LifeManagementAreaSwatchPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8824EFA2E628DF9525F13411 /* LifeManagementAreaSwatchPicker.swift */; };
+		F1BBC7AE7656181142FE5487 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementAreaSwatchPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8824EFA2E628DF9525F13411 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementAreaSwatchPicker.swift */; };
 		F1C0A1234B56789000ABCD02 /* TaskDetailViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C0A1234B56789000ABCD01 /* TaskDetailViewModelTests.swift */; };
-		F260B975BFD99463197CD6A0 /* CelebrationKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222C1D1DF983BFFDF4BB651E /* CelebrationKind.swift */; };
+		F260B975BFD99463197CD6A0 /* LifeBoard/Presentation/ViewModels/Home/CelebrationKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222C1D1DF983BFFDF4BB651E /* LifeBoard/Presentation/ViewModels/Home/CelebrationKind.swift */; };
 		F2A1B2C3D4E5F60718293B50 /* HomeBottomBarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2A1B2C3D4E5F60718293A50 /* HomeBottomBarItem.swift */; };
 		F2A1B2C3D4E5F60718293B51 /* HomeBottomBarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2A1B2C3D4E5F60718293A51 /* HomeBottomBarState.swift */; };
 		F2A1B2C3D4E5F60718293B53 /* HomeBottomBarStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2A1B2C3D4E5F60718293A53 /* HomeBottomBarStateTests.swift */; };
 		F2A1B2C3D4E5F60718293B54 /* HomeViewModelXPScoreRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2A1B2C3D4E5F60718293A54 /* HomeViewModelXPScoreRegressionTests.swift */; };
 		F2D78244C6C3ADD6444121B8 /* HomeViewController+OnboardingAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A10E0B067197D4A32724B9F /* HomeViewController+OnboardingAdapter.swift */; };
-		F3240A09F43701C96CE99815 /* HomeViewModel+FocusWhyCandidates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34C9C6671884EE8926C32968 /* HomeViewModel+FocusWhyCandidates.swift */; };
+		F3240A09F43701C96CE99815 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+FocusWhyCandidates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34C9C6671884EE8926C32968 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+FocusWhyCandidates.swift */; };
 		F3A1B2C3D4E5F60718293B55 /* HomeSunriseLayoutMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3A1B2C3D4E5F60718293A55 /* HomeSunriseLayoutMetricsTests.swift */; };
-		F3C1E701D90B17B69DA1D98C /* OnboardingHeroVideoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFC525E06BF11EBA6D7A5BC3 /* OnboardingHeroVideoView.swift */; };
-		F3C3DA3A987F1E361784B3C3 /* TimelineStreamGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 083E8304C4213AFE52640917 /* TimelineStreamGeometry.swift */; };
-		F40B68EBDD554016F132F4E0 /* TimelineGapPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80785BB956EE3DB3802D9858 /* TimelineGapPrompt.swift */; };
-		F425DA7463D1A09323AFE4DE /* HomeDateNavigationSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F491D6AE37A2795AA0485A7 /* HomeDateNavigationSource.swift */; };
+		F3C1E701D90B17B69DA1D98C /* LifeBoard/Onboarding/Views/OnboardingHeroVideoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFC525E06BF11EBA6D7A5BC3 /* LifeBoard/Onboarding/Views/OnboardingHeroVideoView.swift */; };
+		F3C3DA3A987F1E361784B3C3 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 083E8304C4213AFE52640917 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamGeometry.swift */; };
+		F40B68EBDD554016F132F4E0 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineGapPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80785BB956EE3DB3802D9858 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineGapPrompt.swift */; };
+		F425DA7463D1A09323AFE4DE /* LifeBoard/Presentation/ViewModels/Home/HomeDateNavigationSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F491D6AE37A2795AA0485A7 /* LifeBoard/Presentation/ViewModels/Home/HomeDateNavigationSource.swift */; };
 		F4A1B2C3D4E5F60718293B56 /* HomeSunriseHintEligibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4A1B2C3D4E5F60718293A56 /* HomeSunriseHintEligibilityTests.swift */; };
-		F4CE8A08BB795C67615BDCB1 /* TimelineRoutineTextFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1528CAF56D71468F82A432 /* TimelineRoutineTextFormatter.swift */; };
-		F4FF0FD29ACA5B7B4CF12827 /* MessageView+CommandResultsAndUndo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B7C1A4EF10964C5EF4DC33 /* MessageView+CommandResultsAndUndo.swift */; };
+		F4CE8A08BB795C67615BDCB1 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineRoutineTextFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1528CAF56D71468F82A432 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineRoutineTextFormatter.swift */; };
+		F4FF0FD29ACA5B7B4CF12827 /* LifeBoard/LLM/Views/Chat/Conversation/MessageView+CommandResultsAndUndo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B7C1A4EF10964C5EF4DC33 /* LifeBoard/LLM/Views/Chat/Conversation/MessageView+CommandResultsAndUndo.swift */; };
 		F5A100012F6A200100ABC001 /* LifeBoardAppShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5A100002F6A200100ABC001 /* LifeBoardAppShortcuts.swift */; };
 		F5A100032F6A200100ABC001 /* LifeBoardAppShortcutsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5A100022F6A200100ABC001 /* LifeBoardAppShortcutsTests.swift */; };
-		F5BD3FA4315CD2E0D8E33730 /* EvaChiefOfStaffGuideView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC8C39098BF0A10AE6CC5EE3 /* EvaChiefOfStaffGuideView.swift */; };
-		F5C55F69B9C3BEDDF1C2FD8F /* LifeManagementColorSwatchButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E54A7695DD06B755561CDB3D /* LifeManagementColorSwatchButton.swift */; };
-		F64C9A3B63E962670DB86280 /* CelebrationEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5199C25A108D3EDC5DD5E0D9 /* CelebrationEvent.swift */; };
+		F5BD3FA4315CD2E0D8E33730 /* LifeBoard/LLM/Views/Chat/Chrome/EvaChiefOfStaffGuideView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC8C39098BF0A10AE6CC5EE3 /* LifeBoard/LLM/Views/Chat/Chrome/EvaChiefOfStaffGuideView.swift */; };
+		F5C55F69B9C3BEDDF1C2FD8F /* LifeBoard/Views/Settings/LifeManagement/LifeManagementColorSwatchButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E54A7695DD06B755561CDB3D /* LifeBoard/Views/Settings/LifeManagement/LifeManagementColorSwatchButton.swift */; };
+		F64C9A3B63E962670DB86280 /* LifeBoard/Presentation/ViewModels/Home/CelebrationEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5199C25A108D3EDC5DD5E0D9 /* LifeBoard/Presentation/ViewModels/Home/CelebrationEvent.swift */; };
 		F6A1B2C3D4E5F60718293B57 /* HomeChromeSnapshotPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6A1B2C3D4E5F60718293A57 /* HomeChromeSnapshotPresentationTests.swift */; };
-		F6BF00E2BC75CA6D7EA0D449 /* TimelineNormalItemCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = F37CC3576F638C63EB2D1943 /* TimelineNormalItemCard.swift */; };
-		F71A150EACB33EB7B19F1E24 /* OverdueRescueSwipeHint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DDAE6004CD5111C2C273E69 /* OverdueRescueSwipeHint.swift */; };
-		F7B0AB4286AC80DE2918E298 /* TimelineDayStablePresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36F7B2A4D32F9921BBA51449 /* TimelineDayStablePresentation.swift */; };
-		F7F1A376574BECAD5FD6A5E3 /* CoreDataReminderRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10EE348FF84C5F729A416848 /* CoreDataReminderRepository.swift */; };
-		F825BC32A2F154EF1E81504E /* StarterWorkspaceCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98E3FDAB970DF9A475E91D5F /* StarterWorkspaceCatalog.swift */; };
-		F85EBA97A802F4DC015E332F /* HabitArchiveRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E17B1D7658A53B43A03A2DB /* HabitArchiveRow.swift */; };
+		F6BF00E2BC75CA6D7EA0D449 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineNormalItemCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = F37CC3576F638C63EB2D1943 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineNormalItemCard.swift */; };
+		F71A150EACB33EB7B19F1E24 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSwipeHint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DDAE6004CD5111C2C273E69 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSwipeHint.swift */; };
+		F7B0AB4286AC80DE2918E298 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineDayStablePresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36F7B2A4D32F9921BBA51449 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineDayStablePresentation.swift */; };
+		F7F1A376574BECAD5FD6A5E3 /* LifeBoard/State/Repositories/CoreDataReminderRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10EE348FF84C5F729A416848 /* LifeBoard/State/Repositories/CoreDataReminderRepository.swift */; };
+		F825BC32A2F154EF1E81504E /* LifeBoard/Onboarding/Models/StarterWorkspaceCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98E3FDAB970DF9A475E91D5F /* LifeBoard/Onboarding/Models/StarterWorkspaceCatalog.swift */; };
+		F85EBA97A802F4DC015E332F /* LifeBoard/Views/Settings/LifeManagement/HabitArchiveRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E17B1D7658A53B43A03A2DB /* LifeBoard/Views/Settings/LifeManagement/HabitArchiveRow.swift */; };
 		F8C1A0019AB24E01A11C0001 /* TaskIconSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C1A0019AB24E01A11C1001 /* TaskIconSupport.swift */; };
 		F8C1A0019AB24E01A11C0002 /* TaskIconSymbolManifest.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C1A0019AB24E01A11C1002 /* TaskIconSymbolManifest.generated.swift */; };
 		F8C1A0019AB24E01A11C0003 /* TaskIconSymbolManifest.generated.json in Resources */ = {isa = PBXBuildFile; fileRef = F8C1A0019AB24E01A11C1003 /* TaskIconSymbolManifest.generated.json */; };
-		FA06177C5FE545D4DB799E31 /* MessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E97E787881F510FC540EC5B8 /* MessageView.swift */; };
-		FA1924E817EE26D9DB798F93 /* ReminderDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F394C64907F22C89881E3A /* ReminderDefinition.swift */; };
-		FA2867EC44B15B0F834583B7 /* TimelinePlacementDock.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDAEF0D7419DC76585760D6E /* TimelinePlacementDock.swift */; };
+		FA06177C5FE545D4DB799E31 /* LifeBoard/LLM/Views/Chat/Conversation/MessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E97E787881F510FC540EC5B8 /* LifeBoard/LLM/Views/Chat/Conversation/MessageView.swift */; };
+		FA1924E817EE26D9DB798F93 /* LifeBoard/Domain/Models/ReminderDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F394C64907F22C89881E3A /* LifeBoard/Domain/Models/ReminderDefinition.swift */; };
+		FA2867EC44B15B0F834583B7 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelinePlacementDock.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDAEF0D7419DC76585760D6E /* LifeBoard/Presentation/Home/Timeline/Surface/TimelinePlacementDock.swift */; };
 		FA7A583FEC8560AC162964C2 /* SettingsFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 718216D68E8278668DDB49BC /* SettingsFooterView.swift */; };
-		FAD4981C27F2BBC7898744CD /* Achievement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C900006EE1DF0BACD33342B /* Achievement.swift */; };
-		FB8B2B57A23CA5361BE9C535 /* OverdueRescueActionGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79F6BFD855ABC89559135C56 /* OverdueRescueActionGrid.swift */; };
-		FC7A4DCCA6C83872D730A8BF /* OverdueRescueVisualSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78AC645DDBDFE8BDCA4826F7 /* OverdueRescueVisualSpec.swift */; };
-		FCC23D047188986E5F29D1EF /* OnboardingFlowModel+LifeAreaHabitTaskSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD51EED85A7A2713DD596393 /* OnboardingFlowModel+LifeAreaHabitTaskSetup.swift */; };
-		FD5A8F04A6436C78DBBD43A4 /* TombstoneMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD059BC932A17FD845CAC6CD /* TombstoneMapper.swift */; };
-		FD83FBA515FA99D90DE5465C /* FlowPromptChipsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25FBF99ED821FFD0AF0826C2 /* FlowPromptChipsView.swift */; };
-		FE8EC07F1D05E4B12382FEA9 /* TimelineDenseTitleFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 687C38FA46273E45A8A46143 /* TimelineDenseTitleFormatter.swift */; };
-		FF5BDB5653D5CB66DA106A16 /* XPEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85F3DEB89B5BEB05F1972CA7 /* XPEvent.swift */; };
-		FFCF1FC469B2AE9FC88CF3D1 /* InsightsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52EDFF0556DE6F60CD19AA39 /* InsightsViewModel.swift */; };
-		FFE402DD68D4595A5B90EC4B /* LifeManagementAreaIconPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DEE0B3DA1576389071E8CEA /* LifeManagementAreaIconPicker.swift */; };
+		FAD4981C27F2BBC7898744CD /* LifeBoard/Domain/Models/Achievement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C900006EE1DF0BACD33342B /* LifeBoard/Domain/Models/Achievement.swift */; };
+		FB8B2B57A23CA5361BE9C535 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueActionGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79F6BFD855ABC89559135C56 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueActionGrid.swift */; };
+		FC7A4DCCA6C83872D730A8BF /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueVisualSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78AC645DDBDFE8BDCA4826F7 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueVisualSpec.swift */; };
+		FCC23D047188986E5F29D1EF /* LifeBoard/Onboarding/Services/OnboardingFlowModel+LifeAreaHabitTaskSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD51EED85A7A2713DD596393 /* LifeBoard/Onboarding/Services/OnboardingFlowModel+LifeAreaHabitTaskSetup.swift */; };
+		FD5A8F04A6436C78DBBD43A4 /* LifeBoard/Domain/Mappers/TombstoneMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD059BC932A17FD845CAC6CD /* LifeBoard/Domain/Mappers/TombstoneMapper.swift */; };
+		FD83FBA515FA99D90DE5465C /* LifeBoard/LLM/Views/Chat/Chrome/FlowPromptChipsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25FBF99ED821FFD0AF0826C2 /* LifeBoard/LLM/Views/Chat/Chrome/FlowPromptChipsView.swift */; };
+		FE8EC07F1D05E4B12382FEA9 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineDenseTitleFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 687C38FA46273E45A8A46143 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineDenseTitleFormatter.swift */; };
+		FF5BDB5653D5CB66DA106A16 /* LifeBoard/Domain/Models/XPEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85F3DEB89B5BEB05F1972CA7 /* LifeBoard/Domain/Models/XPEvent.swift */; };
+		FFCF1FC469B2AE9FC88CF3D1 /* LifeBoard/Presentation/ViewModels/InsightsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52EDFF0556DE6F60CD19AA39 /* LifeBoard/Presentation/ViewModels/InsightsViewModel.swift */; };
+		FFE402DD68D4595A5B90EC4B /* LifeBoard/Views/Settings/LifeManagement/LifeManagementAreaIconPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DEE0B3DA1576389071E8CEA /* LifeBoard/Views/Settings/LifeManagement/LifeManagementAreaIconPicker.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1207,313 +1208,313 @@
 /* Begin PBXFileReference section */
 		010871EDBE39DF63B4E49E2C /* Pods-LifeBoard.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LifeBoard.debug.xcconfig"; path = "Target Support Files/Pods-LifeBoard/Pods-LifeBoard.debug.xcconfig"; sourceTree = "<group>"; };
 		017ECAA6FA89C9A7825A3E8A /* EnhancedDependencyContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EnhancedDependencyContainer.swift; path = LifeBoard/State/DI/EnhancedDependencyContainer.swift; sourceTree = SOURCE_ROOT; };
-		01EE7EB5F53129BCEE1A8679 /* TimelineDayCurrentState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineDayCurrentState.swift; sourceTree = SOURCE_ROOT; };
-		02140BA5618285E3AC49CA18 /* CalendarCardChromeModifier.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Shell/SunriseAppShell/CalendarCardChromeModifier.swift; sourceTree = SOURCE_ROOT; };
-		030D7ED39864D654D71BF1CE /* AppOnboardingJourneyView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Views/AppOnboardingJourneyView.swift; sourceTree = SOURCE_ROOT; };
-		032B26704AEC551E42E3A08D /* UserDefaultsOverdueRescueSessionStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/UserDefaultsOverdueRescueSessionStore.swift; sourceTree = SOURCE_ROOT; };
-		035ACE6073D062BB622B9CF2 /* OverdueRescueEditDraft.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueEditDraft.swift; sourceTree = SOURCE_ROOT; };
-		03EEB4E98CFC74139C3D08E9 /* HomeViewModel+NeedsReplanStateAndPlacement.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+NeedsReplanStateAndPlacement.swift"; sourceTree = SOURCE_ROOT; };
-		045B754842BE69FA3CC11368 /* ConversationViewRoot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Conversation/ConversationViewRoot.swift; sourceTree = SOURCE_ROOT; };
-		04856A49C5F0944D2A558B4F /* OnboardingTheme.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingTheme.swift; sourceTree = SOURCE_ROOT; };
+		01EE7EB5F53129BCEE1A8679 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineDayCurrentState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineDayCurrentState.swift; sourceTree = SOURCE_ROOT; };
+		02140BA5618285E3AC49CA18 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/CalendarCardChromeModifier.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Shell/SunriseAppShell/CalendarCardChromeModifier.swift; sourceTree = SOURCE_ROOT; };
+		030D7ED39864D654D71BF1CE /* LifeBoard/Onboarding/Views/AppOnboardingJourneyView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Views/AppOnboardingJourneyView.swift; sourceTree = SOURCE_ROOT; };
+		032B26704AEC551E42E3A08D /* LifeBoard/Presentation/Home/Modals/OverdueRescue/UserDefaultsOverdueRescueSessionStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/UserDefaultsOverdueRescueSessionStore.swift; sourceTree = SOURCE_ROOT; };
+		035ACE6073D062BB622B9CF2 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueEditDraft.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueEditDraft.swift; sourceTree = SOURCE_ROOT; };
+		03EEB4E98CFC74139C3D08E9 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+NeedsReplanStateAndPlacement.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+NeedsReplanStateAndPlacement.swift"; sourceTree = SOURCE_ROOT; };
+		045B754842BE69FA3CC11368 /* LifeBoard/LLM/Views/Chat/Conversation/ConversationViewRoot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Conversation/ConversationViewRoot.swift; sourceTree = SOURCE_ROOT; };
+		04856A49C5F0944D2A558B4F /* LifeBoard/Onboarding/Models/OnboardingTheme.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingTheme.swift; sourceTree = SOURCE_ROOT; };
 		04AC7378336F374F0E61EA79 /* LifeBoardWatchWidgets.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = LifeBoardWatchWidgets.entitlements; sourceTree = "<group>"; };
-		04BB26CD286E91AABB2ECF5B /* timelineAccessibilityLabel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/timelineAccessibilityLabel.swift; sourceTree = SOURCE_ROOT; };
+		04BB26CD286E91AABB2ECF5B /* LifeBoard/Presentation/Home/Timeline/Surface/timelineAccessibilityLabel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/timelineAccessibilityLabel.swift; sourceTree = SOURCE_ROOT; };
 		0569FE829370226C7433FCAE /* HomeViewController+Testing.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "HomeViewController+Testing.swift"; sourceTree = "<group>"; };
-		05709BBC85C1A6062231609B /* timelineRingColor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/timelineRingColor.swift; sourceTree = SOURCE_ROOT; };
-		059D7229E32477D1B282E2A2 /* MessageView+DayOverviewAndProposalActions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/LLM/Views/Chat/Conversation/MessageView+DayOverviewAndProposalActions.swift"; sourceTree = SOURCE_ROOT; };
-		05E5245EF6140902F09F99CA /* RecordXPUseCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Gamification/RecordXPUseCase.swift; sourceTree = SOURCE_ROOT; };
+		05709BBC85C1A6062231609B /* LifeBoard/Presentation/Home/Timeline/Surface/timelineRingColor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/timelineRingColor.swift; sourceTree = SOURCE_ROOT; };
+		059D7229E32477D1B282E2A2 /* LifeBoard/LLM/Views/Chat/Conversation/MessageView+DayOverviewAndProposalActions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/LLM/Views/Chat/Conversation/MessageView+DayOverviewAndProposalActions.swift"; sourceTree = SOURCE_ROOT; };
+		05E5245EF6140902F09F99CA /* LifeBoard/UseCases/Gamification/RecordXPUseCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Gamification/RecordXPUseCase.swift; sourceTree = SOURCE_ROOT; };
 		0633BF8BACC2D4FBC9508866 /* SlashCommandCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashCommandCatalog.swift; sourceTree = "<group>"; };
-		0643A03092D9D90FE7DC26D4 /* ManageTagsUseCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Tag/ManageTagsUseCase.swift; sourceTree = SOURCE_ROOT; };
-		06C9F0E1B9A7D11A42BEFEB1 /* HomeViewModel+DueTodayAgenda.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+DueTodayAgenda.swift"; sourceTree = SOURCE_ROOT; };
-		076D0B0C6429D3BED7BCBF7A /* OnboardingFloatingNextButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingFloatingNextButton.swift; sourceTree = SOURCE_ROOT; };
-		0782589C1467EBE5827782EF /* OnboardingInputField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingInputField.swift; sourceTree = SOURCE_ROOT; };
-		078F0DB7D6806A7A2A660437 /* HomeTimelineReplanStateSignature.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeTimelineReplanStateSignature.swift; sourceTree = SOURCE_ROOT; };
-		0791A21C5814ADEF3277BAB1 /* TimelinePlanningShelf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelinePlanningShelf.swift; sourceTree = SOURCE_ROOT; };
-		079A43F8E9012BEFEACB658C /* OnboardingFlowModel+CatalogPresentation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Onboarding/Services/OnboardingFlowModel+CatalogPresentation.swift"; sourceTree = SOURCE_ROOT; };
-		081764019CFE89EAC4FE6BBD /* EvaDayHabitHeaderView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitHeaderView.swift; sourceTree = SOURCE_ROOT; };
-		083E8304C4213AFE52640917 /* TimelineStreamGeometry.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamGeometry.swift; sourceTree = SOURCE_ROOT; };
-		08CEBA82D3CB1ACE79D0E158 /* CoreDataExternalSyncRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Repositories/CoreDataExternalSyncRepository.swift; sourceTree = SOURCE_ROOT; };
-		093C76FA2FAF1A80BE897904 /* TimelineStreamPalette.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamPalette.swift; sourceTree = SOURCE_ROOT; };
-		09813915E7878C1392C791D0 /* OverdueRescueEligibilityService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueEligibilityService.swift; sourceTree = SOURCE_ROOT; };
-		098E6EFC49514867101BA977 /* OnboardingTaskTemplateState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingTaskTemplateState.swift; sourceTree = SOURCE_ROOT; };
-		0AA18F175EDA0C022217BD98 /* timelineStemColor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/timelineStemColor.swift; sourceTree = SOURCE_ROOT; };
-		0B33EB5C978F76DF3A6A735C /* EvaDaySunriseTaskRowView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Conversation/EvaDaySunriseTaskRowView.swift; sourceTree = SOURCE_ROOT; };
-		0C6A23DC0DB1740CCDF6D30F /* DailyTimelineCompactView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/DailyTimelineCompactView.swift; sourceTree = SOURCE_ROOT; };
-		0D09C9507B3C691C73DA808A /* PendingOnboardingPresentation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/PendingOnboardingPresentation.swift; sourceTree = SOURCE_ROOT; };
-		0D70DF5D3C4DE407EF935B48 /* Section.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/Section.swift; sourceTree = SOURCE_ROOT; };
-		0D9B95BD66FD5C98B9AB37AE /* HomeOnboardingGuidanceModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Services/HomeOnboardingGuidanceModel.swift; sourceTree = SOURCE_ROOT; };
-		0D9FE88AEA020FF9DA3791C7 /* OnboardingPromptTheme.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingPromptTheme.swift; sourceTree = SOURCE_ROOT; };
-		0F491D6AE37A2795AA0485A7 /* HomeDateNavigationSource.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeDateNavigationSource.swift; sourceTree = SOURCE_ROOT; };
-		102FF39D56775B7335081882 /* OnboardingPromptFooterMaterialModifier.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingPromptFooterMaterialModifier.swift; sourceTree = SOURCE_ROOT; };
-		107822EF572057FAE8E0EF37 /* LifeAreaRepositoryProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Interfaces/LifeAreaRepositoryProtocol.swift; sourceTree = SOURCE_ROOT; };
-		10E031C3127045DB0AF8ACF9 /* LifeManagementProjectDetailView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementProjectDetailView.swift; sourceTree = SOURCE_ROOT; };
-		10EE348FF84C5F729A416848 /* CoreDataReminderRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Repositories/CoreDataReminderRepository.swift; sourceTree = SOURCE_ROOT; };
-		1134D09887CAA3CD8F14E808 /* CoreDataGamificationRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Repositories/CoreDataGamificationRepository.swift; sourceTree = SOURCE_ROOT; };
+		0643A03092D9D90FE7DC26D4 /* LifeBoard/UseCases/Tag/ManageTagsUseCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Tag/ManageTagsUseCase.swift; sourceTree = SOURCE_ROOT; };
+		06C9F0E1B9A7D11A42BEFEB1 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+DueTodayAgenda.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+DueTodayAgenda.swift"; sourceTree = SOURCE_ROOT; };
+		076D0B0C6429D3BED7BCBF7A /* LifeBoard/Onboarding/Components/OnboardingFloatingNextButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingFloatingNextButton.swift; sourceTree = SOURCE_ROOT; };
+		0782589C1467EBE5827782EF /* LifeBoard/Onboarding/Models/OnboardingInputField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingInputField.swift; sourceTree = SOURCE_ROOT; };
+		078F0DB7D6806A7A2A660437 /* LifeBoard/Presentation/ViewModels/Home/HomeTimelineReplanStateSignature.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeTimelineReplanStateSignature.swift; sourceTree = SOURCE_ROOT; };
+		0791A21C5814ADEF3277BAB1 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelinePlanningShelf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelinePlanningShelf.swift; sourceTree = SOURCE_ROOT; };
+		079A43F8E9012BEFEACB658C /* LifeBoard/Onboarding/Services/OnboardingFlowModel+CatalogPresentation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Onboarding/Services/OnboardingFlowModel+CatalogPresentation.swift"; sourceTree = SOURCE_ROOT; };
+		081764019CFE89EAC4FE6BBD /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitHeaderView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitHeaderView.swift; sourceTree = SOURCE_ROOT; };
+		083E8304C4213AFE52640917 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamGeometry.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamGeometry.swift; sourceTree = SOURCE_ROOT; };
+		08CEBA82D3CB1ACE79D0E158 /* LifeBoard/State/Repositories/CoreDataExternalSyncRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Repositories/CoreDataExternalSyncRepository.swift; sourceTree = SOURCE_ROOT; };
+		093C76FA2FAF1A80BE897904 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamPalette.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamPalette.swift; sourceTree = SOURCE_ROOT; };
+		09813915E7878C1392C791D0 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueEligibilityService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueEligibilityService.swift; sourceTree = SOURCE_ROOT; };
+		098E6EFC49514867101BA977 /* LifeBoard/Onboarding/Models/OnboardingTaskTemplateState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingTaskTemplateState.swift; sourceTree = SOURCE_ROOT; };
+		0AA18F175EDA0C022217BD98 /* LifeBoard/Presentation/Home/Timeline/Surface/timelineStemColor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/timelineStemColor.swift; sourceTree = SOURCE_ROOT; };
+		0B33EB5C978F76DF3A6A735C /* LifeBoard/LLM/Views/Chat/Conversation/EvaDaySunriseTaskRowView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Conversation/EvaDaySunriseTaskRowView.swift; sourceTree = SOURCE_ROOT; };
+		0C6A23DC0DB1740CCDF6D30F /* LifeBoard/Presentation/Home/Timeline/Surface/DailyTimelineCompactView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/DailyTimelineCompactView.swift; sourceTree = SOURCE_ROOT; };
+		0D09C9507B3C691C73DA808A /* LifeBoard/Onboarding/Models/PendingOnboardingPresentation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/PendingOnboardingPresentation.swift; sourceTree = SOURCE_ROOT; };
+		0D70DF5D3C4DE407EF935B48 /* LifeBoard/Domain/Models/Section.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/Section.swift; sourceTree = SOURCE_ROOT; };
+		0D9B95BD66FD5C98B9AB37AE /* LifeBoard/Onboarding/Services/HomeOnboardingGuidanceModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Services/HomeOnboardingGuidanceModel.swift; sourceTree = SOURCE_ROOT; };
+		0D9FE88AEA020FF9DA3791C7 /* LifeBoard/Onboarding/Models/OnboardingPromptTheme.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingPromptTheme.swift; sourceTree = SOURCE_ROOT; };
+		0F491D6AE37A2795AA0485A7 /* LifeBoard/Presentation/ViewModels/Home/HomeDateNavigationSource.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeDateNavigationSource.swift; sourceTree = SOURCE_ROOT; };
+		102FF39D56775B7335081882 /* LifeBoard/Onboarding/Models/OnboardingPromptFooterMaterialModifier.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingPromptFooterMaterialModifier.swift; sourceTree = SOURCE_ROOT; };
+		107822EF572057FAE8E0EF37 /* LifeBoard/Domain/Interfaces/LifeAreaRepositoryProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Interfaces/LifeAreaRepositoryProtocol.swift; sourceTree = SOURCE_ROOT; };
+		10E031C3127045DB0AF8ACF9 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementProjectDetailView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementProjectDetailView.swift; sourceTree = SOURCE_ROOT; };
+		10EE348FF84C5F729A416848 /* LifeBoard/State/Repositories/CoreDataReminderRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Repositories/CoreDataReminderRepository.swift; sourceTree = SOURCE_ROOT; };
+		1134D09887CAA3CD8F14E808 /* LifeBoard/State/Repositories/CoreDataGamificationRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Repositories/CoreDataGamificationRepository.swift; sourceTree = SOURCE_ROOT; };
 		1144C788F612CB7B2BB7458B /* TimelinePreferenceKeys.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TimelinePreferenceKeys.swift; sourceTree = "<group>"; };
-		1160613FFDAE3936EA841FD2 /* HomePerformanceSignposts.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomePerformanceSignposts.swift; sourceTree = SOURCE_ROOT; };
+		1160613FFDAE3936EA841FD2 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomePerformanceSignposts.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomePerformanceSignposts.swift; sourceTree = SOURCE_ROOT; };
 		116F9AD2836EC304C14DF552 /* Pods_LifeBoardTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_LifeBoardTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		120C5DB7F91E3BDB4BF9580F /* TimelineStreamGeometry+LaneLayoutAndPaths.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamGeometry+LaneLayoutAndPaths.swift"; sourceTree = SOURCE_ROOT; };
-		1265EFBF270FC894A5FCA278 /* CompleteTaskDefinitionUseCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Task/CompleteTaskDefinitionUseCase.swift; sourceTree = SOURCE_ROOT; };
-		12B9F0A506329D6FA33A3932 /* onboardingLogLine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/onboardingLogLine.swift; sourceTree = SOURCE_ROOT; };
+		120C5DB7F91E3BDB4BF9580F /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamGeometry+LaneLayoutAndPaths.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamGeometry+LaneLayoutAndPaths.swift"; sourceTree = SOURCE_ROOT; };
+		1265EFBF270FC894A5FCA278 /* LifeBoard/UseCases/Task/CompleteTaskDefinitionUseCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Task/CompleteTaskDefinitionUseCase.swift; sourceTree = SOURCE_ROOT; };
+		12B9F0A506329D6FA33A3932 /* LifeBoard/Onboarding/Models/onboardingLogLine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/onboardingLogLine.swift; sourceTree = SOURCE_ROOT; };
 		1371F4BC6B6BB7BF68747A7F /* SlashCommandExecutionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashCommandExecutionService.swift; sourceTree = "<group>"; };
-		13E7DC8765CCB903348B7B91 /* HomeTimelineReplanPhaseSignature.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeTimelineReplanPhaseSignature.swift; sourceTree = SOURCE_ROOT; };
-		144D7D155E9471F5D9E1CD62 /* OnboardingMiniMetric.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingMiniMetric.swift; sourceTree = SOURCE_ROOT; };
+		13E7DC8765CCB903348B7B91 /* LifeBoard/Presentation/ViewModels/Home/HomeTimelineReplanPhaseSignature.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeTimelineReplanPhaseSignature.swift; sourceTree = SOURCE_ROOT; };
+		144D7D155E9471F5D9E1CD62 /* LifeBoard/Onboarding/Models/OnboardingMiniMetric.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingMiniMetric.swift; sourceTree = SOURCE_ROOT; };
 		147B7C5EB48AC2259B009894 /* SettingsNavigationRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsNavigationRow.swift; sourceTree = "<group>"; };
-		16B708DAB6EC819BECE9B5A8 /* HomeCalendarEventDetailSelection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeCalendarEventDetailSelection.swift; sourceTree = SOURCE_ROOT; };
-		16CA0CB88D6BCF379DD02183 /* OnboardingDownloadStatusStrip.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingDownloadStatusStrip.swift; sourceTree = SOURCE_ROOT; };
-		16D60461249FA816620C956F /* TimelineCompactGapRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompactGapRow.swift; sourceTree = SOURCE_ROOT; };
-		175B3F0CAAFBA0E5E38D57EE /* OverdueRescueDragResolution.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDragResolution.swift; sourceTree = SOURCE_ROOT; };
-		17DC0A5BC84D9C6C792B2AB6 /* HomeXPHeroView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/View/HomeXPHeroView.swift; sourceTree = SOURCE_ROOT; };
-		1859F3D260EADFEA49FDBA98 /* AppOnboardingSummary.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/AppOnboardingSummary.swift; sourceTree = SOURCE_ROOT; };
-		1A81F8713DDE19EF4F956288 /* ResolvedProjectSelection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/ResolvedProjectSelection.swift; sourceTree = SOURCE_ROOT; };
+		16B708DAB6EC819BECE9B5A8 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeCalendarEventDetailSelection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeCalendarEventDetailSelection.swift; sourceTree = SOURCE_ROOT; };
+		16CA0CB88D6BCF379DD02183 /* LifeBoard/Onboarding/Models/OnboardingDownloadStatusStrip.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingDownloadStatusStrip.swift; sourceTree = SOURCE_ROOT; };
+		16D60461249FA816620C956F /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompactGapRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompactGapRow.swift; sourceTree = SOURCE_ROOT; };
+		175B3F0CAAFBA0E5E38D57EE /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDragResolution.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDragResolution.swift; sourceTree = SOURCE_ROOT; };
+		17DC0A5BC84D9C6C792B2AB6 /* LifeBoard/View/HomeXPHeroView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/View/HomeXPHeroView.swift; sourceTree = SOURCE_ROOT; };
+		1859F3D260EADFEA49FDBA98 /* LifeBoard/Onboarding/Models/AppOnboardingSummary.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/AppOnboardingSummary.swift; sourceTree = SOURCE_ROOT; };
+		1A81F8713DDE19EF4F956288 /* LifeBoard/Onboarding/Models/ResolvedProjectSelection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/ResolvedProjectSelection.swift; sourceTree = SOURCE_ROOT; };
 		1A94E5E4F9BB3AA846B56A72 /* UIKit+TokenAdapters.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UIKit+TokenAdapters.swift"; sourceTree = "<group>"; };
-		1B271BB8000F7BA9D183AA5F /* TimelineCurrentTimeMarker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineCurrentTimeMarker.swift; sourceTree = SOURCE_ROOT; };
-		1B764C348624AC32EFC9F04F /* TimelinePalette.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelinePalette.swift; sourceTree = SOURCE_ROOT; };
-		1BD2CC14C16ACDED405C7814 /* StarterLifeAreaTemplate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/StarterLifeAreaTemplate.swift; sourceTree = SOURCE_ROOT; };
-		1C5FAE972A10C45BCDDB0142 /* GamificationEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Gamification/GamificationEngine.swift; sourceTree = SOURCE_ROOT; };
+		1B271BB8000F7BA9D183AA5F /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCurrentTimeMarker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineCurrentTimeMarker.swift; sourceTree = SOURCE_ROOT; };
+		1B764C348624AC32EFC9F04F /* LifeBoard/Presentation/Home/Timeline/Surface/TimelinePalette.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelinePalette.swift; sourceTree = SOURCE_ROOT; };
+		1BD2CC14C16ACDED405C7814 /* LifeBoard/Onboarding/Models/StarterLifeAreaTemplate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/StarterLifeAreaTemplate.swift; sourceTree = SOURCE_ROOT; };
+		1C5FAE972A10C45BCDDB0142 /* LifeBoard/UseCases/Gamification/GamificationEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Gamification/GamificationEngine.swift; sourceTree = SOURCE_ROOT; };
 		1D1019B77D01322B031EC108 /* InMemoryCacheService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = InMemoryCacheService.swift; path = LifeBoard/State/Cache/InMemoryCacheService.swift; sourceTree = SOURCE_ROOT; };
-		1DB65ADBF6B22879FF33FF66 /* OnboardingHabitRecommendationCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingHabitRecommendationCard.swift; sourceTree = SOURCE_ROOT; };
-		1E09A984D40ECCC16F14B36F /* TimelineDayPresentation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineDayPresentation.swift; sourceTree = SOURCE_ROOT; };
+		1DB65ADBF6B22879FF33FF66 /* LifeBoard/Onboarding/Components/OnboardingHabitRecommendationCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingHabitRecommendationCard.swift; sourceTree = SOURCE_ROOT; };
+		1E09A984D40ECCC16F14B36F /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineDayPresentation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineDayPresentation.swift; sourceTree = SOURCE_ROOT; };
 		1E3F56B4B6E3DA6111B5E513 /* AddTaskSecondaryDetailsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTaskSecondaryDetailsSection.swift; sourceTree = "<group>"; };
-		1E69586D6A0661BB639FAE5F /* HomeViewModel+RenderTransaction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+RenderTransaction.swift"; sourceTree = SOURCE_ROOT; };
-		1E88A3C9B5309D183423ACF8 /* HomeViewModel+DailyAnalytics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+DailyAnalytics.swift"; sourceTree = SOURCE_ROOT; };
+		1E69586D6A0661BB639FAE5F /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+RenderTransaction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+RenderTransaction.swift"; sourceTree = SOURCE_ROOT; };
+		1E88A3C9B5309D183423ACF8 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+DailyAnalytics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+DailyAnalytics.swift"; sourceTree = SOURCE_ROOT; };
 		1F1E30EEB9BC19FBBF513F2F /* Pods-LifeBoardTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LifeBoardTests.debug.xcconfig"; path = "Target Support Files/Pods-LifeBoardTests/Pods-LifeBoardTests.debug.xcconfig"; sourceTree = "<group>"; };
-		1F47DE38B051783EAE99853E /* HomeHabitMutationFeedbackHaptic.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationFeedbackHaptic.swift; sourceTree = SOURCE_ROOT; };
+		1F47DE38B051783EAE99853E /* LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationFeedbackHaptic.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationFeedbackHaptic.swift; sourceTree = SOURCE_ROOT; };
 		1F9B00002FBA700000000001 /* HomeNavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeNavigationCoordinator.swift; sourceTree = "<group>"; };
 		1F9B00022FBA700000000003 /* HomeReloadCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeReloadCoordinator.swift; sourceTree = "<group>"; };
 		1F9B00042FBA700000000004 /* HomeNavigationIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeNavigationIntent.swift; sourceTree = "<group>"; };
 		1F9B00062FBA700000000006 /* HomeNavigationEventAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeNavigationEventAdapter.swift; sourceTree = "<group>"; };
 		1F9B00082FBA700000000008 /* HomeLaunchHarnessService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeLaunchHarnessService.swift; sourceTree = "<group>"; };
-		1F9BFCCD7C709FF34D6E5824 /* HomeViewModel+EvaRescueActions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+EvaRescueActions.swift"; sourceTree = SOURCE_ROOT; };
-		208608AB50F4EA01C74D2758 /* Occurrence.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/Occurrence.swift; sourceTree = SOURCE_ROOT; };
-		2113ED4006493C0B58760C99 /* SunriseAppShellView+TaskListAndDaySwipe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+TaskListAndDaySwipe.swift"; sourceTree = SOURCE_ROOT; };
-		2139792A102DCF4971E889CC /* OnboardingPresentationQueue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingPresentationQueue.swift; sourceTree = SOURCE_ROOT; };
-		2152A62EA1C5CBB8557A37E7 /* OverdueRescueErrorView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueErrorView.swift; sourceTree = SOURCE_ROOT; };
-		21637D8476DC186EA285FB33 /* WidgetSnapshot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Shared/WidgetSnapshot.swift; sourceTree = SOURCE_ROOT; };
-		21E20317B5C516035FAEE85D /* OnboardingSuccessSummaryCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingSuccessSummaryCard.swift; sourceTree = SOURCE_ROOT; };
-		220815DD3BB32A14C051A1BF /* GamificationRepositoryProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Interfaces/GamificationRepositoryProtocol.swift; sourceTree = SOURCE_ROOT; };
-		222C1D1DF983BFFDF4BB651E /* CelebrationKind.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/CelebrationKind.swift; sourceTree = SOURCE_ROOT; };
-		22B025D510428B62C47FBE05 /* ReconcileExternalRemindersUseCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Sync/ReconcileExternalRemindersUseCase.swift; sourceTree = SOURCE_ROOT; };
-		23A78189DAF93E5F5EA0C769 /* CoreDataTombstoneRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Repositories/CoreDataTombstoneRepository.swift; sourceTree = SOURCE_ROOT; };
-		24A454E67411059893B17309 /* TimelineNowBeadPresentation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineNowBeadPresentation.swift; sourceTree = SOURCE_ROOT; };
+		1F9BFCCD7C709FF34D6E5824 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+EvaRescueActions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+EvaRescueActions.swift"; sourceTree = SOURCE_ROOT; };
+		208608AB50F4EA01C74D2758 /* LifeBoard/Domain/Models/Occurrence.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/Occurrence.swift; sourceTree = SOURCE_ROOT; };
+		2113ED4006493C0B58760C99 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+TaskListAndDaySwipe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+TaskListAndDaySwipe.swift"; sourceTree = SOURCE_ROOT; };
+		2139792A102DCF4971E889CC /* LifeBoard/Onboarding/Models/OnboardingPresentationQueue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingPresentationQueue.swift; sourceTree = SOURCE_ROOT; };
+		2152A62EA1C5CBB8557A37E7 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueErrorView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueErrorView.swift; sourceTree = SOURCE_ROOT; };
+		21637D8476DC186EA285FB33 /* Shared/WidgetSnapshot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Shared/WidgetSnapshot.swift; sourceTree = SOURCE_ROOT; };
+		21E20317B5C516035FAEE85D /* LifeBoard/Onboarding/Components/OnboardingSuccessSummaryCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingSuccessSummaryCard.swift; sourceTree = SOURCE_ROOT; };
+		220815DD3BB32A14C051A1BF /* LifeBoard/Domain/Interfaces/GamificationRepositoryProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Interfaces/GamificationRepositoryProtocol.swift; sourceTree = SOURCE_ROOT; };
+		222C1D1DF983BFFDF4BB651E /* LifeBoard/Presentation/ViewModels/Home/CelebrationKind.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/CelebrationKind.swift; sourceTree = SOURCE_ROOT; };
+		22B025D510428B62C47FBE05 /* LifeBoard/UseCases/Sync/ReconcileExternalRemindersUseCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Sync/ReconcileExternalRemindersUseCase.swift; sourceTree = SOURCE_ROOT; };
+		23A78189DAF93E5F5EA0C769 /* LifeBoard/State/Repositories/CoreDataTombstoneRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Repositories/CoreDataTombstoneRepository.swift; sourceTree = SOURCE_ROOT; };
+		24A454E67411059893B17309 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineNowBeadPresentation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineNowBeadPresentation.swift; sourceTree = SOURCE_ROOT; };
 		24EC3451B4B59726B8F286E2 /* ColorTokenGenerationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ColorTokenGenerationTests.swift; sourceTree = "<group>"; };
-		256FD8E6876C56256C606CBF /* OnboardingFlowModel+EvaActivationPreparation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Onboarding/Services/OnboardingFlowModel+EvaActivationPreparation.swift"; sourceTree = SOURCE_ROOT; };
-		25FBF99ED821FFD0AF0826C2 /* FlowPromptChipsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Chrome/FlowPromptChipsView.swift; sourceTree = SOURCE_ROOT; };
+		256FD8E6876C56256C606CBF /* LifeBoard/Onboarding/Services/OnboardingFlowModel+EvaActivationPreparation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Onboarding/Services/OnboardingFlowModel+EvaActivationPreparation.swift"; sourceTree = SOURCE_ROOT; };
+		25FBF99ED821FFD0AF0826C2 /* LifeBoard/LLM/Views/Chat/Chrome/FlowPromptChipsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Chrome/FlowPromptChipsView.swift; sourceTree = SOURCE_ROOT; };
 		267DB3EE27A6E3C161F380D5 /* DueSoonLeadTimeCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DueSoonLeadTimeCard.swift; sourceTree = "<group>"; };
 		2687D1B80519E0EB4CB71E2F /* HomeViewModel+Timeline.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "HomeViewModel+Timeline.swift"; sourceTree = "<group>"; };
-		2689E7BAE48C3D0915401020 /* OnboardingFrictionSelectorWidthPreferenceKey.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingFrictionSelectorWidthPreferenceKey.swift; sourceTree = SOURCE_ROOT; };
-		269A705710B0EA3EFEDCBE82 /* EvaOverdueRescueSheetV2Root.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/EvaOverdueRescueSheetV2Root.swift; sourceTree = SOURCE_ROOT; };
-		26D9ECAA7CAE990AACBF05E5 /* CoreDataLifeAreaRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Repositories/CoreDataLifeAreaRepository.swift; sourceTree = SOURCE_ROOT; };
+		2689E7BAE48C3D0915401020 /* LifeBoard/Onboarding/Components/OnboardingFrictionSelectorWidthPreferenceKey.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingFrictionSelectorWidthPreferenceKey.swift; sourceTree = SOURCE_ROOT; };
+		269A705710B0EA3EFEDCBE82 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/EvaOverdueRescueSheetV2Root.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/EvaOverdueRescueSheetV2Root.swift; sourceTree = SOURCE_ROOT; };
+		26D9ECAA7CAE990AACBF05E5 /* LifeBoard/State/Repositories/CoreDataLifeAreaRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Repositories/CoreDataLifeAreaRepository.swift; sourceTree = SOURCE_ROOT; };
 		26EAC60DD5866D607F966D0E /* HomeSunriseFace.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeSunriseFace.swift; sourceTree = "<group>"; };
-		272F492CB5085884C2B03F16 /* TimelineStreamInfluenceExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamInfluenceExtension.swift; sourceTree = SOURCE_ROOT; };
-		27994B950A0F914CFEDC6740 /* CreateHabitUseCaseExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/CreateHabitUseCaseExtension.swift; sourceTree = SOURCE_ROOT; };
+		272F492CB5085884C2B03F16 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamInfluenceExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamInfluenceExtension.swift; sourceTree = SOURCE_ROOT; };
+		27994B950A0F914CFEDC6740 /* LifeBoard/Onboarding/Models/CreateHabitUseCaseExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/CreateHabitUseCaseExtension.swift; sourceTree = SOURCE_ROOT; };
 		2856D1EE26429146B60B6633 /* TaskReadQueries.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TaskReadQueries.swift; sourceTree = "<group>"; };
-		286C6F6CD6B150C5152666E2 /* lifeManagementHabitCadenceLabel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/lifeManagementHabitCadenceLabel.swift; sourceTree = SOURCE_ROOT; };
-		29564FDC651771ED4BB94446 /* OnboardingCompactHabitRail.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingCompactHabitRail.swift; sourceTree = SOURCE_ROOT; };
-		29787A3C205793132F924985 /* OverdueRescuePauseView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescuePauseView.swift; sourceTree = SOURCE_ROOT; };
+		286C6F6CD6B150C5152666E2 /* LifeBoard/Views/Settings/LifeManagement/lifeManagementHabitCadenceLabel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/lifeManagementHabitCadenceLabel.swift; sourceTree = SOURCE_ROOT; };
+		29564FDC651771ED4BB94446 /* LifeBoard/Onboarding/Models/OnboardingCompactHabitRail.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingCompactHabitRail.swift; sourceTree = SOURCE_ROOT; };
+		29787A3C205793132F924985 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescuePauseView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescuePauseView.swift; sourceTree = SOURCE_ROOT; };
 		2A1F5E5105AE9585B4120F9F /* AddTaskRepeatEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTaskRepeatEditor.swift; sourceTree = "<group>"; };
 		2A7397B50382FF7FB4FAEC5F /* SunriseTaskSectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SunriseTaskSectionView.swift; sourceTree = "<group>"; };
-		2AB81062DAE961E3F10652E2 /* HomeHabitMutationKey.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationKey.swift; sourceTree = SOURCE_ROOT; };
-		2BA91AA8F90D4C022C4E890E /* TimelineShelfItemCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineShelfItemCard.swift; sourceTree = SOURCE_ROOT; };
-		2C7BD248BA8AC069F8261EE8 /* HomeViewModel+HabitReconciliation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+HabitReconciliation.swift"; sourceTree = SOURCE_ROOT; };
+		2AB81062DAE961E3F10652E2 /* LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationKey.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationKey.swift; sourceTree = SOURCE_ROOT; };
+		2BA91AA8F90D4C022C4E890E /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineShelfItemCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineShelfItemCard.swift; sourceTree = SOURCE_ROOT; };
+		2C7BD248BA8AC069F8261EE8 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+HabitReconciliation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+HabitReconciliation.swift"; sourceTree = SOURCE_ROOT; };
 		2D01967BDAF0ABB45A855C29 /* AddTaskTaskPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTaskTaskPicker.swift; sourceTree = "<group>"; };
-		2D16AF9130E446C22AB65042 /* OnboardingEvaPreparationPhase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingEvaPreparationPhase.swift; sourceTree = SOURCE_ROOT; };
-		2D98632874AFDD2B129187E0 /* OnboardingHomeDemoSnapshotFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingHomeDemoSnapshotFactory.swift; sourceTree = SOURCE_ROOT; };
-		2E5F5580FE6F9B4D29FFAA14 /* TimelineCompletionRing.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompletionRing.swift; sourceTree = SOURCE_ROOT; };
+		2D16AF9130E446C22AB65042 /* LifeBoard/Onboarding/Models/OnboardingEvaPreparationPhase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingEvaPreparationPhase.swift; sourceTree = SOURCE_ROOT; };
+		2D98632874AFDD2B129187E0 /* LifeBoard/Onboarding/Models/OnboardingHomeDemoSnapshotFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingHomeDemoSnapshotFactory.swift; sourceTree = SOURCE_ROOT; };
+		2E5F5580FE6F9B4D29FFAA14 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompletionRing.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompletionRing.swift; sourceTree = SOURCE_ROOT; };
 		2E753995C5FB25BE948BE1E9 /* HomeFilterState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeFilterState.swift; sourceTree = "<group>"; };
-		2F80480EA58FB983550B882B /* GenerateOccurrencesUseCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Schedule/GenerateOccurrencesUseCase.swift; sourceTree = SOURCE_ROOT; };
-		2F86906A0E4C13F4F10D0C6B /* OverdueRescueDecisionSource.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDecisionSource.swift; sourceTree = SOURCE_ROOT; };
-		2FAC5C958944C25B7E561037 /* LifeManagementProjectColorPicker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementProjectColorPicker.swift; sourceTree = SOURCE_ROOT; };
-		315FEE8A1F6EB8E3768FAEF0 /* OverdueRescueMoveLaterResolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueMoveLaterResolver.swift; sourceTree = SOURCE_ROOT; };
+		2F80480EA58FB983550B882B /* LifeBoard/UseCases/Schedule/GenerateOccurrencesUseCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Schedule/GenerateOccurrencesUseCase.swift; sourceTree = SOURCE_ROOT; };
+		2F86906A0E4C13F4F10D0C6B /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDecisionSource.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDecisionSource.swift; sourceTree = SOURCE_ROOT; };
+		2FAC5C958944C25B7E561037 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementProjectColorPicker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementProjectColorPicker.swift; sourceTree = SOURCE_ROOT; };
+		315FEE8A1F6EB8E3768FAEF0 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueMoveLaterResolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueMoveLaterResolver.swift; sourceTree = SOURCE_ROOT; };
 		316921199F513341A93BD753 /* AddTaskDurationPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTaskDurationPicker.swift; sourceTree = "<group>"; };
-		3206AE8D772083ABEFFE26DA /* OnboardingPromptChecklistCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingPromptChecklistCard.swift; sourceTree = SOURCE_ROOT; };
+		3206AE8D772083ABEFFE26DA /* LifeBoard/Onboarding/Components/OnboardingPromptChecklistCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingPromptChecklistCard.swift; sourceTree = SOURCE_ROOT; };
 		32CFD17024C4F8FF10386CE1 /* TypographyTokenTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TypographyTokenTests.swift; sourceTree = "<group>"; };
-		33167B1E5D148BC1B8907161 /* timelineCapsuleHeight.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/timelineCapsuleHeight.swift; sourceTree = SOURCE_ROOT; };
-		338615107E8C8B6C3389301D /* HomeViewModel+ReferenceDataLoading.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+ReferenceDataLoading.swift"; sourceTree = SOURCE_ROOT; };
-		341974EF0AE031E749EE396D /* CurvingDayStreamView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/CurvingDayStreamView.swift; sourceTree = SOURCE_ROOT; };
-		34288F9F2CB1DADA41F1673D /* LifeArea.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/LifeArea.swift; sourceTree = SOURCE_ROOT; };
-		34C247867FBCFF10E376C692 /* EvaDayTaskOverlayState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Conversation/EvaDayTaskOverlayState.swift; sourceTree = SOURCE_ROOT; };
-		34C9C6671884EE8926C32968 /* HomeViewModel+FocusWhyCandidates.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+FocusWhyCandidates.swift"; sourceTree = SOURCE_ROOT; };
-		34CC91CCAA408A3ADB2D8693 /* V2FeatureFlags.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Services/V2FeatureFlags.swift; sourceTree = SOURCE_ROOT; };
-		351390B6BEADE2277EF6ECBA /* OnboardingTrustRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingTrustRow.swift; sourceTree = SOURCE_ROOT; };
-		3528CDE2C353B77B8CC4EB35 /* EvaDayTaskActionButtonView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Conversation/EvaDayTaskActionButtonView.swift; sourceTree = SOURCE_ROOT; };
+		33167B1E5D148BC1B8907161 /* LifeBoard/Presentation/Home/Timeline/Surface/timelineCapsuleHeight.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/timelineCapsuleHeight.swift; sourceTree = SOURCE_ROOT; };
+		338615107E8C8B6C3389301D /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+ReferenceDataLoading.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+ReferenceDataLoading.swift"; sourceTree = SOURCE_ROOT; };
+		341974EF0AE031E749EE396D /* LifeBoard/Presentation/Home/Timeline/Surface/CurvingDayStreamView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/CurvingDayStreamView.swift; sourceTree = SOURCE_ROOT; };
+		34288F9F2CB1DADA41F1673D /* LifeBoard/Domain/Models/LifeArea.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/LifeArea.swift; sourceTree = SOURCE_ROOT; };
+		34C247867FBCFF10E376C692 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayTaskOverlayState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Conversation/EvaDayTaskOverlayState.swift; sourceTree = SOURCE_ROOT; };
+		34C9C6671884EE8926C32968 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+FocusWhyCandidates.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+FocusWhyCandidates.swift"; sourceTree = SOURCE_ROOT; };
+		34CC91CCAA408A3ADB2D8693 /* LifeBoard/Services/V2FeatureFlags.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Services/V2FeatureFlags.swift; sourceTree = SOURCE_ROOT; };
+		351390B6BEADE2277EF6ECBA /* LifeBoard/Onboarding/Components/OnboardingTrustRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingTrustRow.swift; sourceTree = SOURCE_ROOT; };
+		3528CDE2C353B77B8CC4EB35 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayTaskActionButtonView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Conversation/EvaDayTaskActionButtonView.swift; sourceTree = SOURCE_ROOT; };
 		3556357BB33A833A1684F06B /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		35E5A3CA91F06A962F9FF9FA /* AppIntents.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppIntents.framework; path = System/Library/Frameworks/AppIntents.framework; sourceTree = SDKROOT; };
-		35FFAEB5937CA521A5C5C4DC /* ChatHeaderView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Chrome/ChatHeaderView.swift; sourceTree = SOURCE_ROOT; };
-		3674205CDE72EB0BA59F05D4 /* HomeTaskDetailRelationshipMetadataState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeTaskDetailRelationshipMetadataState.swift; sourceTree = SOURCE_ROOT; };
-		36BCF2891531B59B34A6773C /* HomeHabitWidgetRowsState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeHabitWidgetRowsState.swift; sourceTree = SOURCE_ROOT; };
-		36F7B2A4D32F9921BBA51449 /* TimelineDayStablePresentation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineDayStablePresentation.swift; sourceTree = SOURCE_ROOT; };
-		377436A41D3BA36DD06E3C58 /* OnboardingWelcomeIntroLine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingWelcomeIntroLine.swift; sourceTree = SOURCE_ROOT; };
-		37DD8CAB8F66109195DD8D31 /* OnboardingMode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingMode.swift; sourceTree = SOURCE_ROOT; };
-		37E2466DBE2A76A73458F530 /* SunriseFocusTimerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/View/SunriseFocusTimerView.swift; sourceTree = SOURCE_ROOT; };
-		382D7A14C1F519D843A2365D /* LifeManagementAreaComposerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementAreaComposerView.swift; sourceTree = SOURCE_ROOT; };
-		384185D0DBC900F3E3B48AF3 /* EvaHomePromptChip.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Chrome/EvaHomePromptChip.swift; sourceTree = SOURCE_ROOT; };
-		38AE057025E85DF89448752B /* TypingIndicator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Conversation/TypingIndicator.swift; sourceTree = SOURCE_ROOT; };
-		38BF65FECAAA9E50000FFA9E /* OnboardingStepVisualTheme.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingStepVisualTheme.swift; sourceTree = SOURCE_ROOT; };
-		391110AA08B7ED7F8ED57B9C /* HomeViewModel+RescueEligibility.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+RescueEligibility.swift"; sourceTree = SOURCE_ROOT; };
-		3A455CC1761B05C261D2051B /* timelineTitleColor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/timelineTitleColor.swift; sourceTree = SOURCE_ROOT; };
-		3A74DF0E9DCAEB8A8179F375 /* TodayXPWidget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoardWidgets/TodayXPWidget.swift; sourceTree = SOURCE_ROOT; };
-		3ACB1F98FD6BA7DDDC213D7B /* OnboardingProgress.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingProgress.swift; sourceTree = SOURCE_ROOT; };
+		35FFAEB5937CA521A5C5C4DC /* LifeBoard/LLM/Views/Chat/Chrome/ChatHeaderView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Chrome/ChatHeaderView.swift; sourceTree = SOURCE_ROOT; };
+		3674205CDE72EB0BA59F05D4 /* LifeBoard/Presentation/ViewModels/Home/HomeTaskDetailRelationshipMetadataState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeTaskDetailRelationshipMetadataState.swift; sourceTree = SOURCE_ROOT; };
+		36BCF2891531B59B34A6773C /* LifeBoard/Presentation/ViewModels/Home/HomeHabitWidgetRowsState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeHabitWidgetRowsState.swift; sourceTree = SOURCE_ROOT; };
+		36F7B2A4D32F9921BBA51449 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineDayStablePresentation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineDayStablePresentation.swift; sourceTree = SOURCE_ROOT; };
+		377436A41D3BA36DD06E3C58 /* LifeBoard/Onboarding/Models/OnboardingWelcomeIntroLine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingWelcomeIntroLine.swift; sourceTree = SOURCE_ROOT; };
+		37DD8CAB8F66109195DD8D31 /* LifeBoard/Onboarding/Models/OnboardingMode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingMode.swift; sourceTree = SOURCE_ROOT; };
+		37E2466DBE2A76A73458F530 /* LifeBoard/View/SunriseFocusTimerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/View/SunriseFocusTimerView.swift; sourceTree = SOURCE_ROOT; };
+		382D7A14C1F519D843A2365D /* LifeBoard/Views/Settings/LifeManagement/LifeManagementAreaComposerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementAreaComposerView.swift; sourceTree = SOURCE_ROOT; };
+		384185D0DBC900F3E3B48AF3 /* LifeBoard/LLM/Views/Chat/Chrome/EvaHomePromptChip.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Chrome/EvaHomePromptChip.swift; sourceTree = SOURCE_ROOT; };
+		38AE057025E85DF89448752B /* LifeBoard/LLM/Views/Chat/Conversation/TypingIndicator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Conversation/TypingIndicator.swift; sourceTree = SOURCE_ROOT; };
+		38BF65FECAAA9E50000FFA9E /* LifeBoard/Onboarding/Models/OnboardingStepVisualTheme.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingStepVisualTheme.swift; sourceTree = SOURCE_ROOT; };
+		391110AA08B7ED7F8ED57B9C /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+RescueEligibility.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+RescueEligibility.swift"; sourceTree = SOURCE_ROOT; };
+		3A455CC1761B05C261D2051B /* LifeBoard/Presentation/Home/Timeline/Surface/timelineTitleColor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/timelineTitleColor.swift; sourceTree = SOURCE_ROOT; };
+		3A74DF0E9DCAEB8A8179F375 /* LifeBoardWidgets/TodayXPWidget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoardWidgets/TodayXPWidget.swift; sourceTree = SOURCE_ROOT; };
+		3ACB1F98FD6BA7DDDC213D7B /* LifeBoard/Onboarding/Models/OnboardingProgress.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingProgress.swift; sourceTree = SOURCE_ROOT; };
 		3B52F546EA648DBA17C720A1 /* Pods-LifeBoard-LifeBoardUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LifeBoard-LifeBoardUITests.debug.xcconfig"; path = "Target Support Files/Pods-LifeBoard-LifeBoardUITests/Pods-LifeBoard-LifeBoardUITests.debug.xcconfig"; sourceTree = "<group>"; };
-		3B5B7AA06E3FAF9CBF2A49AE /* TimelineOverlapItemCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineOverlapItemCard.swift; sourceTree = SOURCE_ROOT; };
-		3C66EE511C59B0C5DAAAEA30 /* ProjectMoveSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/ProjectMoveSheet.swift; sourceTree = SOURCE_ROOT; };
-		3C9C1DCD3D8D37AB96401D40 /* onboardingNaturalLanguageList.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/onboardingNaturalLanguageList.swift; sourceTree = SOURCE_ROOT; };
-		3CAA3A6573B0FE5C495C67AC /* ExternalSyncModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/ExternalSyncModels.swift; sourceTree = SOURCE_ROOT; };
+		3B5B7AA06E3FAF9CBF2A49AE /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineOverlapItemCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineOverlapItemCard.swift; sourceTree = SOURCE_ROOT; };
+		3C66EE511C59B0C5DAAAEA30 /* LifeBoard/Views/Settings/LifeManagement/ProjectMoveSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/ProjectMoveSheet.swift; sourceTree = SOURCE_ROOT; };
+		3C9C1DCD3D8D37AB96401D40 /* LifeBoard/Onboarding/Models/onboardingNaturalLanguageList.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/onboardingNaturalLanguageList.swift; sourceTree = SOURCE_ROOT; };
+		3CAA3A6573B0FE5C495C67AC /* LifeBoard/Domain/Models/ExternalSyncModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/ExternalSyncModels.swift; sourceTree = SOURCE_ROOT; };
 		3D233F155B6A87F62F52F845 /* HomeQuickFilterSummary.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeQuickFilterSummary.swift; sourceTree = "<group>"; };
-		3DF9AEF356D3B2242580C561 /* HomeViewModel+RefreshEntryPoints.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+RefreshEntryPoints.swift"; sourceTree = SOURCE_ROOT; };
-		3E03A10085F34C95F49402B3 /* HomeHabitMutationRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationRequest.swift; sourceTree = SOURCE_ROOT; };
-		3E224DFA4DB09C938556B07B /* CompleteTaskDefinitionUseCaseExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/CompleteTaskDefinitionUseCaseExtension.swift; sourceTree = SOURCE_ROOT; };
-		3F0DB5144721E54F43222D3D /* NSLockExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/NSLockExtension.swift; sourceTree = SOURCE_ROOT; };
-		3F6049AC20F10CEBF79F8BAD /* lifeManagementAreaAccentHex.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/lifeManagementAreaAccentHex.swift; sourceTree = SOURCE_ROOT; };
-		3F730ADFEFDF0357ECA49761 /* LifeManagementView+BrowserAndTree.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Views/Settings/LifeManagement/LifeManagementView+BrowserAndTree.swift"; sourceTree = SOURCE_ROOT; };
-		3F73F08CE7AF7398D7835E7F /* LifeManagementAreaPaletteOption.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementAreaPaletteOption.swift; sourceTree = SOURCE_ROOT; };
+		3DF9AEF356D3B2242580C561 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+RefreshEntryPoints.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+RefreshEntryPoints.swift"; sourceTree = SOURCE_ROOT; };
+		3E03A10085F34C95F49402B3 /* LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationRequest.swift; sourceTree = SOURCE_ROOT; };
+		3E224DFA4DB09C938556B07B /* LifeBoard/Onboarding/Models/CompleteTaskDefinitionUseCaseExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/CompleteTaskDefinitionUseCaseExtension.swift; sourceTree = SOURCE_ROOT; };
+		3F0DB5144721E54F43222D3D /* LifeBoard/Presentation/ViewModels/Home/NSLockExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/NSLockExtension.swift; sourceTree = SOURCE_ROOT; };
+		3F6049AC20F10CEBF79F8BAD /* LifeBoard/Views/Settings/LifeManagement/lifeManagementAreaAccentHex.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/lifeManagementAreaAccentHex.swift; sourceTree = SOURCE_ROOT; };
+		3F730ADFEFDF0357ECA49761 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementView+BrowserAndTree.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Views/Settings/LifeManagement/LifeManagementView+BrowserAndTree.swift"; sourceTree = SOURCE_ROOT; };
+		3F73F08CE7AF7398D7835E7F /* LifeBoard/Views/Settings/LifeManagement/LifeManagementAreaPaletteOption.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementAreaPaletteOption.swift; sourceTree = SOURCE_ROOT; };
 		3F90A4ACBFBF5EEA42C69976 /* HomeViewController+Navigation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "HomeViewController+Navigation.swift"; sourceTree = "<group>"; };
-		400A0C43B52E9F1509D5EC4C /* LifeBoardProgressBar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/LifeBoardProgressBar.swift; sourceTree = SOURCE_ROOT; };
-		4033ABAF3ABB94CB6771C4CC /* TimelineCompactItemRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompactItemRow.swift; sourceTree = SOURCE_ROOT; };
-		4051577E3E4D5CC85DA57B2C /* LifeManagementViewRoot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementViewRoot.swift; sourceTree = SOURCE_ROOT; };
-		40541FE4F6750C143582AC0D /* OnboardingEvaPreparationState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingEvaPreparationState.swift; sourceTree = SOURCE_ROOT; };
-		4090E95CAD9BC75484267914 /* HomeDayNavigationDirection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeDayNavigationDirection.swift; sourceTree = SOURCE_ROOT; };
-		41DF50E6CD46F6C802CC86EE /* ProjectRepositoryProtocolExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/ProjectRepositoryProtocolExtension.swift; sourceTree = SOURCE_ROOT; };
-		41E91E7B08A3DB7F6092C4D4 /* HomeViewModel+TaskCreationDependencies.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+TaskCreationDependencies.swift"; sourceTree = SOURCE_ROOT; };
-		41F67EC4C592FE8E37C3B456 /* DailyTimelineCanvas.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/DailyTimelineCanvas.swift; sourceTree = SOURCE_ROOT; };
-		41FF5D1F1BC2347D454A7768 /* EvaDayTaskMetadataView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Conversation/EvaDayTaskMetadataView.swift; sourceTree = SOURCE_ROOT; };
-		425B8A685EE2C485783B0578 /* HomeHabitSectionCardHost.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeHabitSectionCardHost.swift; sourceTree = SOURCE_ROOT; };
-		42885152818D9953B13C071B /* EvaChiefOfStaffGuideContent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Chrome/EvaChiefOfStaffGuideContent.swift; sourceTree = SOURCE_ROOT; };
-		42AD2BFC988A80E8157AD2B2 /* V2RepositoryProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Interfaces/V2RepositoryProtocols.swift; sourceTree = SOURCE_ROOT; };
-		431D37A2C5059760CA9637D5 /* TimelineRailPresentationSpec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailPresentationSpec.swift; sourceTree = SOURCE_ROOT; };
-		432D634291596A7CBBCFA76B /* AssistantActionRepositoryProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Interfaces/AssistantActionRepositoryProtocol.swift; sourceTree = SOURCE_ROOT; };
-		433D1B69B2B63A326822F611 /* TimelineRailTypography.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailTypography.swift; sourceTree = SOURCE_ROOT; };
-		439335894506149A6B79E4A7 /* TimelineDayRelation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineDayRelation.swift; sourceTree = SOURCE_ROOT; };
-		43CB43D27ACFD36EEFFDD829 /* LifeManagementAppearanceLine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementAppearanceLine.swift; sourceTree = SOURCE_ROOT; };
-		44367A0F426BE6D78CC89655 /* OverdueRescueSessionScope.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSessionScope.swift; sourceTree = SOURCE_ROOT; };
-		44CFBD9F581CA1A255A49A85 /* CoreDataHabitRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Repositories/CoreDataHabitRepository.swift; sourceTree = SOURCE_ROOT; };
+		400A0C43B52E9F1509D5EC4C /* LifeBoard/Presentation/Home/Modals/OverdueRescue/LifeBoardProgressBar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/LifeBoardProgressBar.swift; sourceTree = SOURCE_ROOT; };
+		4033ABAF3ABB94CB6771C4CC /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompactItemRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompactItemRow.swift; sourceTree = SOURCE_ROOT; };
+		4051577E3E4D5CC85DA57B2C /* LifeBoard/Views/Settings/LifeManagement/LifeManagementViewRoot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementViewRoot.swift; sourceTree = SOURCE_ROOT; };
+		40541FE4F6750C143582AC0D /* LifeBoard/Onboarding/Models/OnboardingEvaPreparationState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingEvaPreparationState.swift; sourceTree = SOURCE_ROOT; };
+		4090E95CAD9BC75484267914 /* LifeBoard/Presentation/ViewModels/Home/HomeDayNavigationDirection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeDayNavigationDirection.swift; sourceTree = SOURCE_ROOT; };
+		41DF50E6CD46F6C802CC86EE /* LifeBoard/Onboarding/Models/ProjectRepositoryProtocolExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/ProjectRepositoryProtocolExtension.swift; sourceTree = SOURCE_ROOT; };
+		41E91E7B08A3DB7F6092C4D4 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+TaskCreationDependencies.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+TaskCreationDependencies.swift"; sourceTree = SOURCE_ROOT; };
+		41F67EC4C592FE8E37C3B456 /* LifeBoard/Presentation/Home/Timeline/Surface/DailyTimelineCanvas.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/DailyTimelineCanvas.swift; sourceTree = SOURCE_ROOT; };
+		41FF5D1F1BC2347D454A7768 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayTaskMetadataView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Conversation/EvaDayTaskMetadataView.swift; sourceTree = SOURCE_ROOT; };
+		425B8A685EE2C485783B0578 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeHabitSectionCardHost.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeHabitSectionCardHost.swift; sourceTree = SOURCE_ROOT; };
+		42885152818D9953B13C071B /* LifeBoard/LLM/Views/Chat/Chrome/EvaChiefOfStaffGuideContent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Chrome/EvaChiefOfStaffGuideContent.swift; sourceTree = SOURCE_ROOT; };
+		42AD2BFC988A80E8157AD2B2 /* LifeBoard/Domain/Interfaces/V2RepositoryProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Interfaces/V2RepositoryProtocols.swift; sourceTree = SOURCE_ROOT; };
+		431D37A2C5059760CA9637D5 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailPresentationSpec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailPresentationSpec.swift; sourceTree = SOURCE_ROOT; };
+		432D634291596A7CBBCFA76B /* LifeBoard/Domain/Interfaces/AssistantActionRepositoryProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Interfaces/AssistantActionRepositoryProtocol.swift; sourceTree = SOURCE_ROOT; };
+		433D1B69B2B63A326822F611 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailTypography.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailTypography.swift; sourceTree = SOURCE_ROOT; };
+		439335894506149A6B79E4A7 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineDayRelation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineDayRelation.swift; sourceTree = SOURCE_ROOT; };
+		43CB43D27ACFD36EEFFDD829 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementAppearanceLine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementAppearanceLine.swift; sourceTree = SOURCE_ROOT; };
+		44367A0F426BE6D78CC89655 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSessionScope.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSessionScope.swift; sourceTree = SOURCE_ROOT; };
+		44CFBD9F581CA1A255A49A85 /* LifeBoard/State/Repositories/CoreDataHabitRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Repositories/CoreDataHabitRepository.swift; sourceTree = SOURCE_ROOT; };
 		464A3B785BB4CE8EB48AB804 /* AddTaskAdvancedPlanningSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTaskAdvancedPlanningSection.swift; sourceTree = "<group>"; };
-		46D86472D55596A7E3DE5FED /* FocusPromotionResult.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/FocusPromotionResult.swift; sourceTree = SOURCE_ROOT; };
+		46D86472D55596A7E3DE5FED /* LifeBoard/Presentation/ViewModels/Home/FocusPromotionResult.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/FocusPromotionResult.swift; sourceTree = SOURCE_ROOT; };
 		4777F58ED4D4C8E747F0F901 /* TimelineRendererModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TimelineRendererModels.swift; sourceTree = "<group>"; };
-		4791B51EBAFFF32DE7642287 /* LifeAreaRepositoryProtocolExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/LifeAreaRepositoryProtocolExtension.swift; sourceTree = SOURCE_ROOT; };
+		4791B51EBAFFF32DE7642287 /* LifeBoard/Onboarding/Models/LifeAreaRepositoryProtocolExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/LifeAreaRepositoryProtocolExtension.swift; sourceTree = SOURCE_ROOT; };
 		47ED06CE7EC4F74A9E373158 /* DailyRitualsCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyRitualsCard.swift; sourceTree = "<group>"; };
-		4811259E3F517E7F0E457DCD /* OnboardingPrimaryCTAButtonStyle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingPrimaryCTAButtonStyle.swift; sourceTree = SOURCE_ROOT; };
+		4811259E3F517E7F0E457DCD /* LifeBoard/Onboarding/Components/OnboardingPrimaryCTAButtonStyle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingPrimaryCTAButtonStyle.swift; sourceTree = SOURCE_ROOT; };
 		4A2D7A866EC5053C29F5AE6F /* Pods_LifeBoard_LifeBoardUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_LifeBoard_LifeBoardUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		4A391C151F9BE79B12EAF441 /* OnboardingReminderPromptState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingReminderPromptState.swift; sourceTree = SOURCE_ROOT; };
-		4A5A3E8C899A8C9FB0694171 /* OverdueRescueShieldHero.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueShieldHero.swift; sourceTree = SOURCE_ROOT; };
+		4A391C151F9BE79B12EAF441 /* LifeBoard/Onboarding/Models/OnboardingReminderPromptState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingReminderPromptState.swift; sourceTree = SOURCE_ROOT; };
+		4A5A3E8C899A8C9FB0694171 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueShieldHero.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueShieldHero.swift; sourceTree = SOURCE_ROOT; };
 		4A7BCB477B2EA5D03B6F3FF0 /* HomeTaskListWidgetSnapshotService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeTaskListWidgetSnapshotService.swift; sourceTree = "<group>"; };
-		4AADEA1EA2E960494BF2F708 /* AppOnboardingState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/AppOnboardingState.swift; sourceTree = SOURCE_ROOT; };
-		4ABDFA484783D44FCE389CA8 /* HomeTimelineReplanCandidateSignature.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeTimelineReplanCandidateSignature.swift; sourceTree = SOURCE_ROOT; };
-		4ABE9BAD19D384E04867D9B2 /* TimelineUtilityRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineUtilityRow.swift; sourceTree = SOURCE_ROOT; };
-		4B5776D8C36FD7BB8FC91DA6 /* OnboardingSectionHeader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingSectionHeader.swift; sourceTree = SOURCE_ROOT; };
-		4BD3AB84121002B80128D5F3 /* OverdueRescueSwipeRevealKind.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSwipeRevealKind.swift; sourceTree = SOURCE_ROOT; };
-		4C109B5D75A091971FB33633 /* LinkExternalRemindersUseCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Sync/LinkExternalRemindersUseCase.swift; sourceTree = SOURCE_ROOT; };
-		4C1759A7E8DB0E5CE0E3384C /* TimelineStreamAnchor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamAnchor.swift; sourceTree = SOURCE_ROOT; };
-		4CF79ECF04752304C36B28F8 /* SunriseTimelineBar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/SunriseTimelineBar.swift; sourceTree = SOURCE_ROOT; };
-		4D1039EA2610A24D8D430EAD /* OnboardingCopy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingCopy.swift; sourceTree = SOURCE_ROOT; };
-		4D16CF764ED2CECF5A9AFDF3 /* HomeTimeIntervalExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeTimeIntervalExtension.swift; sourceTree = SOURCE_ROOT; };
-		4D27FF67FB1DB3066CA04D50 /* SunriseAppShellView+DerivedState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+DerivedState.swift"; sourceTree = SOURCE_ROOT; };
-		4D285845FE9143539A3C857A /* LifeManagementComposerFieldLabel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerFieldLabel.swift; sourceTree = SOURCE_ROOT; };
-		4D3A6556C5C49F5516DB6ECC /* HomeStaggerModifier.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeStaggerModifier.swift; sourceTree = SOURCE_ROOT; };
-		4D84FC1284BCFE8A1BB020B5 /* HabitRecoveryReflectionPrompt.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HabitRecoveryReflectionPrompt.swift; sourceTree = SOURCE_ROOT; };
-		4E3C7D35C2C5FC1FDEF0A89C /* ManageHabitsUseCaseExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/ManageHabitsUseCaseExtension.swift; sourceTree = SOURCE_ROOT; };
-		4E66ADE238E28DD2BC20A9C7 /* OnboardingPermissionHeroIcon.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingPermissionHeroIcon.swift; sourceTree = SOURCE_ROOT; };
-		4EC8D7FF629E27D3B426AD36 /* HomeTimelineEventSignature.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeTimelineEventSignature.swift; sourceTree = SOURCE_ROOT; };
-		4F244B959C35562023B24390 /* OnboardingHomeDemoPreview.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingHomeDemoPreview.swift; sourceTree = SOURCE_ROOT; };
-		4F67F2F26774817EB86045D0 /* OnboardingPromptGlassPanelModifier.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingPromptGlassPanelModifier.swift; sourceTree = SOURCE_ROOT; };
-		4F8E82EED2FB2D349E9F3BE9 /* FocusPinResult.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/FocusPinResult.swift; sourceTree = SOURCE_ROOT; };
-		4FAA78F353FFECD73FA8011A /* TimelineTaskMarkerLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineTaskMarkerLayout.swift; sourceTree = SOURCE_ROOT; };
+		4AADEA1EA2E960494BF2F708 /* LifeBoard/Onboarding/Models/AppOnboardingState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/AppOnboardingState.swift; sourceTree = SOURCE_ROOT; };
+		4ABDFA484783D44FCE389CA8 /* LifeBoard/Presentation/ViewModels/Home/HomeTimelineReplanCandidateSignature.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeTimelineReplanCandidateSignature.swift; sourceTree = SOURCE_ROOT; };
+		4ABE9BAD19D384E04867D9B2 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineUtilityRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineUtilityRow.swift; sourceTree = SOURCE_ROOT; };
+		4B5776D8C36FD7BB8FC91DA6 /* LifeBoard/Onboarding/Models/OnboardingSectionHeader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingSectionHeader.swift; sourceTree = SOURCE_ROOT; };
+		4BD3AB84121002B80128D5F3 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSwipeRevealKind.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSwipeRevealKind.swift; sourceTree = SOURCE_ROOT; };
+		4C109B5D75A091971FB33633 /* LifeBoard/UseCases/Sync/LinkExternalRemindersUseCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Sync/LinkExternalRemindersUseCase.swift; sourceTree = SOURCE_ROOT; };
+		4C1759A7E8DB0E5CE0E3384C /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamAnchor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamAnchor.swift; sourceTree = SOURCE_ROOT; };
+		4CF79ECF04752304C36B28F8 /* LifeBoard/Presentation/Home/Timeline/Surface/SunriseTimelineBar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/SunriseTimelineBar.swift; sourceTree = SOURCE_ROOT; };
+		4D1039EA2610A24D8D430EAD /* LifeBoard/Onboarding/Models/OnboardingCopy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingCopy.swift; sourceTree = SOURCE_ROOT; };
+		4D16CF764ED2CECF5A9AFDF3 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeTimeIntervalExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeTimeIntervalExtension.swift; sourceTree = SOURCE_ROOT; };
+		4D27FF67FB1DB3066CA04D50 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+DerivedState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+DerivedState.swift"; sourceTree = SOURCE_ROOT; };
+		4D285845FE9143539A3C857A /* LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerFieldLabel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerFieldLabel.swift; sourceTree = SOURCE_ROOT; };
+		4D3A6556C5C49F5516DB6ECC /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeStaggerModifier.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeStaggerModifier.swift; sourceTree = SOURCE_ROOT; };
+		4D84FC1284BCFE8A1BB020B5 /* LifeBoard/Presentation/ViewModels/Home/HabitRecoveryReflectionPrompt.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HabitRecoveryReflectionPrompt.swift; sourceTree = SOURCE_ROOT; };
+		4E3C7D35C2C5FC1FDEF0A89C /* LifeBoard/Onboarding/Models/ManageHabitsUseCaseExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/ManageHabitsUseCaseExtension.swift; sourceTree = SOURCE_ROOT; };
+		4E66ADE238E28DD2BC20A9C7 /* LifeBoard/Onboarding/Components/OnboardingPermissionHeroIcon.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingPermissionHeroIcon.swift; sourceTree = SOURCE_ROOT; };
+		4EC8D7FF629E27D3B426AD36 /* LifeBoard/Presentation/ViewModels/Home/HomeTimelineEventSignature.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeTimelineEventSignature.swift; sourceTree = SOURCE_ROOT; };
+		4F244B959C35562023B24390 /* LifeBoard/Onboarding/Components/OnboardingHomeDemoPreview.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingHomeDemoPreview.swift; sourceTree = SOURCE_ROOT; };
+		4F67F2F26774817EB86045D0 /* LifeBoard/Onboarding/Models/OnboardingPromptGlassPanelModifier.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingPromptGlassPanelModifier.swift; sourceTree = SOURCE_ROOT; };
+		4F8E82EED2FB2D349E9F3BE9 /* LifeBoard/Presentation/ViewModels/Home/FocusPinResult.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/FocusPinResult.swift; sourceTree = SOURCE_ROOT; };
+		4FAA78F353FFECD73FA8011A /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineTaskMarkerLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineTaskMarkerLayout.swift; sourceTree = SOURCE_ROOT; };
 		4FCA458CC709E59AA20BC5C8 /* NextActionModule.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NextActionModule.swift; sourceTree = "<group>"; };
-		4FF17DADC7AB95846135B2EE /* TimelineCanvasLayoutPlan.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineCanvasLayoutPlan.swift; sourceTree = SOURCE_ROOT; };
-		5082229527A40A436284F69E /* HomeViewModel+ReloadPipeline.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+ReloadPipeline.swift"; sourceTree = SOURCE_ROOT; };
-		509DC1C9038663BEFE00C96F /* ChatEmptyStateView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Chrome/ChatEmptyStateView.swift; sourceTree = SOURCE_ROOT; };
-		50AA42860707B829E6114218 /* lifeManagementResolvedColor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/lifeManagementResolvedColor.swift; sourceTree = SOURCE_ROOT; };
-		50AA968766A5349A2BB45C61 /* OnboardingSelectableDetailCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingSelectableDetailCard.swift; sourceTree = SOURCE_ROOT; };
-		510B0D69D4D3766C988BF637 /* OverdueRescueDecisionAction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDecisionAction.swift; sourceTree = SOURCE_ROOT; };
-		51669681D49905D56C3864BD /* SunriseTimelineSurface+PlacementHelpers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Timeline/Surface/SunriseTimelineSurface+PlacementHelpers.swift"; sourceTree = SOURCE_ROOT; };
-		51840B6F63D4405BC246D786 /* AreaListRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/AreaListRow.swift; sourceTree = SOURCE_ROOT; };
-		5199C25A108D3EDC5DD5E0D9 /* CelebrationEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/CelebrationEvent.swift; sourceTree = SOURCE_ROOT; };
-		51A57B08A1BB4BC36FE63B9B /* OverdueRescueBackCards.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueBackCards.swift; sourceTree = SOURCE_ROOT; };
-		525792156B7DB238F8089667 /* QuietTrackingRailStreakWidget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Shell/SunriseAppShell/QuietTrackingRailStreakWidget.swift; sourceTree = SOURCE_ROOT; };
-		526C43C6A27A7D7271C5528E /* TimelineBottomProtectionBudget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineBottomProtectionBudget.swift; sourceTree = SOURCE_ROOT; };
-		52AE529746E4CDD7FB4A8C95 /* TimelineStreamInfluence.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamInfluence.swift; sourceTree = SOURCE_ROOT; };
+		4FF17DADC7AB95846135B2EE /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCanvasLayoutPlan.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineCanvasLayoutPlan.swift; sourceTree = SOURCE_ROOT; };
+		5082229527A40A436284F69E /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+ReloadPipeline.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+ReloadPipeline.swift"; sourceTree = SOURCE_ROOT; };
+		509DC1C9038663BEFE00C96F /* LifeBoard/LLM/Views/Chat/Chrome/ChatEmptyStateView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Chrome/ChatEmptyStateView.swift; sourceTree = SOURCE_ROOT; };
+		50AA42860707B829E6114218 /* LifeBoard/Views/Settings/LifeManagement/lifeManagementResolvedColor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/lifeManagementResolvedColor.swift; sourceTree = SOURCE_ROOT; };
+		50AA968766A5349A2BB45C61 /* LifeBoard/Onboarding/Components/OnboardingSelectableDetailCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingSelectableDetailCard.swift; sourceTree = SOURCE_ROOT; };
+		510B0D69D4D3766C988BF637 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDecisionAction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDecisionAction.swift; sourceTree = SOURCE_ROOT; };
+		51669681D49905D56C3864BD /* LifeBoard/Presentation/Home/Timeline/Surface/SunriseTimelineSurface+PlacementHelpers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Timeline/Surface/SunriseTimelineSurface+PlacementHelpers.swift"; sourceTree = SOURCE_ROOT; };
+		51840B6F63D4405BC246D786 /* LifeBoard/Views/Settings/LifeManagement/AreaListRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/AreaListRow.swift; sourceTree = SOURCE_ROOT; };
+		5199C25A108D3EDC5DD5E0D9 /* LifeBoard/Presentation/ViewModels/Home/CelebrationEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/CelebrationEvent.swift; sourceTree = SOURCE_ROOT; };
+		51A57B08A1BB4BC36FE63B9B /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueBackCards.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueBackCards.swift; sourceTree = SOURCE_ROOT; };
+		525792156B7DB238F8089667 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/QuietTrackingRailStreakWidget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Shell/SunriseAppShell/QuietTrackingRailStreakWidget.swift; sourceTree = SOURCE_ROOT; };
+		526C43C6A27A7D7271C5528E /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineBottomProtectionBudget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineBottomProtectionBudget.swift; sourceTree = SOURCE_ROOT; };
+		52AE529746E4CDD7FB4A8C95 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamInfluence.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamInfluence.swift; sourceTree = SOURCE_ROOT; };
 		52E1464E13744427AAFDF824 /* TaskDetailComponents.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TaskDetailComponents.swift; sourceTree = "<group>"; };
-		52EDFF0556DE6F60CD19AA39 /* InsightsViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/InsightsViewModel.swift; sourceTree = SOURCE_ROOT; };
-		533CCDBADB8997DD528CFE0A /* lifeManagementAreaIconLabel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/lifeManagementAreaIconLabel.swift; sourceTree = SOURCE_ROOT; };
-		53C94956D526284966A1EEDC /* LocalNotificationService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Services/LocalNotificationService.swift; sourceTree = SOURCE_ROOT; };
-		5495D17B3F94C89D74CD407E /* HomeViewModel+StateUtilities.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+StateUtilities.swift"; sourceTree = SOURCE_ROOT; };
-		549A929D15B98C035C74BD90 /* TimelineStreamGeometry+MassClustering.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamGeometry+MassClustering.swift"; sourceTree = SOURCE_ROOT; };
-		54D0BEA667E2738CDF713A68 /* InsightsLaunchRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/InsightsLaunchRequest.swift; sourceTree = SOURCE_ROOT; };
-		55440275F14F44B2492C3CAC /* timelineGapPromptText.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/timelineGapPromptText.swift; sourceTree = SOURCE_ROOT; };
+		52EDFF0556DE6F60CD19AA39 /* LifeBoard/Presentation/ViewModels/InsightsViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/InsightsViewModel.swift; sourceTree = SOURCE_ROOT; };
+		533CCDBADB8997DD528CFE0A /* LifeBoard/Views/Settings/LifeManagement/lifeManagementAreaIconLabel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/lifeManagementAreaIconLabel.swift; sourceTree = SOURCE_ROOT; };
+		53C94956D526284966A1EEDC /* LifeBoard/Services/LocalNotificationService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Services/LocalNotificationService.swift; sourceTree = SOURCE_ROOT; };
+		5495D17B3F94C89D74CD407E /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+StateUtilities.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+StateUtilities.swift"; sourceTree = SOURCE_ROOT; };
+		549A929D15B98C035C74BD90 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamGeometry+MassClustering.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamGeometry+MassClustering.swift"; sourceTree = SOURCE_ROOT; };
+		54D0BEA667E2738CDF713A68 /* LifeBoard/Presentation/ViewModels/Home/InsightsLaunchRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/InsightsLaunchRequest.swift; sourceTree = SOURCE_ROOT; };
+		55440275F14F44B2492C3CAC /* LifeBoard/Presentation/Home/Timeline/Surface/timelineGapPromptText.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/timelineGapPromptText.swift; sourceTree = SOURCE_ROOT; };
 		55C5A46909EF46C27D7B84E3 /* SavedHomeViewRepositoryProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SavedHomeViewRepositoryProtocol.swift; sourceTree = "<group>"; };
-		56A37591A5FBC6DAD9309A0E /* EvaDayHabitActionsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitActionsView.swift; sourceTree = SOURCE_ROOT; };
-		571642516EA3BF4BB335B24A /* OverdueRescueSessionStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSessionStore.swift; sourceTree = SOURCE_ROOT; };
-		583A0C544A5AEEE50CB3B870 /* OverdueRescueCompletionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueCompletionView.swift; sourceTree = SOURCE_ROOT; };
-		592346DCA3C3FE56E12617C2 /* TaskDefinitionMapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Mappers/TaskDefinitionMapper.swift; sourceTree = SOURCE_ROOT; };
+		56A37591A5FBC6DAD9309A0E /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitActionsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitActionsView.swift; sourceTree = SOURCE_ROOT; };
+		571642516EA3BF4BB335B24A /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSessionStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSessionStore.swift; sourceTree = SOURCE_ROOT; };
+		583A0C544A5AEEE50CB3B870 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueCompletionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueCompletionView.swift; sourceTree = SOURCE_ROOT; };
+		592346DCA3C3FE56E12617C2 /* LifeBoard/Domain/Mappers/TaskDefinitionMapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Mappers/TaskDefinitionMapper.swift; sourceTree = SOURCE_ROOT; };
 		594ECD331C0135DA36357314 /* SunriseAdvancedFilterSheetView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SunriseAdvancedFilterSheetView.swift; sourceTree = "<group>"; };
-		598CD23D633F1DA652C429A5 /* OnboardingInlineBadge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingInlineBadge.swift; sourceTree = SOURCE_ROOT; };
-		5991B0FA3A61ED01648C82AC /* HomeViewModel+InsightsLaunch.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+InsightsLaunch.swift"; sourceTree = SOURCE_ROOT; };
+		598CD23D633F1DA652C429A5 /* LifeBoard/Onboarding/Models/OnboardingInlineBadge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingInlineBadge.swift; sourceTree = SOURCE_ROOT; };
+		5991B0FA3A61ED01648C82AC /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+InsightsLaunch.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+InsightsLaunch.swift"; sourceTree = SOURCE_ROOT; };
 		5A05E16369BC6D8B09B0D460 /* HomeQuickFilterTriggerButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeQuickFilterTriggerButton.swift; sourceTree = "<group>"; };
-		5A1DE5B5363A7EED7AF42BC8 /* HomeViewModel+SectionProjection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+SectionProjection.swift"; sourceTree = SOURCE_ROOT; };
-		5A7FAC655E04AFF0711F5AD2 /* OnboardingFlowModel+NavigationPersistence.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Onboarding/Services/OnboardingFlowModel+NavigationPersistence.swift"; sourceTree = SOURCE_ROOT; };
-		5AA802C6A00F24E4A28E8E77 /* OnboardingCinematicBackdrop.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingCinematicBackdrop.swift; sourceTree = SOURCE_ROOT; };
-		5B1528CAF56D71468F82A432 /* TimelineRoutineTextFormatter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineRoutineTextFormatter.swift; sourceTree = SOURCE_ROOT; };
-		5B274BA1A3D3146A9178FFC7 /* OnboardingAccessibilityMarker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingAccessibilityMarker.swift; sourceTree = SOURCE_ROOT; };
-		5B59067D0E3C92CC8F6B5A1B /* TimelineFlockRowView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineFlockRowView.swift; sourceTree = SOURCE_ROOT; };
-		5BD755574209F1D4DACEFE20 /* LifeManagementComposerRoute.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerRoute.swift; sourceTree = SOURCE_ROOT; };
-		5C959E191431AD6350132F1D /* LifeManagementProjectComposerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementProjectComposerView.swift; sourceTree = SOURCE_ROOT; };
+		5A1DE5B5363A7EED7AF42BC8 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+SectionProjection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+SectionProjection.swift"; sourceTree = SOURCE_ROOT; };
+		5A7FAC655E04AFF0711F5AD2 /* LifeBoard/Onboarding/Services/OnboardingFlowModel+NavigationPersistence.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Onboarding/Services/OnboardingFlowModel+NavigationPersistence.swift"; sourceTree = SOURCE_ROOT; };
+		5AA802C6A00F24E4A28E8E77 /* LifeBoard/Onboarding/Components/OnboardingCinematicBackdrop.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingCinematicBackdrop.swift; sourceTree = SOURCE_ROOT; };
+		5B1528CAF56D71468F82A432 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineRoutineTextFormatter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineRoutineTextFormatter.swift; sourceTree = SOURCE_ROOT; };
+		5B274BA1A3D3146A9178FFC7 /* LifeBoard/Onboarding/Models/OnboardingAccessibilityMarker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingAccessibilityMarker.swift; sourceTree = SOURCE_ROOT; };
+		5B59067D0E3C92CC8F6B5A1B /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineFlockRowView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineFlockRowView.swift; sourceTree = SOURCE_ROOT; };
+		5BD755574209F1D4DACEFE20 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerRoute.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerRoute.swift; sourceTree = SOURCE_ROOT; };
+		5C959E191431AD6350132F1D /* LifeBoard/Views/Settings/LifeManagement/LifeManagementProjectComposerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementProjectComposerView.swift; sourceTree = SOURCE_ROOT; };
 		5DA1D87ADF956BED887FE0CC /* LifeBoardThemeManagerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoardThemeManagerTests.swift; sourceTree = "<group>"; };
-		5DEE0B3DA1576389071E8CEA /* LifeManagementAreaIconPicker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementAreaIconPicker.swift; sourceTree = SOURCE_ROOT; };
+		5DEE0B3DA1576389071E8CEA /* LifeBoard/Views/Settings/LifeManagement/LifeManagementAreaIconPicker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementAreaIconPicker.swift; sourceTree = SOURCE_ROOT; };
 		5E5E75330E627DA9E1626E6A /* HomeViewModel+ViewState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "HomeViewModel+ViewState.swift"; sourceTree = "<group>"; };
-		5E7A10000000000000000002 /* SunriseInsightsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/View/Insights/SunriseInsightsView.swift; sourceTree = SOURCE_ROOT; };
+		5E7A10000000000000000002 /* LifeBoard/View/Insights/SunriseInsightsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/View/Insights/SunriseInsightsView.swift; sourceTree = SOURCE_ROOT; };
 		5E7A20000000000000000002 /* SunriseInsightsHeaderView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SunriseInsightsHeaderView.swift; sourceTree = "<group>"; };
 		5E7A20000000000000000004 /* SunriseInsightsHeroCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SunriseInsightsHeroCard.swift; sourceTree = "<group>"; };
-		5EA1722FAD5507224C2ED584 /* TimelineFormatting.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineFormatting.swift; sourceTree = SOURCE_ROOT; };
-		5F09F509547AC4BD86E3CC9A /* LifeManagementView+DetailsComposerAndOverlays.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Views/Settings/LifeManagement/LifeManagementView+DetailsComposerAndOverlays.swift"; sourceTree = SOURCE_ROOT; };
-		5F2067B7B6ACA2A4A2DA6279 /* OnboardingFilterChip.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingFilterChip.swift; sourceTree = SOURCE_ROOT; };
-		5F98057DD16FA2790EB04A47 /* TimelineAgendaItemRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineAgendaItemRow.swift; sourceTree = SOURCE_ROOT; };
+		5EA1722FAD5507224C2ED584 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineFormatting.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineFormatting.swift; sourceTree = SOURCE_ROOT; };
+		5F09F509547AC4BD86E3CC9A /* LifeBoard/Views/Settings/LifeManagement/LifeManagementView+DetailsComposerAndOverlays.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Views/Settings/LifeManagement/LifeManagementView+DetailsComposerAndOverlays.swift"; sourceTree = SOURCE_ROOT; };
+		5F2067B7B6ACA2A4A2DA6279 /* LifeBoard/Onboarding/Components/OnboardingFilterChip.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingFilterChip.swift; sourceTree = SOURCE_ROOT; };
+		5F98057DD16FA2790EB04A47 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineAgendaItemRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineAgendaItemRow.swift; sourceTree = SOURCE_ROOT; };
 		607D98C13538414095C75E7B /* AddTaskMetadataRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTaskMetadataRow.swift; sourceTree = "<group>"; };
-		608542355F067EA88F7E716F /* SunriseAppShellView+ObserversSearchAndBackdrop.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+ObserversSearchAndBackdrop.swift"; sourceTree = SOURCE_ROOT; };
+		608542355F067EA88F7E716F /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+ObserversSearchAndBackdrop.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+ObserversSearchAndBackdrop.swift"; sourceTree = SOURCE_ROOT; };
 		60A322E21AF97D46F076D5C8 /* TimelineTimeBlock.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TimelineTimeBlock.swift; sourceTree = "<group>"; };
-		61B03639156A8E2D31701235 /* OnboardingPrimaryGoal.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingPrimaryGoal.swift; sourceTree = SOURCE_ROOT; };
-		61DB2B7298DBBD959D03B5D5 /* OnboardingDownloadStatusPill.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingDownloadStatusPill.swift; sourceTree = SOURCE_ROOT; };
-		6243658CCD3FA73A97B58600 /* ConversationView+LiveOutput.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/LLM/Views/Chat/Conversation/ConversationView+LiveOutput.swift"; sourceTree = SOURCE_ROOT; };
-		62AFC1C2CACBCE0FD8CD0EB9 /* DailyTimelineCanvas+RailAndCanvas.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Timeline/Surface/DailyTimelineCanvas+RailAndCanvas.swift"; sourceTree = SOURCE_ROOT; };
-		6396B895E176C6D9B55C30EC /* OnboardingOutcome.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingOutcome.swift; sourceTree = SOURCE_ROOT; };
-		6406FAAF5EBC202BFD7F2588 /* EvaChatSunriseGlass.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Chrome/EvaChatSunriseGlass.swift; sourceTree = SOURCE_ROOT; };
-		6425309F28BBC7C61C9C58F3 /* SunriseHomeDatePickerPopover.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseHomeDatePickerPopover.swift; sourceTree = SOURCE_ROOT; };
+		61B03639156A8E2D31701235 /* LifeBoard/Onboarding/Models/OnboardingPrimaryGoal.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingPrimaryGoal.swift; sourceTree = SOURCE_ROOT; };
+		61DB2B7298DBBD959D03B5D5 /* LifeBoard/Onboarding/Models/OnboardingDownloadStatusPill.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingDownloadStatusPill.swift; sourceTree = SOURCE_ROOT; };
+		6243658CCD3FA73A97B58600 /* LifeBoard/LLM/Views/Chat/Conversation/ConversationView+LiveOutput.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/LLM/Views/Chat/Conversation/ConversationView+LiveOutput.swift"; sourceTree = SOURCE_ROOT; };
+		62AFC1C2CACBCE0FD8CD0EB9 /* LifeBoard/Presentation/Home/Timeline/Surface/DailyTimelineCanvas+RailAndCanvas.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Timeline/Surface/DailyTimelineCanvas+RailAndCanvas.swift"; sourceTree = SOURCE_ROOT; };
+		6396B895E176C6D9B55C30EC /* LifeBoard/Onboarding/Models/OnboardingOutcome.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingOutcome.swift; sourceTree = SOURCE_ROOT; };
+		6406FAAF5EBC202BFD7F2588 /* LifeBoard/LLM/Views/Chat/Chrome/EvaChatSunriseGlass.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Chrome/EvaChatSunriseGlass.swift; sourceTree = SOURCE_ROOT; };
+		6425309F28BBC7C61C9C58F3 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseHomeDatePickerPopover.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseHomeDatePickerPopover.swift; sourceTree = SOURCE_ROOT; };
 		6442D619CAA8E6CA77B46126 /* LifeBoardTokens.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoardTokens.swift; sourceTree = "<group>"; };
-		6492AC4EA233D9F3AA0FAA30 /* TimelineCompactAnchorRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompactAnchorRow.swift; sourceTree = SOURCE_ROOT; };
-		655BA9C40207D74248D209EE /* TimelineTimeBlockCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineTimeBlockCard.swift; sourceTree = SOURCE_ROOT; };
+		6492AC4EA233D9F3AA0FAA30 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompactAnchorRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompactAnchorRow.swift; sourceTree = SOURCE_ROOT; };
+		655BA9C40207D74248D209EE /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineTimeBlockCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineTimeBlockCard.swift; sourceTree = SOURCE_ROOT; };
 		65A7A039AC9CA38845D1E44F /* SyncMergeState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SyncMergeState.swift; sourceTree = "<group>"; };
-		66890102B461937BC39F7607 /* HomeViewModel+FocusPins.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+FocusPins.swift"; sourceTree = SOURCE_ROOT; };
-		677222149F21BD5C04EE2EC2 /* HomeHabitMutationSectionPatch.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationSectionPatch.swift; sourceTree = SOURCE_ROOT; };
-		67726D5DDDEB64497FEB21C9 /* HomeReplanResolutionKind.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeReplanResolutionKind.swift; sourceTree = SOURCE_ROOT; };
-		683FBF4822AC0FD20D70E253 /* TimelineRailTimeFormatter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailTimeFormatter.swift; sourceTree = SOURCE_ROOT; };
-		687C38FA46273E45A8A46143 /* TimelineDenseTitleFormatter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineDenseTitleFormatter.swift; sourceTree = SOURCE_ROOT; };
-		68E8BC7F87ABDAD6C5B79CE0 /* OnboardingInlineActionRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingInlineActionRow.swift; sourceTree = SOURCE_ROOT; };
-		69507E47E2C799073FE4018A /* ManageLifeAreasUseCaseExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/ManageLifeAreasUseCaseExtension.swift; sourceTree = SOURCE_ROOT; };
-		6956BC00E9F0B0BC847DD7AA /* SectionMapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Mappers/SectionMapper.swift; sourceTree = SOURCE_ROOT; };
-		69B7C1A4EF10964C5EF4DC33 /* MessageView+CommandResultsAndUndo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/LLM/Views/Chat/Conversation/MessageView+CommandResultsAndUndo.swift"; sourceTree = SOURCE_ROOT; };
-		6A30108580052CC2C67D2058 /* HabitDefinition.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/HabitDefinition.swift; sourceTree = SOURCE_ROOT; };
-		6A85EFA2BA71673BE1DDF31C /* TimelineCanvasLayoutPlan+Positioning.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Timeline/Surface/TimelineCanvasLayoutPlan+Positioning.swift"; sourceTree = SOURCE_ROOT; };
-		6B6FB0479B78BDE0B210F2E8 /* HomeTimelineSnapshotCacheKey.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeTimelineSnapshotCacheKey.swift; sourceTree = SOURCE_ROOT; };
-		6C4934047F3DBEA1EF645AC1 /* OnboardingNetworkClass.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingNetworkClass.swift; sourceTree = SOURCE_ROOT; };
-		6D2BF6A90C40333A4450474A /* LifeManagementMenuLabel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementMenuLabel.swift; sourceTree = SOURCE_ROOT; };
-		6D63FBA200D736491232884A /* SunriseFocusSessionSummaryView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/View/SunriseFocusSessionSummaryView.swift; sourceTree = SOURCE_ROOT; };
-		6DA154258145A6BBE62580E5 /* TimelineItemVisuals.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineItemVisuals.swift; sourceTree = SOURCE_ROOT; };
-		6E411E9CDB93D4BE9EDC7EF0 /* EvaDayHabitRowView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitRowView.swift; sourceTree = SOURCE_ROOT; };
-		6E48DF58E65C9466AC4E2893 /* OnboardingFocusTimer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingFocusTimer.swift; sourceTree = SOURCE_ROOT; };
-		6E8131362E7A314733E26CDF /* OverdueRescueSafeFixesView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSafeFixesView.swift; sourceTree = SOURCE_ROOT; };
-		6F5CCCB595F2AED7845487FD /* HomeTimelineWorkspacePreferencesSignature.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeTimelineWorkspacePreferencesSignature.swift; sourceTree = SOURCE_ROOT; };
-		704D674D0BE292CD679FE13E /* SunriseAppShellView+FocusInsightsAndRouting.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+FocusInsightsAndRouting.swift"; sourceTree = SOURCE_ROOT; };
-		70CF1C88BCCEBC000C9FEC38 /* OnboardingNotificationNameExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingNotificationNameExtension.swift; sourceTree = SOURCE_ROOT; };
-		70EF7AB518C2C6E6AB41487E /* OverdueRescueLargeStackView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueLargeStackView.swift; sourceTree = SOURCE_ROOT; };
-		712BE2C322E8930A4886933B /* ScheduleRepositoryProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Interfaces/ScheduleRepositoryProtocol.swift; sourceTree = SOURCE_ROOT; };
-		7163B97F4D083B9AB6B24476 /* OnboardingJourneySnapshot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingJourneySnapshot.swift; sourceTree = SOURCE_ROOT; };
+		66890102B461937BC39F7607 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+FocusPins.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+FocusPins.swift"; sourceTree = SOURCE_ROOT; };
+		677222149F21BD5C04EE2EC2 /* LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationSectionPatch.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationSectionPatch.swift; sourceTree = SOURCE_ROOT; };
+		67726D5DDDEB64497FEB21C9 /* LifeBoard/Presentation/ViewModels/Home/HomeReplanResolutionKind.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeReplanResolutionKind.swift; sourceTree = SOURCE_ROOT; };
+		683FBF4822AC0FD20D70E253 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailTimeFormatter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailTimeFormatter.swift; sourceTree = SOURCE_ROOT; };
+		687C38FA46273E45A8A46143 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineDenseTitleFormatter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineDenseTitleFormatter.swift; sourceTree = SOURCE_ROOT; };
+		68E8BC7F87ABDAD6C5B79CE0 /* LifeBoard/Onboarding/Components/OnboardingInlineActionRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingInlineActionRow.swift; sourceTree = SOURCE_ROOT; };
+		69507E47E2C799073FE4018A /* LifeBoard/Onboarding/Models/ManageLifeAreasUseCaseExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/ManageLifeAreasUseCaseExtension.swift; sourceTree = SOURCE_ROOT; };
+		6956BC00E9F0B0BC847DD7AA /* LifeBoard/Domain/Mappers/SectionMapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Mappers/SectionMapper.swift; sourceTree = SOURCE_ROOT; };
+		69B7C1A4EF10964C5EF4DC33 /* LifeBoard/LLM/Views/Chat/Conversation/MessageView+CommandResultsAndUndo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/LLM/Views/Chat/Conversation/MessageView+CommandResultsAndUndo.swift"; sourceTree = SOURCE_ROOT; };
+		6A30108580052CC2C67D2058 /* LifeBoard/Domain/Models/HabitDefinition.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/HabitDefinition.swift; sourceTree = SOURCE_ROOT; };
+		6A85EFA2BA71673BE1DDF31C /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCanvasLayoutPlan+Positioning.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Timeline/Surface/TimelineCanvasLayoutPlan+Positioning.swift"; sourceTree = SOURCE_ROOT; };
+		6B6FB0479B78BDE0B210F2E8 /* LifeBoard/Presentation/ViewModels/Home/HomeTimelineSnapshotCacheKey.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeTimelineSnapshotCacheKey.swift; sourceTree = SOURCE_ROOT; };
+		6C4934047F3DBEA1EF645AC1 /* LifeBoard/Onboarding/Models/OnboardingNetworkClass.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingNetworkClass.swift; sourceTree = SOURCE_ROOT; };
+		6D2BF6A90C40333A4450474A /* LifeBoard/Views/Settings/LifeManagement/LifeManagementMenuLabel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementMenuLabel.swift; sourceTree = SOURCE_ROOT; };
+		6D63FBA200D736491232884A /* LifeBoard/View/SunriseFocusSessionSummaryView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/View/SunriseFocusSessionSummaryView.swift; sourceTree = SOURCE_ROOT; };
+		6DA154258145A6BBE62580E5 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineItemVisuals.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineItemVisuals.swift; sourceTree = SOURCE_ROOT; };
+		6E411E9CDB93D4BE9EDC7EF0 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitRowView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitRowView.swift; sourceTree = SOURCE_ROOT; };
+		6E48DF58E65C9466AC4E2893 /* LifeBoard/Onboarding/Models/OnboardingFocusTimer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingFocusTimer.swift; sourceTree = SOURCE_ROOT; };
+		6E8131362E7A314733E26CDF /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSafeFixesView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSafeFixesView.swift; sourceTree = SOURCE_ROOT; };
+		6F5CCCB595F2AED7845487FD /* LifeBoard/Presentation/ViewModels/Home/HomeTimelineWorkspacePreferencesSignature.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeTimelineWorkspacePreferencesSignature.swift; sourceTree = SOURCE_ROOT; };
+		704D674D0BE292CD679FE13E /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+FocusInsightsAndRouting.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+FocusInsightsAndRouting.swift"; sourceTree = SOURCE_ROOT; };
+		70CF1C88BCCEBC000C9FEC38 /* LifeBoard/Onboarding/Models/OnboardingNotificationNameExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingNotificationNameExtension.swift; sourceTree = SOURCE_ROOT; };
+		70EF7AB518C2C6E6AB41487E /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueLargeStackView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueLargeStackView.swift; sourceTree = SOURCE_ROOT; };
+		712BE2C322E8930A4886933B /* LifeBoard/Domain/Interfaces/ScheduleRepositoryProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Interfaces/ScheduleRepositoryProtocol.swift; sourceTree = SOURCE_ROOT; };
+		7163B97F4D083B9AB6B24476 /* LifeBoard/Onboarding/Models/OnboardingJourneySnapshot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingJourneySnapshot.swift; sourceTree = SOURCE_ROOT; };
 		718216D68E8278668DDB49BC /* SettingsFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsFooterView.swift; sourceTree = "<group>"; };
-		71FDD1869D0A6C117882AD37 /* SchedulingEngineProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Interfaces/SchedulingEngineProtocol.swift; sourceTree = SOURCE_ROOT; };
+		71FDD1869D0A6C117882AD37 /* LifeBoard/Domain/Interfaces/SchedulingEngineProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Interfaces/SchedulingEngineProtocol.swift; sourceTree = SOURCE_ROOT; };
 		7273F65E17455922134AB7A9 /* QuietHoursTimeBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuietHoursTimeBar.swift; sourceTree = "<group>"; };
-		72A5D667C54915B85FDEAA65 /* HomeHabitMutationSnapshot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationSnapshot.swift; sourceTree = SOURCE_ROOT; };
-		72FC1B3486FA846731E8FCE6 /* ResolveHabitOccurrenceUseCaseExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/ResolveHabitOccurrenceUseCaseExtension.swift; sourceTree = SOURCE_ROOT; };
-		73F5AC60FF99A3BFD8D843C7 /* TimelineUtilityItemExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineUtilityItemExtension.swift; sourceTree = SOURCE_ROOT; };
-		7433F7F7707CF6A0DA1A58B2 /* LifeManagementComposerSectionCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerSectionCard.swift; sourceTree = SOURCE_ROOT; };
-		74615C475C9EB3F67E96D7FE /* OccurrenceRepositoryProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Interfaces/OccurrenceRepositoryProtocol.swift; sourceTree = SOURCE_ROOT; };
-		74E0C50451A57E60BB0E3EC8 /* OnboardingFrictionSelector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingFrictionSelector.swift; sourceTree = SOURCE_ROOT; };
+		72A5D667C54915B85FDEAA65 /* LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationSnapshot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationSnapshot.swift; sourceTree = SOURCE_ROOT; };
+		72FC1B3486FA846731E8FCE6 /* LifeBoard/Onboarding/Models/ResolveHabitOccurrenceUseCaseExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/ResolveHabitOccurrenceUseCaseExtension.swift; sourceTree = SOURCE_ROOT; };
+		73F5AC60FF99A3BFD8D843C7 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineUtilityItemExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineUtilityItemExtension.swift; sourceTree = SOURCE_ROOT; };
+		7433F7F7707CF6A0DA1A58B2 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerSectionCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerSectionCard.swift; sourceTree = SOURCE_ROOT; };
+		74615C475C9EB3F67E96D7FE /* LifeBoard/Domain/Interfaces/OccurrenceRepositoryProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Interfaces/OccurrenceRepositoryProtocol.swift; sourceTree = SOURCE_ROOT; };
+		74E0C50451A57E60BB0E3EC8 /* LifeBoard/Onboarding/Components/OnboardingFrictionSelector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingFrictionSelector.swift; sourceTree = SOURCE_ROOT; };
 		75018BB42E8D0C7C00EA3D0D /* AnalyticsServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsServiceProtocol.swift; sourceTree = "<group>"; };
 		750894C92E8D3C390037FACE /* AnalyticsRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsRepositoryProtocol.swift; sourceTree = "<group>"; };
 		7509A00A2F13D806009162CD /* PresentationDependencyContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationDependencyContainer.swift; sourceTree = "<group>"; };
@@ -1588,7 +1589,7 @@
 		75D8274A2E8C8995000F04E1 /* NotificationServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationServiceProtocol.swift; sourceTree = "<group>"; };
 		75D8274B2E8C8995000F04E1 /* UserRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRepositoryProtocol.swift; sourceTree = "<group>"; };
 		75D827522E8C89BA000F04E1 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
-		75DD317FAC37A8674392A5B6 /* CodingKeys2.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/CodingKeys2.swift; sourceTree = SOURCE_ROOT; };
+		75DD317FAC37A8674392A5B6 /* LifeBoard/Onboarding/Models/CodingKeys2.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/CodingKeys2.swift; sourceTree = SOURCE_ROOT; };
 		75DFF2D32DF22FC300EB8850 /* DateUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateUtils.swift; sourceTree = "<group>"; };
 		75DFF2D42DF22FC300EB8850 /* LoggingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingService.swift; sourceTree = "<group>"; };
 		75E9299B2E8C5C2D00207270 /* UIImage+Resize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Resize.swift"; sourceTree = "<group>"; };
@@ -1644,181 +1645,181 @@
 		75F9937D24859ADB00C340EB /* HomeBottomBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeBottomBarView.swift; sourceTree = "<group>"; };
 		75F9937F2485B04200C340EB /* Score.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Score.swift; sourceTree = "<group>"; };
 		7606FC61CBCCB93B45FC616D /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		76771B9AECD05123393780BE /* ProjectListRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/ProjectListRow.swift; sourceTree = SOURCE_ROOT; };
-		7694AF03A3EBC6AF9B70F6D5 /* TimelineEndAddMarker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineEndAddMarker.swift; sourceTree = SOURCE_ROOT; };
-		77551CB92362A8FB48666198 /* TimelineEmptyStateCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineEmptyStateCard.swift; sourceTree = SOURCE_ROOT; };
-		77DC1194E3FDC7C550953B31 /* HomeRenderInvalidation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeRenderInvalidation.swift; sourceTree = SOURCE_ROOT; };
-		77F82FC408C33F7C6D11BC93 /* OnboardingTaskRecommendationCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingTaskRecommendationCard.swift; sourceTree = SOURCE_ROOT; };
-		782F77DA4E5822C3A8AF4305 /* StarterProjectTemplate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/StarterProjectTemplate.swift; sourceTree = SOURCE_ROOT; };
-		786CACDAB366EB8BCBB657A3 /* HomeDenseSurfaceModifier.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeDenseSurfaceModifier.swift; sourceTree = SOURCE_ROOT; };
-		78AC645DDBDFE8BDCA4826F7 /* OverdueRescueVisualSpec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueVisualSpec.swift; sourceTree = SOURCE_ROOT; };
-		78CBCB775F9593EF36C11AB8 /* AppOnboardingBackground.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Views/AppOnboardingBackground.swift; sourceTree = SOURCE_ROOT; };
-		78DF4503F0438173C6DC91B8 /* OnboardingPressScaleButtonStyle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingPressScaleButtonStyle.swift; sourceTree = SOURCE_ROOT; };
-		793E605571E4D4EDFCC2E4DE /* OverdueRescueDragResolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDragResolver.swift; sourceTree = SOURCE_ROOT; };
-		79E40B0ED12A11ACC6A161C8 /* AppGroupConstants.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Shared/AppGroupConstants.swift; sourceTree = SOURCE_ROOT; };
-		79F16587DB80654C936066F5 /* TimelineOverlapClusterCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineOverlapClusterCard.swift; sourceTree = SOURCE_ROOT; };
-		79F6BFD855ABC89559135C56 /* OverdueRescueActionGrid.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueActionGrid.swift; sourceTree = SOURCE_ROOT; };
+		76771B9AECD05123393780BE /* LifeBoard/Views/Settings/LifeManagement/ProjectListRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/ProjectListRow.swift; sourceTree = SOURCE_ROOT; };
+		7694AF03A3EBC6AF9B70F6D5 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineEndAddMarker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineEndAddMarker.swift; sourceTree = SOURCE_ROOT; };
+		77551CB92362A8FB48666198 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineEmptyStateCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineEmptyStateCard.swift; sourceTree = SOURCE_ROOT; };
+		77DC1194E3FDC7C550953B31 /* LifeBoard/Presentation/ViewModels/Home/HomeRenderInvalidation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeRenderInvalidation.swift; sourceTree = SOURCE_ROOT; };
+		77F82FC408C33F7C6D11BC93 /* LifeBoard/Onboarding/Components/OnboardingTaskRecommendationCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingTaskRecommendationCard.swift; sourceTree = SOURCE_ROOT; };
+		782F77DA4E5822C3A8AF4305 /* LifeBoard/Onboarding/Models/StarterProjectTemplate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/StarterProjectTemplate.swift; sourceTree = SOURCE_ROOT; };
+		786CACDAB366EB8BCBB657A3 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeDenseSurfaceModifier.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeDenseSurfaceModifier.swift; sourceTree = SOURCE_ROOT; };
+		78AC645DDBDFE8BDCA4826F7 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueVisualSpec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueVisualSpec.swift; sourceTree = SOURCE_ROOT; };
+		78CBCB775F9593EF36C11AB8 /* LifeBoard/Onboarding/Views/AppOnboardingBackground.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Views/AppOnboardingBackground.swift; sourceTree = SOURCE_ROOT; };
+		78DF4503F0438173C6DC91B8 /* LifeBoard/Onboarding/Components/OnboardingPressScaleButtonStyle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingPressScaleButtonStyle.swift; sourceTree = SOURCE_ROOT; };
+		793E605571E4D4EDFCC2E4DE /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDragResolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDragResolver.swift; sourceTree = SOURCE_ROOT; };
+		79E40B0ED12A11ACC6A161C8 /* Shared/AppGroupConstants.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Shared/AppGroupConstants.swift; sourceTree = SOURCE_ROOT; };
+		79F16587DB80654C936066F5 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineOverlapClusterCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineOverlapClusterCard.swift; sourceTree = SOURCE_ROOT; };
+		79F6BFD855ABC89559135C56 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueActionGrid.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueActionGrid.swift; sourceTree = SOURCE_ROOT; };
 		7A10E0B067197D4A32724B9F /* HomeViewController+OnboardingAdapter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "HomeViewController+OnboardingAdapter.swift"; sourceTree = "<group>"; };
 		7ADDF7126AA32EF840CE257C /* SpacingElevationCornerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SpacingElevationCornerTests.swift; sourceTree = "<group>"; };
-		7AE36332DC107A6F5A9A4AF2 /* HabitSummaryRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/HabitSummaryRow.swift; sourceTree = SOURCE_ROOT; };
+		7AE36332DC107A6F5A9A4AF2 /* LifeBoard/Views/Settings/LifeManagement/HabitSummaryRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/HabitSummaryRow.swift; sourceTree = SOURCE_ROOT; };
 		7B2B9CCE514C217DC9C76773 /* WatchWidgetSnapshotSync.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WatchWidgetSnapshotSync.swift; sourceTree = "<group>"; };
 		7B3C9A7D2F2B0F1A00D4C112 /* FocusNowSimplificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusNowSimplificationTests.swift; sourceTree = "<group>"; };
-		7B6CF6BCC0828B64D4447931 /* timelineAccessibilityIdentifier.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/timelineAccessibilityIdentifier.swift; sourceTree = SOURCE_ROOT; };
-		7B6F00C3944DB39EBB0DDA55 /* HomeCalendarEventDetailSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeCalendarEventDetailSheet.swift; sourceTree = SOURCE_ROOT; };
-		7C900006EE1DF0BACD33342B /* Achievement.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/Achievement.swift; sourceTree = SOURCE_ROOT; };
-		7C915FFCD3814E051A506B72 /* InsightsTabView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/View/Insights/InsightsTabView.swift; sourceTree = SOURCE_ROOT; };
-		7CC4B584282446580AA72B44 /* FocusSessionUseCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Gamification/FocusSessionUseCase.swift; sourceTree = SOURCE_ROOT; };
+		7B6CF6BCC0828B64D4447931 /* LifeBoard/Presentation/Home/Timeline/Surface/timelineAccessibilityIdentifier.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/timelineAccessibilityIdentifier.swift; sourceTree = SOURCE_ROOT; };
+		7B6F00C3944DB39EBB0DDA55 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeCalendarEventDetailSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeCalendarEventDetailSheet.swift; sourceTree = SOURCE_ROOT; };
+		7C900006EE1DF0BACD33342B /* LifeBoard/Domain/Models/Achievement.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/Achievement.swift; sourceTree = SOURCE_ROOT; };
+		7C915FFCD3814E051A506B72 /* LifeBoard/View/Insights/InsightsTabView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/View/Insights/InsightsTabView.swift; sourceTree = SOURCE_ROOT; };
+		7CC4B584282446580AA72B44 /* LifeBoard/UseCases/Gamification/FocusSessionUseCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Gamification/FocusSessionUseCase.swift; sourceTree = SOURCE_ROOT; };
 		7D6A566DA8BAF8C85BE11CE5 /* Pods-LifeBoardTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LifeBoardTests.release.xcconfig"; path = "Target Support Files/Pods-LifeBoardTests/Pods-LifeBoardTests.release.xcconfig"; sourceTree = "<group>"; };
-		7DD613471ECDE5AFB1BB199B /* ScheduleReminderUseCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Reminder/ScheduleReminderUseCase.swift; sourceTree = SOURCE_ROOT; };
-		7DDAE6004CD5111C2C273E69 /* OverdueRescueSwipeHint.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSwipeHint.swift; sourceTree = SOURCE_ROOT; };
-		7E2736E49AF3234FCB39F354 /* TimelineStemSegments.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineStemSegments.swift; sourceTree = SOURCE_ROOT; };
-		7E3E682A3285FAAED37BACB0 /* OverdueRescueRevealPanel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueRevealPanel.swift; sourceTree = SOURCE_ROOT; };
-		7F1B2C3D4E5F60718293A4B6 /* GamificationRemoteKillSwitchService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Services/GamificationRemoteKillSwitchService.swift; sourceTree = SOURCE_ROOT; };
-		7F1B2C3D4E5F60718293A4B8 /* LiquidMetalCTARemoteConfigService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Services/LiquidMetalCTARemoteConfigService.swift; sourceTree = SOURCE_ROOT; };
-		7F70E654847A2B4F0458F49F /* OnboardingSelectionSummaryCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingSelectionSummaryCard.swift; sourceTree = SOURCE_ROOT; };
+		7DD613471ECDE5AFB1BB199B /* LifeBoard/UseCases/Reminder/ScheduleReminderUseCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Reminder/ScheduleReminderUseCase.swift; sourceTree = SOURCE_ROOT; };
+		7DDAE6004CD5111C2C273E69 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSwipeHint.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSwipeHint.swift; sourceTree = SOURCE_ROOT; };
+		7E2736E49AF3234FCB39F354 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStemSegments.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineStemSegments.swift; sourceTree = SOURCE_ROOT; };
+		7E3E682A3285FAAED37BACB0 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueRevealPanel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueRevealPanel.swift; sourceTree = SOURCE_ROOT; };
+		7F1B2C3D4E5F60718293A4B6 /* LifeBoard/Services/GamificationRemoteKillSwitchService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Services/GamificationRemoteKillSwitchService.swift; sourceTree = SOURCE_ROOT; };
+		7F1B2C3D4E5F60718293A4B8 /* LifeBoard/Services/LiquidMetalCTARemoteConfigService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Services/LiquidMetalCTARemoteConfigService.swift; sourceTree = SOURCE_ROOT; };
+		7F70E654847A2B4F0458F49F /* LifeBoard/Onboarding/Components/OnboardingSelectionSummaryCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingSelectionSummaryCard.swift; sourceTree = SOURCE_ROOT; };
 		7F7676A13058C4757D1E2718 /* SavedHomeView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SavedHomeView.swift; sourceTree = "<group>"; };
 		7FA441E9098F3D735062B78C /* LifeBoardWatchWidgets.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = LifeBoardWatchWidgets.appex; sourceTree = BUILT_PRODUCTS_DIR; };
-		8037E33E14B5471548D66C82 /* OnboardingFeedbackController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Services/OnboardingFeedbackController.swift; sourceTree = SOURCE_ROOT; };
-		80785BB956EE3DB3802D9858 /* TimelineGapPrompt.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineGapPrompt.swift; sourceTree = SOURCE_ROOT; };
-		80E4F64519A39289AF03A73C /* OnboardingHabitTemplateState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingHabitTemplateState.swift; sourceTree = SOURCE_ROOT; };
-		80EEB0762BB49B5983079AF3 /* MessageView+EvaProposalAndDayOverview.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/LLM/Views/Chat/Conversation/MessageView+EvaProposalAndDayOverview.swift"; sourceTree = SOURCE_ROOT; };
+		8037E33E14B5471548D66C82 /* LifeBoard/Onboarding/Services/OnboardingFeedbackController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Services/OnboardingFeedbackController.swift; sourceTree = SOURCE_ROOT; };
+		80785BB956EE3DB3802D9858 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineGapPrompt.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineGapPrompt.swift; sourceTree = SOURCE_ROOT; };
+		80E4F64519A39289AF03A73C /* LifeBoard/Onboarding/Models/OnboardingHabitTemplateState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingHabitTemplateState.swift; sourceTree = SOURCE_ROOT; };
+		80EEB0762BB49B5983079AF3 /* LifeBoard/LLM/Views/Chat/Conversation/MessageView+EvaProposalAndDayOverview.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/LLM/Views/Chat/Conversation/MessageView+EvaProposalAndDayOverview.swift"; sourceTree = SOURCE_ROOT; };
 		817A26FD3474A08EC2250BED /* SwiftUI+TokenAdapters.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "SwiftUI+TokenAdapters.swift"; sourceTree = "<group>"; };
-		81B4061464040091D355959D /* HomeViewModel+DailySummaryModal.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+DailySummaryModal.swift"; sourceTree = SOURCE_ROOT; };
+		81B4061464040091D355959D /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+DailySummaryModal.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+DailySummaryModal.swift"; sourceTree = SOURCE_ROOT; };
 		82752F8BF563DB0673AB2770 /* HomeQuickFilterDropdown.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeQuickFilterDropdown.swift; sourceTree = "<group>"; };
-		82775C66CDC41F9E7034D949 /* HomeViewModel+FocusSessions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+FocusSessions.swift"; sourceTree = SOURCE_ROOT; };
+		82775C66CDC41F9E7034D949 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+FocusSessions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+FocusSessions.swift"; sourceTree = SOURCE_ROOT; };
 		82ACA5EA351487686C155548 /* SettingsSectionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSectionHeader.swift; sourceTree = "<group>"; };
-		82CED5AEF0E893280880972E /* TimelineGapExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineGapExtension.swift; sourceTree = SOURCE_ROOT; };
-		8332C14C05A3610EB0ECA84B /* OverdueRescueSummary.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSummary.swift; sourceTree = SOURCE_ROOT; };
-		83540D1FFD9826270275D74A /* SunriseAppShellViewRoot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellViewRoot.swift; sourceTree = SOURCE_ROOT; };
-		836DC307393EA1752081FFEE /* V2CoreDataRepositorySupport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Repositories/V2CoreDataRepositorySupport.swift; sourceTree = SOURCE_ROOT; };
-		83B4B8D198A7243A6496C809 /* OnboardingMascotCarousel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingMascotCarousel.swift; sourceTree = SOURCE_ROOT; };
-		83BA608636D6DB86CBE1DC83 /* OnboardingChecklistRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingChecklistRow.swift; sourceTree = SOURCE_ROOT; };
-		83C12D0895BE1B134C2DEDF5 /* HomeOverdueRescueLauncherState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeOverdueRescueLauncherState.swift; sourceTree = SOURCE_ROOT; };
+		82CED5AEF0E893280880972E /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineGapExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineGapExtension.swift; sourceTree = SOURCE_ROOT; };
+		8332C14C05A3610EB0ECA84B /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSummary.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSummary.swift; sourceTree = SOURCE_ROOT; };
+		83540D1FFD9826270275D74A /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellViewRoot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellViewRoot.swift; sourceTree = SOURCE_ROOT; };
+		836DC307393EA1752081FFEE /* LifeBoard/State/Repositories/V2CoreDataRepositorySupport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Repositories/V2CoreDataRepositorySupport.swift; sourceTree = SOURCE_ROOT; };
+		83B4B8D198A7243A6496C809 /* LifeBoard/Onboarding/Models/OnboardingMascotCarousel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingMascotCarousel.swift; sourceTree = SOURCE_ROOT; };
+		83BA608636D6DB86CBE1DC83 /* LifeBoard/Onboarding/Components/OnboardingChecklistRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingChecklistRow.swift; sourceTree = SOURCE_ROOT; };
+		83C12D0895BE1B134C2DEDF5 /* LifeBoard/Presentation/ViewModels/Home/HomeOverdueRescueLauncherState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeOverdueRescueLauncherState.swift; sourceTree = SOURCE_ROOT; };
 		849A846930F8CAB1E8403C68 /* HomeViewController+Reload.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "HomeViewController+Reload.swift"; sourceTree = "<group>"; };
-		855AD3CAAA08B951BDD134FD /* SunriseAppShellView+FacesAndSearchChat.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+FacesAndSearchChat.swift"; sourceTree = SOURCE_ROOT; };
-		8565ACC6D97DD8CCE34EA3E0 /* DeleteProjectSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/DeleteProjectSheet.swift; sourceTree = SOURCE_ROOT; };
-		856DDB017465F5A7BA124E09 /* LifeManagementComposerPreviewMetric.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerPreviewMetric.swift; sourceTree = SOURCE_ROOT; };
-		85DF0433A9683E2365552FC2 /* timelineMetaColor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/timelineMetaColor.swift; sourceTree = SOURCE_ROOT; };
-		85F3DEB89B5BEB05F1972CA7 /* XPEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/XPEvent.swift; sourceTree = SOURCE_ROOT; };
-		862166F085A7F815ADA70872 /* OnboardingWorkspaceSnapshot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingWorkspaceSnapshot.swift; sourceTree = SOURCE_ROOT; };
-		871E14455069188F7847E1DB /* TaskDefinitionRepositoryProtocolExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/TaskDefinitionRepositoryProtocolExtension.swift; sourceTree = SOURCE_ROOT; };
-		875713F2747185071D35BDF9 /* CelebrationPresentation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/CelebrationPresentation.swift; sourceTree = SOURCE_ROOT; };
-		8763CA6B0B62B52616869680 /* HomeTaskReloadNotificationEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeTaskReloadNotificationEvent.swift; sourceTree = SOURCE_ROOT; };
-		87FF3FCE748CD6D1CC8DD64D /* OnboardingEyebrowLabel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingEyebrowLabel.swift; sourceTree = SOURCE_ROOT; };
-		8824EFA2E628DF9525F13411 /* LifeManagementAreaSwatchPicker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementAreaSwatchPicker.swift; sourceTree = SOURCE_ROOT; };
-		884AE8F47B1E2B1F9D346956 /* timelineDisplayedNow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/timelineDisplayedNow.swift; sourceTree = SOURCE_ROOT; };
-		88EAC5F41DAFB21D34E6790E /* LLMContextProjectionService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Models/LLMContextProjectionService.swift; sourceTree = SOURCE_ROOT; };
-		89676F376DC27DF3823AB623 /* NextMilestoneWidget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoardWidgets/NextMilestoneWidget.swift; sourceTree = SOURCE_ROOT; };
-		89E23AC0E5DF84E0125F5845 /* HomeViewModel+RecurringTopUp.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+RecurringTopUp.swift"; sourceTree = SOURCE_ROOT; };
-		8AA0626EE55DAF0FA5CD8995 /* OverdueRescueLauncherOverlayView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Shell/SunriseAppShell/OverdueRescueLauncherOverlayView.swift; sourceTree = SOURCE_ROOT; };
+		855AD3CAAA08B951BDD134FD /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+FacesAndSearchChat.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+FacesAndSearchChat.swift"; sourceTree = SOURCE_ROOT; };
+		8565ACC6D97DD8CCE34EA3E0 /* LifeBoard/Views/Settings/LifeManagement/DeleteProjectSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/DeleteProjectSheet.swift; sourceTree = SOURCE_ROOT; };
+		856DDB017465F5A7BA124E09 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerPreviewMetric.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerPreviewMetric.swift; sourceTree = SOURCE_ROOT; };
+		85DF0433A9683E2365552FC2 /* LifeBoard/Presentation/Home/Timeline/Surface/timelineMetaColor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/timelineMetaColor.swift; sourceTree = SOURCE_ROOT; };
+		85F3DEB89B5BEB05F1972CA7 /* LifeBoard/Domain/Models/XPEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/XPEvent.swift; sourceTree = SOURCE_ROOT; };
+		862166F085A7F815ADA70872 /* LifeBoard/Onboarding/Models/OnboardingWorkspaceSnapshot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingWorkspaceSnapshot.swift; sourceTree = SOURCE_ROOT; };
+		871E14455069188F7847E1DB /* LifeBoard/Onboarding/Models/TaskDefinitionRepositoryProtocolExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/TaskDefinitionRepositoryProtocolExtension.swift; sourceTree = SOURCE_ROOT; };
+		875713F2747185071D35BDF9 /* LifeBoard/Presentation/ViewModels/Home/CelebrationPresentation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/CelebrationPresentation.swift; sourceTree = SOURCE_ROOT; };
+		8763CA6B0B62B52616869680 /* LifeBoard/Presentation/ViewModels/Home/HomeTaskReloadNotificationEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeTaskReloadNotificationEvent.swift; sourceTree = SOURCE_ROOT; };
+		87FF3FCE748CD6D1CC8DD64D /* LifeBoard/Onboarding/Models/OnboardingEyebrowLabel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingEyebrowLabel.swift; sourceTree = SOURCE_ROOT; };
+		8824EFA2E628DF9525F13411 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementAreaSwatchPicker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementAreaSwatchPicker.swift; sourceTree = SOURCE_ROOT; };
+		884AE8F47B1E2B1F9D346956 /* LifeBoard/Presentation/Home/Timeline/Surface/timelineDisplayedNow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/timelineDisplayedNow.swift; sourceTree = SOURCE_ROOT; };
+		88EAC5F41DAFB21D34E6790E /* LifeBoard/LLM/Models/LLMContextProjectionService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Models/LLMContextProjectionService.swift; sourceTree = SOURCE_ROOT; };
+		89676F376DC27DF3823AB623 /* LifeBoardWidgets/NextMilestoneWidget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoardWidgets/NextMilestoneWidget.swift; sourceTree = SOURCE_ROOT; };
+		89E23AC0E5DF84E0125F5845 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+RecurringTopUp.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+RecurringTopUp.swift"; sourceTree = SOURCE_ROOT; };
+		8AA0626EE55DAF0FA5CD8995 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/OverdueRescueLauncherOverlayView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Shell/SunriseAppShell/OverdueRescueLauncherOverlayView.swift; sourceTree = SOURCE_ROOT; };
 		8AD631E2A2245F830BA92FA5 /* CoreDataProjectRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CoreDataProjectRepository.swift; path = LifeBoard/State/Repositories/CoreDataProjectRepository.swift; sourceTree = SOURCE_ROOT; };
-		8B64FFD6CD4BC91A0687E1B2 /* HomeCanonicalHabitMutationLoadState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeCanonicalHabitMutationLoadState.swift; sourceTree = SOURCE_ROOT; };
+		8B64FFD6CD4BC91A0687E1B2 /* LifeBoard/Presentation/ViewModels/Home/HomeCanonicalHabitMutationLoadState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeCanonicalHabitMutationLoadState.swift; sourceTree = SOURCE_ROOT; };
 		8C72110A1F555F951D89BBEB /* CornerTokens.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CornerTokens.swift; sourceTree = "<group>"; };
-		8CB5F00E7099AA872CD49634 /* OnboardingAccessibilityMarkerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Views/OnboardingAccessibilityMarkerView.swift; sourceTree = SOURCE_ROOT; };
-		8D0FFCDBD5039DB8EE185B5E /* ReminderRepositoryProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Interfaces/ReminderRepositoryProtocol.swift; sourceTree = SOURCE_ROOT; };
-		8DC33D900FB020DE25E9BA33 /* OverdueRescueBackground.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueBackground.swift; sourceTree = SOURCE_ROOT; };
-		8DE0001352EA0BD0110E4A7F /* TimelineRailMetrics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailMetrics.swift; sourceTree = SOURCE_ROOT; };
-		8E16263361281852BA8E5B7F /* OnboardingEvaStatusCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingEvaStatusCard.swift; sourceTree = SOURCE_ROOT; };
+		8CB5F00E7099AA872CD49634 /* LifeBoard/Onboarding/Views/OnboardingAccessibilityMarkerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Views/OnboardingAccessibilityMarkerView.swift; sourceTree = SOURCE_ROOT; };
+		8D0FFCDBD5039DB8EE185B5E /* LifeBoard/Domain/Interfaces/ReminderRepositoryProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Interfaces/ReminderRepositoryProtocol.swift; sourceTree = SOURCE_ROOT; };
+		8DC33D900FB020DE25E9BA33 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueBackground.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueBackground.swift; sourceTree = SOURCE_ROOT; };
+		8DE0001352EA0BD0110E4A7F /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailMetrics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailMetrics.swift; sourceTree = SOURCE_ROOT; };
+		8E16263361281852BA8E5B7F /* LifeBoard/Onboarding/Components/OnboardingEvaStatusCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingEvaStatusCard.swift; sourceTree = SOURCE_ROOT; };
 		8E9F0A1B2C3D4E5F60718292 /* LifeBoardHexColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoardHexColor.swift; sourceTree = "<group>"; };
-		8F0354062DD8AECC3D1B17C4 /* lifeManagementResolvedHex.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/lifeManagementResolvedHex.swift; sourceTree = SOURCE_ROOT; };
-		8F4D92143BA2F3C1FE24BFFE /* TimelineStreamSegment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamSegment.swift; sourceTree = SOURCE_ROOT; };
-		8F4F0CDFF4458CFC2FFBA4A5 /* DailySummaryLoadState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/DailySummaryLoadState.swift; sourceTree = SOURCE_ROOT; };
-		8FC11A075C9E37AF0A3A64C8 /* HomeViewModel+InitialLoading.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+InitialLoading.swift"; sourceTree = SOURCE_ROOT; };
-		8FDA708D6EFE103BE7B725E0 /* SunriseAppShellView+RescueOverlays.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+RescueOverlays.swift"; sourceTree = SOURCE_ROOT; };
-		903BFF6DB72A0D515603C771 /* HabitListRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/HabitListRow.swift; sourceTree = SOURCE_ROOT; };
-		90F01E2761C0C86CBDFA7BB9 /* TimelineWeekDayCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineWeekDayCell.swift; sourceTree = SOURCE_ROOT; };
-		917E928680EC00ECB792B118 /* HomeReloadBatchTracker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeReloadBatchTracker.swift; sourceTree = SOURCE_ROOT; };
+		8F0354062DD8AECC3D1B17C4 /* LifeBoard/Views/Settings/LifeManagement/lifeManagementResolvedHex.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/lifeManagementResolvedHex.swift; sourceTree = SOURCE_ROOT; };
+		8F4D92143BA2F3C1FE24BFFE /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamSegment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamSegment.swift; sourceTree = SOURCE_ROOT; };
+		8F4F0CDFF4458CFC2FFBA4A5 /* LifeBoard/Presentation/ViewModels/Home/DailySummaryLoadState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/DailySummaryLoadState.swift; sourceTree = SOURCE_ROOT; };
+		8FC11A075C9E37AF0A3A64C8 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+InitialLoading.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+InitialLoading.swift"; sourceTree = SOURCE_ROOT; };
+		8FDA708D6EFE103BE7B725E0 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+RescueOverlays.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+RescueOverlays.swift"; sourceTree = SOURCE_ROOT; };
+		903BFF6DB72A0D515603C771 /* LifeBoard/Views/Settings/LifeManagement/HabitListRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/HabitListRow.swift; sourceTree = SOURCE_ROOT; };
+		90F01E2761C0C86CBDFA7BB9 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineWeekDayCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineWeekDayCell.swift; sourceTree = SOURCE_ROOT; };
+		917E928680EC00ECB792B118 /* LifeBoard/Presentation/ViewModels/Home/HomeReloadBatchTracker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeReloadBatchTracker.swift; sourceTree = SOURCE_ROOT; };
 		919DB5CEED1B1E1906FF474C /* NotificationPermissionBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPermissionBanner.swift; sourceTree = "<group>"; };
-		91B7A1ACCF6D1219FEF880EC /* timelineSuggestedAddDate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/timelineSuggestedAddDate.swift; sourceTree = SOURCE_ROOT; };
-		91DC2B1EAEE6DF2FDE3242F1 /* OnboardingWelcomeCinematicOverlay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingWelcomeCinematicOverlay.swift; sourceTree = SOURCE_ROOT; };
-		9251C0BF9A1E5D8BB7B9FC05 /* MaintainOccurrencesUseCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Schedule/MaintainOccurrencesUseCase.swift; sourceTree = SOURCE_ROOT; };
-		931896F94542B69EC7D8FCB7 /* OverdueRescueTaskCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueTaskCard.swift; sourceTree = SOURCE_ROOT; };
-		9334755BADE444C8A77BCA3E /* ManageSectionsUseCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Section/ManageSectionsUseCase.swift; sourceTree = SOURCE_ROOT; };
+		91B7A1ACCF6D1219FEF880EC /* LifeBoard/Presentation/Home/Timeline/Surface/timelineSuggestedAddDate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/timelineSuggestedAddDate.swift; sourceTree = SOURCE_ROOT; };
+		91DC2B1EAEE6DF2FDE3242F1 /* LifeBoard/Onboarding/Models/OnboardingWelcomeCinematicOverlay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingWelcomeCinematicOverlay.swift; sourceTree = SOURCE_ROOT; };
+		9251C0BF9A1E5D8BB7B9FC05 /* LifeBoard/UseCases/Schedule/MaintainOccurrencesUseCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Schedule/MaintainOccurrencesUseCase.swift; sourceTree = SOURCE_ROOT; };
+		931896F94542B69EC7D8FCB7 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueTaskCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueTaskCard.swift; sourceTree = SOURCE_ROOT; };
+		9334755BADE444C8A77BCA3E /* LifeBoard/UseCases/Section/ManageSectionsUseCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Section/ManageSectionsUseCase.swift; sourceTree = SOURCE_ROOT; };
 		93D25A779BBE1A1B798EFA4D /* SlashCommandPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashCommandPickerView.swift; sourceTree = "<group>"; };
-		93DB4D12EFFDD4985EEBD374 /* OnboardingBreakdownStep.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingBreakdownStep.swift; sourceTree = SOURCE_ROOT; };
-		93E4A4DA88B81666171B5808 /* HabitRepositoryProtocolExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/HabitRepositoryProtocolExtension.swift; sourceTree = SOURCE_ROOT; };
-		940BF66B5480A201F5424FC9 /* OnboardingEligibilityService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Services/OnboardingEligibilityService.swift; sourceTree = SOURCE_ROOT; };
-		945E754344BF05CE3FA97D8E /* XPEnums.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/XPEnums.swift; sourceTree = SOURCE_ROOT; };
-		950F69C7A81EE1B80D656D06 /* OnboardingFocusHeroCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingFocusHeroCard.swift; sourceTree = SOURCE_ROOT; };
-		953E5DF656076B7D7969E40B /* TimelineRailLabel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailLabel.swift; sourceTree = SOURCE_ROOT; };
+		93DB4D12EFFDD4985EEBD374 /* LifeBoard/Onboarding/Models/OnboardingBreakdownStep.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingBreakdownStep.swift; sourceTree = SOURCE_ROOT; };
+		93E4A4DA88B81666171B5808 /* LifeBoard/Onboarding/Models/HabitRepositoryProtocolExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/HabitRepositoryProtocolExtension.swift; sourceTree = SOURCE_ROOT; };
+		940BF66B5480A201F5424FC9 /* LifeBoard/Onboarding/Services/OnboardingEligibilityService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Services/OnboardingEligibilityService.swift; sourceTree = SOURCE_ROOT; };
+		945E754344BF05CE3FA97D8E /* LifeBoard/Domain/Models/XPEnums.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/XPEnums.swift; sourceTree = SOURCE_ROOT; };
+		950F69C7A81EE1B80D656D06 /* LifeBoard/Onboarding/Components/OnboardingFocusHeroCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingFocusHeroCard.swift; sourceTree = SOURCE_ROOT; };
+		953E5DF656076B7D7969E40B /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailLabel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailLabel.swift; sourceTree = SOURCE_ROOT; };
 		95932952BC5EBADE8D30791C /* AddTaskTagMultiSelect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTaskTagMultiSelect.swift; sourceTree = "<group>"; };
-		9632B2C3609C7092AB65BFF4 /* OnboardingEntryContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingEntryContext.swift; sourceTree = SOURCE_ROOT; };
-		96F9262E57D935FD98FFDE2C /* OnboardingCustomEntryRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingCustomEntryRow.swift; sourceTree = SOURCE_ROOT; };
-		9762A762CB36A9A40F919329 /* AppOnboardingStateStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Services/AppOnboardingStateStore.swift; sourceTree = SOURCE_ROOT; };
-		97D15C36A06B1399EAC04C8A /* EvaDayHabitActionButtonView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitActionButtonView.swift; sourceTree = SOURCE_ROOT; };
-		98955AE7E300D2E682AE486B /* AssistantActionPipelineUseCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/LLM/AssistantActionPipelineUseCase.swift; sourceTree = SOURCE_ROOT; };
-		98AB62BE5A27121F39C5F499 /* OnboardingProjectDraft.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingProjectDraft.swift; sourceTree = SOURCE_ROOT; };
-		98E3FDAB970DF9A475E91D5F /* StarterWorkspaceCatalog.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/StarterWorkspaceCatalog.swift; sourceTree = SOURCE_ROOT; };
-		98FB866510908516712F3407 /* OnboardingHeroMediaAsset.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingHeroMediaAsset.swift; sourceTree = SOURCE_ROOT; };
-		9929F28DF1EA53ABDB5CEE2B /* EvaChatNavigationChromeState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Chrome/EvaChatNavigationChromeState.swift; sourceTree = SOURCE_ROOT; };
-		99ED29FB4D6A1C5E61C6A702 /* DefaultCelebrationRouter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/DefaultCelebrationRouter.swift; sourceTree = SOURCE_ROOT; };
-		9A0864533C56B27765DDB7A4 /* HomeViewModel+DateNavigation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+DateNavigation.swift"; sourceTree = SOURCE_ROOT; };
-		9A7730F5637D23CE103B743B /* TimelinePlacementPrompt.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelinePlacementPrompt.swift; sourceTree = SOURCE_ROOT; };
-		9AE41E54BA355D96A678CBF7 /* ReminderMergeEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Sync/ReminderMergeEngine.swift; sourceTree = SOURCE_ROOT; };
+		9632B2C3609C7092AB65BFF4 /* LifeBoard/Onboarding/Models/OnboardingEntryContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingEntryContext.swift; sourceTree = SOURCE_ROOT; };
+		96F9262E57D935FD98FFDE2C /* LifeBoard/Onboarding/Components/OnboardingCustomEntryRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingCustomEntryRow.swift; sourceTree = SOURCE_ROOT; };
+		9762A762CB36A9A40F919329 /* LifeBoard/Onboarding/Services/AppOnboardingStateStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Services/AppOnboardingStateStore.swift; sourceTree = SOURCE_ROOT; };
+		97D15C36A06B1399EAC04C8A /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitActionButtonView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitActionButtonView.swift; sourceTree = SOURCE_ROOT; };
+		98955AE7E300D2E682AE486B /* LifeBoard/UseCases/LLM/AssistantActionPipelineUseCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/LLM/AssistantActionPipelineUseCase.swift; sourceTree = SOURCE_ROOT; };
+		98AB62BE5A27121F39C5F499 /* LifeBoard/Onboarding/Models/OnboardingProjectDraft.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingProjectDraft.swift; sourceTree = SOURCE_ROOT; };
+		98E3FDAB970DF9A475E91D5F /* LifeBoard/Onboarding/Models/StarterWorkspaceCatalog.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/StarterWorkspaceCatalog.swift; sourceTree = SOURCE_ROOT; };
+		98FB866510908516712F3407 /* LifeBoard/Onboarding/Components/OnboardingHeroMediaAsset.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingHeroMediaAsset.swift; sourceTree = SOURCE_ROOT; };
+		9929F28DF1EA53ABDB5CEE2B /* LifeBoard/LLM/Views/Chat/Chrome/EvaChatNavigationChromeState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Chrome/EvaChatNavigationChromeState.swift; sourceTree = SOURCE_ROOT; };
+		99ED29FB4D6A1C5E61C6A702 /* LifeBoard/Presentation/ViewModels/Home/DefaultCelebrationRouter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/DefaultCelebrationRouter.swift; sourceTree = SOURCE_ROOT; };
+		9A0864533C56B27765DDB7A4 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+DateNavigation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+DateNavigation.swift"; sourceTree = SOURCE_ROOT; };
+		9A7730F5637D23CE103B743B /* LifeBoard/Presentation/Home/Timeline/Surface/TimelinePlacementPrompt.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelinePlacementPrompt.swift; sourceTree = SOURCE_ROOT; };
+		9AE41E54BA355D96A678CBF7 /* LifeBoard/UseCases/Sync/ReminderMergeEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Sync/ReminderMergeEngine.swift; sourceTree = SOURCE_ROOT; };
 		9AF308251FE7FA9FEE55702D /* GetHomeFilteredTasksUseCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GetHomeFilteredTasksUseCase.swift; sourceTree = "<group>"; };
-		9B303E46398ACDB321C2EC64 /* HomeViewModel+HabitMutationPatching.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+HabitMutationPatching.swift"; sourceTree = SOURCE_ROOT; };
-		9B526F1E51EB6600E103374A /* AppOnboardingPromptSheetView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Views/AppOnboardingPromptSheetView.swift; sourceTree = SOURCE_ROOT; };
-		9B9E9E50F4A0FB453B025B6A /* TimelineFlockBlock.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineFlockBlock.swift; sourceTree = SOURCE_ROOT; };
+		9B303E46398ACDB321C2EC64 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+HabitMutationPatching.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+HabitMutationPatching.swift"; sourceTree = SOURCE_ROOT; };
+		9B526F1E51EB6600E103374A /* LifeBoard/Onboarding/Views/AppOnboardingPromptSheetView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Views/AppOnboardingPromptSheetView.swift; sourceTree = SOURCE_ROOT; };
+		9B9E9E50F4A0FB453B025B6A /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineFlockBlock.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineFlockBlock.swift; sourceTree = SOURCE_ROOT; };
 		9BA48957620D83F95FBC4049 /* Pods-LifeBoard-LifeBoardUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LifeBoard-LifeBoardUITests.release.xcconfig"; path = "Target Support Files/Pods-LifeBoard-LifeBoardUITests/Pods-LifeBoard-LifeBoardUITests.release.xcconfig"; sourceTree = "<group>"; };
-		9BBE8CE1B13AA2877F4BBCAE /* StreakResilienceWidget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoardWidgets/StreakResilienceWidget.swift; sourceTree = SOURCE_ROOT; };
-		9C18263F8735AB2DC17840F5 /* StarterHabitTemplate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/StarterHabitTemplate.swift; sourceTree = SOURCE_ROOT; };
-		9D1C89561D17B2073AFA6BC1 /* OverdueRescueSessionState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSessionState.swift; sourceTree = SOURCE_ROOT; };
-		9D9D661B4914CE34AEA2DD30 /* AppOnboardingCoordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Coordinator/AppOnboardingCoordinator.swift; sourceTree = SOURCE_ROOT; };
-		9E17B1D7658A53B43A03A2DB /* HabitArchiveRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/HabitArchiveRow.swift; sourceTree = SOURCE_ROOT; };
-		9E4273FD3FE15CC3F6892741 /* LifeManagementIconTile.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementIconTile.swift; sourceTree = SOURCE_ROOT; };
-		9EA22869E8CBC680A061ABAC /* HomeDataRevision.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeDataRevision.swift; sourceTree = SOURCE_ROOT; };
-		9F5B152C46928DBD19C7ABC5 /* ChatComposerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Chrome/ChatComposerView.swift; sourceTree = SOURCE_ROOT; };
-		9F71AFCC54832F564B2D7CED /* TimelineLongGapIndicator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineLongGapIndicator.swift; sourceTree = SOURCE_ROOT; };
-		9FD8DED9951762C1A0ACCBDD /* CoreDataTagRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Repositories/CoreDataTagRepository.swift; sourceTree = SOURCE_ROOT; };
-		A061843E78EAF882FA911295 /* TimelineSpineEndView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineSpineEndView.swift; sourceTree = SOURCE_ROOT; };
-		A06726F28B0B30E18CCF0D3B /* HomeDerivedHabitRowsCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeDerivedHabitRowsCache.swift; sourceTree = SOURCE_ROOT; };
-		A07B9FA858B4AFC05615FCFA /* WelcomeIntroPhase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/WelcomeIntroPhase.swift; sourceTree = SOURCE_ROOT; };
-		A07E21E632557DE3A511B5C8 /* HomeHabitMutationFeedback.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationFeedback.swift; sourceTree = SOURCE_ROOT; };
-		A09AAB294BC776DE3EEF7673 /* TimelineMeetingBlockRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineMeetingBlockRow.swift; sourceTree = SOURCE_ROOT; };
+		9BBE8CE1B13AA2877F4BBCAE /* LifeBoardWidgets/StreakResilienceWidget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoardWidgets/StreakResilienceWidget.swift; sourceTree = SOURCE_ROOT; };
+		9C18263F8735AB2DC17840F5 /* LifeBoard/Onboarding/Models/StarterHabitTemplate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/StarterHabitTemplate.swift; sourceTree = SOURCE_ROOT; };
+		9D1C89561D17B2073AFA6BC1 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSessionState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSessionState.swift; sourceTree = SOURCE_ROOT; };
+		9D9D661B4914CE34AEA2DD30 /* LifeBoard/Onboarding/Coordinator/AppOnboardingCoordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Coordinator/AppOnboardingCoordinator.swift; sourceTree = SOURCE_ROOT; };
+		9E17B1D7658A53B43A03A2DB /* LifeBoard/Views/Settings/LifeManagement/HabitArchiveRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/HabitArchiveRow.swift; sourceTree = SOURCE_ROOT; };
+		9E4273FD3FE15CC3F6892741 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementIconTile.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementIconTile.swift; sourceTree = SOURCE_ROOT; };
+		9EA22869E8CBC680A061ABAC /* LifeBoard/Presentation/ViewModels/Home/HomeDataRevision.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeDataRevision.swift; sourceTree = SOURCE_ROOT; };
+		9F5B152C46928DBD19C7ABC5 /* LifeBoard/LLM/Views/Chat/Chrome/ChatComposerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Chrome/ChatComposerView.swift; sourceTree = SOURCE_ROOT; };
+		9F71AFCC54832F564B2D7CED /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineLongGapIndicator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineLongGapIndicator.swift; sourceTree = SOURCE_ROOT; };
+		9FD8DED9951762C1A0ACCBDD /* LifeBoard/State/Repositories/CoreDataTagRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Repositories/CoreDataTagRepository.swift; sourceTree = SOURCE_ROOT; };
+		A061843E78EAF882FA911295 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineSpineEndView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineSpineEndView.swift; sourceTree = SOURCE_ROOT; };
+		A06726F28B0B30E18CCF0D3B /* LifeBoard/Presentation/ViewModels/Home/HomeDerivedHabitRowsCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeDerivedHabitRowsCache.swift; sourceTree = SOURCE_ROOT; };
+		A07B9FA858B4AFC05615FCFA /* LifeBoard/Onboarding/Models/WelcomeIntroPhase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/WelcomeIntroPhase.swift; sourceTree = SOURCE_ROOT; };
+		A07E21E632557DE3A511B5C8 /* LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationFeedback.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationFeedback.swift; sourceTree = SOURCE_ROOT; };
+		A09AAB294BC776DE3EEF7673 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineMeetingBlockRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineMeetingBlockRow.swift; sourceTree = SOURCE_ROOT; };
 		A10000000000000000000001 /* QuickViewSelector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = QuickViewSelector.swift; sourceTree = "<group>"; };
 		A10000000000000000000002 /* NavPieChart.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NavPieChart.swift; sourceTree = "<group>"; };
 		A10000000000000000000003 /* SunriseFocusZone.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SunriseFocusZone.swift; sourceTree = "<group>"; };
 		A10000000000000000000004 /* UrgencyBadge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UrgencyBadge.swift; sourceTree = "<group>"; };
 		A10000000000000000000005 /* XPBadge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = XPBadge.swift; sourceTree = "<group>"; };
 		A10000000000000000000007 /* CelebrationEffects.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CelebrationEffects.swift; sourceTree = "<group>"; };
-		A109D2B957E1D5A47149A0D9 /* TimelineVisualTokens.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineVisualTokens.swift; sourceTree = SOURCE_ROOT; };
-		A10B1C2D3E4F506172839401 /* StateLifeAreaMapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Mappers/StateLifeAreaMapper.swift; sourceTree = SOURCE_ROOT; };
-		A10B1C2D3E4F506172839402 /* StateSectionMapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Mappers/StateSectionMapper.swift; sourceTree = SOURCE_ROOT; };
-		A10B1C2D3E4F506172839403 /* StateTagMapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Mappers/StateTagMapper.swift; sourceTree = SOURCE_ROOT; };
-		A10B1C2D3E4F506172839404 /* StateTombstoneMapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Mappers/StateTombstoneMapper.swift; sourceTree = SOURCE_ROOT; };
-		A10B1C2D3E4F506172839405 /* StateHabitDefinitionMapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Mappers/StateHabitDefinitionMapper.swift; sourceTree = SOURCE_ROOT; };
-		A10B1C2D3E4F506172839407 /* StateTaskDefinitionMapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Mappers/StateTaskDefinitionMapper.swift; sourceTree = SOURCE_ROOT; };
-		A10B1C2D3E4F506172839408 /* StateProjectMapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Mappers/StateProjectMapper.swift; sourceTree = SOURCE_ROOT; };
+		A109D2B957E1D5A47149A0D9 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineVisualTokens.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineVisualTokens.swift; sourceTree = SOURCE_ROOT; };
+		A10B1C2D3E4F506172839401 /* LifeBoard/State/Mappers/StateLifeAreaMapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Mappers/StateLifeAreaMapper.swift; sourceTree = SOURCE_ROOT; };
+		A10B1C2D3E4F506172839402 /* LifeBoard/State/Mappers/StateSectionMapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Mappers/StateSectionMapper.swift; sourceTree = SOURCE_ROOT; };
+		A10B1C2D3E4F506172839403 /* LifeBoard/State/Mappers/StateTagMapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Mappers/StateTagMapper.swift; sourceTree = SOURCE_ROOT; };
+		A10B1C2D3E4F506172839404 /* LifeBoard/State/Mappers/StateTombstoneMapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Mappers/StateTombstoneMapper.swift; sourceTree = SOURCE_ROOT; };
+		A10B1C2D3E4F506172839405 /* LifeBoard/State/Mappers/StateHabitDefinitionMapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Mappers/StateHabitDefinitionMapper.swift; sourceTree = SOURCE_ROOT; };
+		A10B1C2D3E4F506172839407 /* LifeBoard/State/Mappers/StateTaskDefinitionMapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Mappers/StateTaskDefinitionMapper.swift; sourceTree = SOURCE_ROOT; };
+		A10B1C2D3E4F506172839408 /* LifeBoard/State/Mappers/StateProjectMapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Mappers/StateProjectMapper.swift; sourceTree = SOURCE_ROOT; };
 		A11B22C32F10000100ABCDEF /* TaskNotificationDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskNotificationDispatcher.swift; sourceTree = "<group>"; };
 		A11D5A110000000000000001 /* SunriseDaySwipeSide.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SunriseDaySwipeSide.swift; sourceTree = "<group>"; };
 		A11D5A110000000000000002 /* SunriseDaySwipeData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SunriseDaySwipeData.swift; sourceTree = "<group>"; };
 		A11D5A110000000000000003 /* SunriseDaySwipeWaveShape.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SunriseDaySwipeWaveShape.swift; sourceTree = "<group>"; };
 		A11D5A110000000000000004 /* SunriseDaySwipeOverlay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SunriseDaySwipeOverlay.swift; sourceTree = "<group>"; };
 		A134F2A3EA61AB508E9A3ED9 /* HomeViewController+Keyboard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "HomeViewController+Keyboard.swift"; sourceTree = "<group>"; };
-		A13C9964C87A904A153CCAC6 /* OnboardingSuccessSummaryRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingSuccessSummaryRow.swift; sourceTree = SOURCE_ROOT; };
+		A13C9964C87A904A153CCAC6 /* LifeBoard/Onboarding/Components/OnboardingSuccessSummaryRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingSuccessSummaryRow.swift; sourceTree = SOURCE_ROOT; };
 		A1B2C3D42EAA11BB00CCDDEE /* LLMModelRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLMModelRegistryTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F607080910AB02 /* GradientTokens.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GradientTokens.swift; sourceTree = "<group>"; };
 		A1B2C3D62F90000100AA1001 /* TaskEditorSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskEditorSection.swift; sourceTree = "<group>"; };
 		A1B2C3D72F90000100AA1001 /* TaskEditorSectionCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskEditorSectionCard.swift; sourceTree = "<group>"; };
 		A1C2D3E4F5A60718293B4C5C /* AssistantPlannerServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssistantPlannerServiceTests.swift; sourceTree = "<group>"; };
 		A1C2D3E4F5A60718293B4C5F /* AssistantEnvelopeValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssistantEnvelopeValidatorTests.swift; sourceTree = "<group>"; };
-		A1D100032F90000100AA2001 /* ShortcutHandoffStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Shared/ShortcutHandoffStore.swift; sourceTree = SOURCE_ROOT; };
-		A1D100042F90000100AA2001 /* LifeBoardPersistentStoreBootstrapService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/DI/LifeBoardPersistentStoreBootstrapService.swift; sourceTree = SOURCE_ROOT; };
-		A1E5C40F2F1A4B9D9C1E8A12 /* AppleRemindersProviderProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Interfaces/AppleRemindersProviderProtocol.swift; sourceTree = SOURCE_ROOT; };
-		A1E5C40F2F1A4B9D9C1E8A13 /* EventKitAppleRemindersProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Services/EventKitAppleRemindersProvider.swift; sourceTree = SOURCE_ROOT; };
+		A1D100032F90000100AA2001 /* Shared/ShortcutHandoffStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Shared/ShortcutHandoffStore.swift; sourceTree = SOURCE_ROOT; };
+		A1D100042F90000100AA2001 /* LifeBoard/State/DI/LifeBoardPersistentStoreBootstrapService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/DI/LifeBoardPersistentStoreBootstrapService.swift; sourceTree = SOURCE_ROOT; };
+		A1E5C40F2F1A4B9D9C1E8A12 /* LifeBoard/Domain/Interfaces/AppleRemindersProviderProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Interfaces/AppleRemindersProviderProtocol.swift; sourceTree = SOURCE_ROOT; };
+		A1E5C40F2F1A4B9D9C1E8A13 /* LifeBoard/State/Services/EventKitAppleRemindersProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Services/EventKitAppleRemindersProvider.swift; sourceTree = SOURCE_ROOT; };
 		A1F0D0B12F5A100100ABC001 /* AppOnboarding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppOnboarding.swift; sourceTree = "<group>"; };
 		A1F0D0B42F5A100100ABC001 /* AppOnboardingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppOnboardingTests.swift; sourceTree = "<group>"; };
 		A1F0D0B62F5A100100ABC001 /* OnboardingUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingUITests.swift; sourceTree = "<group>"; };
 		A25F3E0B9D00FA850EE9E8A9 /* TimelinePhoneRenderModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TimelinePhoneRenderModel.swift; sourceTree = "<group>"; };
 		A365503F0A1EC71D5D159FC0 /* UserDefaultsSavedHomeViewRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UserDefaultsSavedHomeViewRepository.swift; path = State/Repositories/UserDefaultsSavedHomeViewRepository.swift; sourceTree = "<group>"; };
-		A3CC802FBBE9AFA39AF7CCFA /* OverdueRescueStateMachine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueStateMachine.swift; sourceTree = SOURCE_ROOT; };
+		A3CC802FBBE9AFA39AF7CCFA /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueStateMachine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueStateMachine.swift; sourceTree = SOURCE_ROOT; };
 		A41487F741A541AD1CB7DD2E /* Pods_LifeBoard.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_LifeBoard.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		A4C2E9F12B7D4C5581AA0003 /* HomeTaskMutationPayload.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/HomeTaskMutationPayload.swift; sourceTree = SOURCE_ROOT; };
+		A4C2E9F12B7D4C5581AA0003 /* LifeBoard/Domain/Models/HomeTaskMutationPayload.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/HomeTaskMutationPayload.swift; sourceTree = SOURCE_ROOT; };
 		A4C2E9F12B7D4C5581AA0004 /* HomeTaskMutationPayloadTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeTaskMutationPayloadTests.swift; sourceTree = "<group>"; };
-		A4E8C9D22F9A4C3600A1B2C3 /* LifeAreaIdentityRepair.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Integrity/LifeAreaIdentityRepair.swift; sourceTree = SOURCE_ROOT; };
-		A66619E14C36928EAAFD471F /* TimelineCanvasLayoutPlan+VisualTimeMapping.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Timeline/Surface/TimelineCanvasLayoutPlan+VisualTimeMapping.swift"; sourceTree = SOURCE_ROOT; };
+		A4E8C9D22F9A4C3600A1B2C3 /* LifeBoard/State/Integrity/LifeAreaIdentityRepair.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Integrity/LifeAreaIdentityRepair.swift; sourceTree = SOURCE_ROOT; };
+		A66619E14C36928EAAFD471F /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCanvasLayoutPlan+VisualTimeMapping.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Timeline/Surface/TimelineCanvasLayoutPlan+VisualTimeMapping.swift"; sourceTree = SOURCE_ROOT; };
 		A684113549194AD47BD191DB /* LifeBoardWatch.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = LifeBoardWatch.entitlements; sourceTree = "<group>"; };
-		A686073CD1BB07971DFD578B /* TimelineStreamSample.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamSample.swift; sourceTree = SOURCE_ROOT; };
+		A686073CD1BB07971DFD578B /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamSample.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamSample.swift; sourceTree = SOURCE_ROOT; };
 		A6E1D3F52F3C100100B1C2D3 /* AISuggestionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AISuggestionService.swift; sourceTree = "<group>"; };
 		A6E1D3F72F3C100100B1C2D3 /* AssistantCardPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssistantCardPayload.swift; sourceTree = "<group>"; };
 		A6E1D4022F3C120100B1C2D3 /* AIChatModeRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatModeRouter.swift; sourceTree = "<group>"; };
@@ -1836,67 +1837,67 @@
 		A6E1D41A2F3C120100B1C2D3 /* EvaProposalCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaProposalCard.swift; sourceTree = "<group>"; };
 		A6E1D41B2F3C120100B1C2D3 /* EvaDayOverview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaDayOverview.swift; sourceTree = "<group>"; };
 		A6E1D42A2F3C120100B1C2D3 /* TaskSemanticRetrievalServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskSemanticRetrievalServiceTests.swift; sourceTree = "<group>"; };
-		A6F510C5BFB0D534AB441244 /* ManageProjectsUseCaseExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/ManageProjectsUseCaseExtension.swift; sourceTree = SOURCE_ROOT; };
+		A6F510C5BFB0D534AB441244 /* LifeBoard/Onboarding/Models/ManageProjectsUseCaseExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/ManageProjectsUseCaseExtension.swift; sourceTree = SOURCE_ROOT; };
 		A7B8C9D0E1F20123456789A1 /* HabitBoardPresentationBuilderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HabitBoardPresentationBuilderTests.swift; sourceTree = "<group>"; };
 		A7B8C9D0E1F20123456789A3 /* HomeHabitLastCellInteractionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeHabitLastCellInteractionTests.swift; sourceTree = "<group>"; };
 		A7B8C9D0E1F20123456789A5 /* HabitLastCellRuntimeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HabitLastCellRuntimeTests.swift; sourceTree = "<group>"; };
 		A7B8C9D0E1F20123456789A7 /* QuietTrackingRailPresentationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = QuietTrackingRailPresentationTests.swift; sourceTree = "<group>"; };
 		A7B8C9D0E1F2030405060708 /* TaskModelV3_Timeline.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = TaskModelV3_Timeline.xcdatamodel; sourceTree = "<group>"; };
 		A7B8C9D12F13D806009162CD /* TaskDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskDetailViewModel.swift; sourceTree = "<group>"; };
-		A7E56873BA58AFC39AFB0D20 /* HomeViewModel+FiltersAndSavedViews.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+FiltersAndSavedViews.swift"; sourceTree = SOURCE_ROOT; };
-		A8699B1ED0E60EAAE73AE2E3 /* AssistantCommandExecutor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/LLM/AssistantCommandExecutor.swift; sourceTree = SOURCE_ROOT; };
+		A7E56873BA58AFC39AFB0D20 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+FiltersAndSavedViews.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+FiltersAndSavedViews.swift"; sourceTree = SOURCE_ROOT; };
+		A8699B1ED0E60EAAE73AE2E3 /* LifeBoard/UseCases/LLM/AssistantCommandExecutor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/LLM/AssistantCommandExecutor.swift; sourceTree = SOURCE_ROOT; };
 		A8F1D2045E9C44A100112233 /* LifeBoardLayoutContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoardLayoutContext.swift; sourceTree = "<group>"; };
 		A8F1D2055E9C44A100112233 /* DeviceOrientationPolicyResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceOrientationPolicyResolver.swift; sourceTree = "<group>"; };
 		A8F1D2065E9C44A100112233 /* DeviceOrientationPolicyResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceOrientationPolicyResolverTests.swift; sourceTree = "<group>"; };
 		A91F8E132F44420100AB11C1 /* LifeManagementView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeManagementView.swift; sourceTree = "<group>"; };
 		A91F8E142F44420100AB11C1 /* LifeManagementViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeManagementViewModel.swift; sourceTree = "<group>"; };
 		A91F8E152F44420100AB11C1 /* LifeManagementFeatureTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeManagementFeatureTests.swift; sourceTree = "<group>"; };
-		A93FE62F2A34CD25059D4950 /* OnboardingSelectableCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingSelectableCard.swift; sourceTree = SOURCE_ROOT; };
-		A95FD785F6B6001D9106C2B8 /* CoreDataTaskReadModelRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Repositories/CoreDataTaskReadModelRepository.swift; sourceTree = SOURCE_ROOT; };
-		A9ADCB5DB568A54708322C8E /* GamificationProfile.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/GamificationProfile.swift; sourceTree = SOURCE_ROOT; };
+		A93FE62F2A34CD25059D4950 /* LifeBoard/Onboarding/Components/OnboardingSelectableCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingSelectableCard.swift; sourceTree = SOURCE_ROOT; };
+		A95FD785F6B6001D9106C2B8 /* LifeBoard/State/Repositories/CoreDataTaskReadModelRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Repositories/CoreDataTaskReadModelRepository.swift; sourceTree = SOURCE_ROOT; };
+		A9ADCB5DB568A54708322C8E /* LifeBoard/Domain/Models/GamificationProfile.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/GamificationProfile.swift; sourceTree = SOURCE_ROOT; };
 		A9C6F21138AB4C41B2D309E7 /* TaskModelV3_Gamification.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = TaskModelV3_Gamification.xcdatamodel; sourceTree = "<group>"; };
-		A9E54F6F587FF89056E429DF /* CoreDataOccurrenceRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Repositories/CoreDataOccurrenceRepository.swift; sourceTree = SOURCE_ROOT; };
-		AAB000000000000000000001 /* HomeRenderState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/RenderState/HomeRenderState.swift; sourceTree = SOURCE_ROOT; };
-		AAB000000000000000000003 /* HomeStores.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Stores/HomeStores.swift; sourceTree = SOURCE_ROOT; };
-		AAB000000000000000000008 /* HomeShellTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Shell/HomeShellTypes.swift; sourceTree = SOURCE_ROOT; };
-		AAB00000000000000000000C /* OnboardingTaskDetailDismissBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OnboardingTaskDetailDismissBridge.swift; sourceTree = SOURCE_ROOT; };
-		AAB00000000000000000000E /* RescheduleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/RescheduleViewController.swift; sourceTree = SOURCE_ROOT; };
-		AAB000000000000000000010 /* HomeDailySummaryModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/HomeDailySummaryModalView.swift; sourceTree = SOURCE_ROOT; };
-		AAB000000000000000000012 /* SunriseRecurringTaskDeleteConfirmationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/SunriseRecurringTaskDeleteConfirmationView.swift; sourceTree = SOURCE_ROOT; };
-		AAB000000000000000000014 /* HomeUITestWorkspaceSeeder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/TestingSupport/HomeUITestWorkspaceSeeder.swift; sourceTree = SOURCE_ROOT; };
-		AAB000000000000000000018 /* NeedsReplanTrayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Replan/NeedsReplanTrayView.swift; sourceTree = SOURCE_ROOT; };
-		AAB00000000000000000001A /* NeedsReplanLauncherSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Replan/NeedsReplanLauncherSheet.swift; sourceTree = SOURCE_ROOT; };
-		AAB00000000000000000001C /* NeedsReplanCardOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Replan/NeedsReplanCardOverlay.swift; sourceTree = SOURCE_ROOT; };
-		AAB00000000000000000001E /* NeedsReplanSummaryOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Replan/NeedsReplanSummaryOverlay.swift; sourceTree = SOURCE_ROOT; };
-		AAB000000000000000000020 /* HomePrimaryWidgetRail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Widgets/HomePrimaryWidgetRail.swift; sourceTree = SOURCE_ROOT; };
-		AAB000000000000000000023 /* EvaOverdueRescueSheetV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/EvaOverdueRescueSheetV2.swift; sourceTree = SOURCE_ROOT; };
-		AAB000000000000000000025 /* HomeiPadShell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Shell/HomeiPadShell.swift; sourceTree = SOURCE_ROOT; };
-		AAB000000000000000000028 /* HomeTimelineSnapshotRenderCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/HomeTimelineSnapshotRenderCache.swift; sourceTree = SOURCE_ROOT; };
-		AAB00000000000000000002A /* HomeTimelineColumnLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/HomeTimelineColumnLayout.swift; sourceTree = SOURCE_ROOT; };
-		AAB00000000000000000002C /* HomeSunriseLayoutSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Shell/HomeSunriseLayoutSupport.swift; sourceTree = SOURCE_ROOT; };
-		AAB00000000000000000002E /* HomeDaySwipeResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Shell/HomeDaySwipeResolver.swift; sourceTree = SOURCE_ROOT; };
-		AAB000000000000000000030 /* HomeSearchState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Search/HomeSearchState.swift; sourceTree = SOURCE_ROOT; };
+		A9E54F6F587FF89056E429DF /* LifeBoard/State/Repositories/CoreDataOccurrenceRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Repositories/CoreDataOccurrenceRepository.swift; sourceTree = SOURCE_ROOT; };
+		AAB000000000000000000001 /* LifeBoard/Presentation/Home/RenderState/HomeRenderState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/RenderState/HomeRenderState.swift; sourceTree = SOURCE_ROOT; };
+		AAB000000000000000000003 /* LifeBoard/Presentation/Home/Stores/HomeStores.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Stores/HomeStores.swift; sourceTree = SOURCE_ROOT; };
+		AAB000000000000000000008 /* LifeBoard/Presentation/Home/Shell/HomeShellTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Shell/HomeShellTypes.swift; sourceTree = SOURCE_ROOT; };
+		AAB00000000000000000000C /* LifeBoard/Presentation/Home/Modals/OnboardingTaskDetailDismissBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OnboardingTaskDetailDismissBridge.swift; sourceTree = SOURCE_ROOT; };
+		AAB00000000000000000000E /* LifeBoard/Presentation/Home/Modals/RescheduleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/RescheduleViewController.swift; sourceTree = SOURCE_ROOT; };
+		AAB000000000000000000010 /* LifeBoard/Presentation/Home/Modals/HomeDailySummaryModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/HomeDailySummaryModalView.swift; sourceTree = SOURCE_ROOT; };
+		AAB000000000000000000012 /* LifeBoard/Presentation/Home/Modals/SunriseRecurringTaskDeleteConfirmationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/SunriseRecurringTaskDeleteConfirmationView.swift; sourceTree = SOURCE_ROOT; };
+		AAB000000000000000000014 /* LifeBoard/TestingSupport/HomeUITestWorkspaceSeeder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/TestingSupport/HomeUITestWorkspaceSeeder.swift; sourceTree = SOURCE_ROOT; };
+		AAB000000000000000000018 /* LifeBoard/Presentation/Home/Replan/NeedsReplanTrayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Replan/NeedsReplanTrayView.swift; sourceTree = SOURCE_ROOT; };
+		AAB00000000000000000001A /* LifeBoard/Presentation/Home/Replan/NeedsReplanLauncherSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Replan/NeedsReplanLauncherSheet.swift; sourceTree = SOURCE_ROOT; };
+		AAB00000000000000000001C /* LifeBoard/Presentation/Home/Replan/NeedsReplanCardOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Replan/NeedsReplanCardOverlay.swift; sourceTree = SOURCE_ROOT; };
+		AAB00000000000000000001E /* LifeBoard/Presentation/Home/Replan/NeedsReplanSummaryOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Replan/NeedsReplanSummaryOverlay.swift; sourceTree = SOURCE_ROOT; };
+		AAB000000000000000000020 /* LifeBoard/Presentation/Home/Widgets/HomePrimaryWidgetRail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Widgets/HomePrimaryWidgetRail.swift; sourceTree = SOURCE_ROOT; };
+		AAB000000000000000000023 /* LifeBoard/Presentation/Home/Modals/EvaOverdueRescueSheetV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/EvaOverdueRescueSheetV2.swift; sourceTree = SOURCE_ROOT; };
+		AAB000000000000000000025 /* LifeBoard/Presentation/Home/Shell/HomeiPadShell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Shell/HomeiPadShell.swift; sourceTree = SOURCE_ROOT; };
+		AAB000000000000000000028 /* LifeBoard/Presentation/Home/Timeline/HomeTimelineSnapshotRenderCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/HomeTimelineSnapshotRenderCache.swift; sourceTree = SOURCE_ROOT; };
+		AAB00000000000000000002A /* LifeBoard/Presentation/Home/Timeline/HomeTimelineColumnLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/HomeTimelineColumnLayout.swift; sourceTree = SOURCE_ROOT; };
+		AAB00000000000000000002C /* LifeBoard/Presentation/Home/Shell/HomeSunriseLayoutSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Shell/HomeSunriseLayoutSupport.swift; sourceTree = SOURCE_ROOT; };
+		AAB00000000000000000002E /* LifeBoard/Presentation/Home/Shell/HomeDaySwipeResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Shell/HomeDaySwipeResolver.swift; sourceTree = SOURCE_ROOT; };
+		AAB000000000000000000030 /* LifeBoard/Presentation/Home/Search/HomeSearchState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Search/HomeSearchState.swift; sourceTree = SOURCE_ROOT; };
 		AAE767D2FA20060D16FE82AA /* Pods-LifeBoard.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LifeBoard.release.xcconfig"; path = "Target Support Files/Pods-LifeBoard/Pods-LifeBoard.release.xcconfig"; sourceTree = "<group>"; };
 		AB12CD34EF5607891234ABCD /* CoverFlipTransition.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CoverFlipTransition.swift; sourceTree = "<group>"; };
-		AB34BB65B7298F039E9C6A1C /* logOnboardingInfo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/logOnboardingInfo.swift; sourceTree = SOURCE_ROOT; };
-		AB8C1BB0D0F72004D8CD5497 /* ProjectSummaryRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/ProjectSummaryRow.swift; sourceTree = SOURCE_ROOT; };
-		ABA8BBA9B91A5587A8389B33 /* OnboardingPromptValueCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingPromptValueCard.swift; sourceTree = SOURCE_ROOT; };
+		AB34BB65B7298F039E9C6A1C /* LifeBoard/Onboarding/Models/logOnboardingInfo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/logOnboardingInfo.swift; sourceTree = SOURCE_ROOT; };
+		AB8C1BB0D0F72004D8CD5497 /* LifeBoard/Views/Settings/LifeManagement/ProjectSummaryRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/ProjectSummaryRow.swift; sourceTree = SOURCE_ROOT; };
+		ABA8BBA9B91A5587A8389B33 /* LifeBoard/Onboarding/Components/OnboardingPromptValueCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingPromptValueCard.swift; sourceTree = SOURCE_ROOT; };
 		ABCD00000000000000000021 /* AddHabitViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddHabitViewModel.swift; sourceTree = "<group>"; };
-		ABCD00000000000000000023 /* HabitIconCatalog.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Habits/HabitIconCatalog.swift; sourceTree = SOURCE_ROOT; };
+		ABCD00000000000000000023 /* LifeBoard/Presentation/Habits/HabitIconCatalog.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Habits/HabitIconCatalog.swift; sourceTree = SOURCE_ROOT; };
 		ABCD00000000000000000024 /* SunriseHabitLibraryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SunriseHabitLibraryView.swift; sourceTree = "<group>"; };
-		ABDC5FDB10DF919EB7B94CC4 /* AppOnboardingHostAdapter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Coordinator/AppOnboardingHostAdapter.swift; sourceTree = SOURCE_ROOT; };
-		AC0C44769FFD55EF43FB1B63 /* TimelineCompactLayoutPlan.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompactLayoutPlan.swift; sourceTree = SOURCE_ROOT; };
-		AC4ABAA08D90818447AA6D03 /* CreateTaskDefinitionUseCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Task/CreateTaskDefinitionUseCase.swift; sourceTree = SOURCE_ROOT; };
-		AC4E931BD28EB1FD4F7E2671 /* OverdueRescuePalette.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescuePalette.swift; sourceTree = SOURCE_ROOT; };
-		AD2798DFE7058AA45DECE737 /* FocusSessionDefinition.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/FocusSessionDefinition.swift; sourceTree = SOURCE_ROOT; };
-		AD6F79B4F4AF4D2B4E34CD17 /* timelineRailText.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/timelineRailText.swift; sourceTree = SOURCE_ROOT; };
+		ABDC5FDB10DF919EB7B94CC4 /* LifeBoard/Onboarding/Coordinator/AppOnboardingHostAdapter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Coordinator/AppOnboardingHostAdapter.swift; sourceTree = SOURCE_ROOT; };
+		AC0C44769FFD55EF43FB1B63 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompactLayoutPlan.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompactLayoutPlan.swift; sourceTree = SOURCE_ROOT; };
+		AC4ABAA08D90818447AA6D03 /* LifeBoard/UseCases/Task/CreateTaskDefinitionUseCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Task/CreateTaskDefinitionUseCase.swift; sourceTree = SOURCE_ROOT; };
+		AC4E931BD28EB1FD4F7E2671 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescuePalette.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescuePalette.swift; sourceTree = SOURCE_ROOT; };
+		AD2798DFE7058AA45DECE737 /* LifeBoard/Domain/Models/FocusSessionDefinition.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/FocusSessionDefinition.swift; sourceTree = SOURCE_ROOT; };
+		AD6F79B4F4AF4D2B4E34CD17 /* LifeBoard/Presentation/Home/Timeline/Surface/timelineRailText.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/timelineRailText.swift; sourceTree = SOURCE_ROOT; };
 		ADB62B5450F5D70EBBEC2940 /* ElevationTokens.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ElevationTokens.swift; sourceTree = "<group>"; };
 		AE5DC87E5EFAD171634D5F0A /* HomeViewController+Presentation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "HomeViewController+Presentation.swift"; sourceTree = "<group>"; };
-		AE79C7D2227A80F8ECDFDFD2 /* OverdueRescueCardModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueCardModel.swift; sourceTree = SOURCE_ROOT; };
-		AFAECD01C463CF2E65F669CB /* LifeManagementAreaDetailView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementAreaDetailView.swift; sourceTree = SOURCE_ROOT; };
-		B010C6D75FA3187BE754B3BF /* InsightsActionIntentExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Shell/SunriseAppShell/InsightsActionIntentExtension.swift; sourceTree = SOURCE_ROOT; };
-		B0B60F4DC92BA3ACD065F8D3 /* HomeTaskDetailMetadataState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeTaskDetailMetadataState.swift; sourceTree = SOURCE_ROOT; };
-		B0B69EFFAB72804AE4A38EB3 /* ManageHabitsUseCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Habit/ManageHabitsUseCase.swift; sourceTree = SOURCE_ROOT; };
+		AE79C7D2227A80F8ECDFDFD2 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueCardModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueCardModel.swift; sourceTree = SOURCE_ROOT; };
+		AFAECD01C463CF2E65F669CB /* LifeBoard/Views/Settings/LifeManagement/LifeManagementAreaDetailView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementAreaDetailView.swift; sourceTree = SOURCE_ROOT; };
+		B010C6D75FA3187BE754B3BF /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/InsightsActionIntentExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Shell/SunriseAppShell/InsightsActionIntentExtension.swift; sourceTree = SOURCE_ROOT; };
+		B0B60F4DC92BA3ACD065F8D3 /* LifeBoard/Presentation/ViewModels/Home/HomeTaskDetailMetadataState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeTaskDetailMetadataState.swift; sourceTree = SOURCE_ROOT; };
+		B0B69EFFAB72804AE4A38EB3 /* LifeBoard/UseCases/Habit/ManageHabitsUseCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Habit/ManageHabitsUseCase.swift; sourceTree = SOURCE_ROOT; };
 		B1A000000000000000000011 /* LifeBoardFilterComponents.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoardFilterComponents.swift; sourceTree = "<group>"; };
 		B1A000000000000000000012 /* LifeBoardSearchChrome.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoardSearchChrome.swift; sourceTree = "<group>"; };
 		B1A000000000000000000013 /* HomeChromeComponents.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeChromeComponents.swift; sourceTree = "<group>"; };
@@ -1907,46 +1908,47 @@
 		B1A000000000000000000018 /* FocusCardFlipView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FocusCardFlipView.swift; sourceTree = "<group>"; };
 		B1A1C1D1E1F1020304050602 /* BootstrapFailureViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BootstrapFailureViewController.swift; sourceTree = "<group>"; };
 		B1A1C1D1E1F1020304050605 /* ProjectSelectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectSelectionViewModel.swift; sourceTree = "<group>"; };
-		B1C2D3E72F90000100AA1001 /* TaskWidgetFoundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoardWidgets/TaskWidgetFoundation.swift; sourceTree = SOURCE_ROOT; };
-		B1C2D3E82F90000100AA1001 /* TaskWidgetHomeViews.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoardWidgets/TaskWidgetHomeViews.swift; sourceTree = SOURCE_ROOT; };
-		B1C2D3E92F90000100AA1001 /* TaskWidgetAccessoryViews.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoardWidgets/TaskWidgetAccessoryViews.swift; sourceTree = SOURCE_ROOT; };
-		B1C2D3EB2F90000100AA1001 /* TaskWidgetDesignSystemCompat.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoardWidgets/TaskWidgetDesignSystemCompat.swift; sourceTree = SOURCE_ROOT; };
-		B1C2D3ED2F90000100AA1001 /* HomeCalendarWidgetView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoardWidgets/HomeCalendarWidgetView.swift; sourceTree = SOURCE_ROOT; };
-		B1C2D3F02F90000100AA1001 /* HomeTimelineWidgetView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoardWidgets/HomeTimelineWidgetView.swift; sourceTree = SOURCE_ROOT; };
-		B1D4A4EDAF6692D9D7819FF1 /* HomeOnboardingGuidanceBanner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/HomeOnboardingGuidanceBanner.swift; sourceTree = SOURCE_ROOT; };
+		B1C2D3E72F90000100AA1001 /* LifeBoardWidgets/TaskWidgetFoundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoardWidgets/TaskWidgetFoundation.swift; sourceTree = SOURCE_ROOT; };
+		B1C2D3E82F90000100AA1001 /* LifeBoardWidgets/TaskWidgetHomeViews.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoardWidgets/TaskWidgetHomeViews.swift; sourceTree = SOURCE_ROOT; };
+		B1C2D3E92F90000100AA1001 /* LifeBoardWidgets/TaskWidgetAccessoryViews.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoardWidgets/TaskWidgetAccessoryViews.swift; sourceTree = SOURCE_ROOT; };
+		B1C2D3EB2F90000100AA1001 /* LifeBoardWidgets/TaskWidgetDesignSystemCompat.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoardWidgets/TaskWidgetDesignSystemCompat.swift; sourceTree = SOURCE_ROOT; };
+		B1C2D3ED2F90000100AA1001 /* LifeBoardWidgets/HomeCalendarWidgetView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoardWidgets/HomeCalendarWidgetView.swift; sourceTree = SOURCE_ROOT; };
+		B1C2D3F02F90000100AA1001 /* LifeBoardWidgets/HomeTimelineWidgetView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoardWidgets/HomeTimelineWidgetView.swift; sourceTree = SOURCE_ROOT; };
+		B1D4A4EDAF6692D9D7819FF1 /* LifeBoard/Onboarding/Components/HomeOnboardingGuidanceBanner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/HomeOnboardingGuidanceBanner.swift; sourceTree = SOURCE_ROOT; };
 		B2039197BDDBF221CD921D76 /* LifeBoardWatchWidgetBundle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoardWatchWidgetBundle.swift; sourceTree = "<group>"; };
 		B20E51E01323F68DC0F47205 /* WatchSnapshotReceiver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WatchSnapshotReceiver.swift; sourceTree = "<group>"; };
-		B20F2D4962594CB52DC1918C /* CalendarIntegrationServiceExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Services/CalendarIntegrationServiceExtension.swift; sourceTree = SOURCE_ROOT; };
-		B2190A6A5BA73A78CB6CE64A /* TimelineTaskBlockRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineTaskBlockRow.swift; sourceTree = SOURCE_ROOT; };
-		B2BF76CE760383A7CA3E84F4 /* CreateTaskDefinitionUseCaseExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/CreateTaskDefinitionUseCaseExtension.swift; sourceTree = SOURCE_ROOT; };
+		B20F2D4962594CB52DC1918C /* LifeBoard/Onboarding/Services/CalendarIntegrationServiceExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Services/CalendarIntegrationServiceExtension.swift; sourceTree = SOURCE_ROOT; };
+		B2190A6A5BA73A78CB6CE64A /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineTaskBlockRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineTaskBlockRow.swift; sourceTree = SOURCE_ROOT; };
+		B2BF76CE760383A7CA3E84F4 /* LifeBoard/Onboarding/Models/CreateTaskDefinitionUseCaseExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/CreateTaskDefinitionUseCaseExtension.swift; sourceTree = SOURCE_ROOT; };
 		B2D4E5F6A7B8C9D0E1F2A3B4 /* KeyboardShortcutsCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcutsCard.swift; sourceTree = "<group>"; };
-		B2E100000000000000000101 /* HomeTodayRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Models/HomeTodayRow.swift; sourceTree = SOURCE_ROOT; };
-		B2E100000000000000000102 /* HomeHabitRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Models/HomeHabitRow.swift; sourceTree = SOURCE_ROOT; };
-		B2E100000000000000000103 /* BuildHomeAgendaUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Home/BuildHomeAgendaUseCase.swift; sourceTree = SOURCE_ROOT; };
-		B2E100000000000000000104 /* HomeHabitRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/View/HomeHabitRowView.swift; sourceTree = SOURCE_ROOT; };
-		B2E100000000000000000105 /* HomeSectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Models/HomeSectionState.swift; sourceTree = SOURCE_ROOT; };
-		B2E100000000000000000106 /* HomeHabitLastCellInteraction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Models/HomeHabitLastCellInteraction.swift; sourceTree = SOURCE_ROOT; };
-		B2E100000000000000000107 /* HomeTaskTintResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Models/HomeTaskTintResolver.swift; sourceTree = SOURCE_ROOT; };
-		B2E10000000000000000010B /* BuildNeedsReplanCandidatesUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Home/BuildNeedsReplanCandidatesUseCase.swift; sourceTree = SOURCE_ROOT; };
-		B2E10000000000000000010C /* HomeTimelineProjectionBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Home/HomeTimelineProjectionBuilder.swift; sourceTree = SOURCE_ROOT; };
-		B36F56E947D18C0D1D111E0C /* ChatScaffoldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Chrome/ChatScaffoldView.swift; sourceTree = SOURCE_ROOT; };
-		B37462636B49FEA555BA9E24 /* OnboardingLoopingPlayerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Views/OnboardingLoopingPlayerView.swift; sourceTree = SOURCE_ROOT; };
-		B3A1F2C4D5E6F708 /* AchievementCatalog.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/AchievementCatalog.swift; sourceTree = SOURCE_ROOT; };
-		B3A1F2C4D5E6F709 /* BadgeGalleryView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/View/BadgeGalleryView.swift; sourceTree = SOURCE_ROOT; };
-		B3A1F2C4D5E6F70A /* LevelUpCelebrationView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/View/LevelUpCelebrationView.swift; sourceTree = SOURCE_ROOT; };
-		B3A1F2C4D5E6F70B /* MilestoneCelebrationView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/View/MilestoneCelebrationView.swift; sourceTree = SOURCE_ROOT; };
-		B3A1F2C4D5E6F70C /* BadgeDetailSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/View/BadgeDetailSheet.swift; sourceTree = SOURCE_ROOT; };
-		B3A7A770EE9760A923219618 /* StarterTaskTemplate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/StarterTaskTemplate.swift; sourceTree = SOURCE_ROOT; };
-		B3CBE8CE6330FA556306A57F /* HomeViewModel+HabitMutations.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+HabitMutations.swift"; sourceTree = SOURCE_ROOT; };
+		B2E100000000000000000101 /* LifeBoard/Presentation/Models/HomeTodayRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Models/HomeTodayRow.swift; sourceTree = SOURCE_ROOT; };
+		B2E100000000000000000102 /* LifeBoard/Presentation/Models/HomeHabitRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Models/HomeHabitRow.swift; sourceTree = SOURCE_ROOT; };
+		B2E100000000000000000103 /* LifeBoard/UseCases/Home/BuildHomeAgendaUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Home/BuildHomeAgendaUseCase.swift; sourceTree = SOURCE_ROOT; };
+		B2E100000000000000000104 /* LifeBoard/View/HomeHabitRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/View/HomeHabitRowView.swift; sourceTree = SOURCE_ROOT; };
+		B2E100000000000000000105 /* LifeBoard/Presentation/Models/HomeSectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Models/HomeSectionState.swift; sourceTree = SOURCE_ROOT; };
+		B2E100000000000000000106 /* LifeBoard/Presentation/Models/HomeHabitLastCellInteraction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Models/HomeHabitLastCellInteraction.swift; sourceTree = SOURCE_ROOT; };
+		B2E100000000000000000107 /* LifeBoard/Presentation/Models/HomeTaskTintResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Models/HomeTaskTintResolver.swift; sourceTree = SOURCE_ROOT; };
+		B2E10000000000000000010B /* LifeBoard/UseCases/Home/BuildNeedsReplanCandidatesUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Home/BuildNeedsReplanCandidatesUseCase.swift; sourceTree = SOURCE_ROOT; };
+		B2E10000000000000000010C /* LifeBoard/UseCases/Home/HomeTimelineProjectionBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Home/HomeTimelineProjectionBuilder.swift; sourceTree = SOURCE_ROOT; };
+		B36F56E947D18C0D1D111E0C /* LifeBoard/LLM/Views/Chat/Chrome/ChatScaffoldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Chrome/ChatScaffoldView.swift; sourceTree = SOURCE_ROOT; };
+		B37462636B49FEA555BA9E24 /* LifeBoard/Onboarding/Views/OnboardingLoopingPlayerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Views/OnboardingLoopingPlayerView.swift; sourceTree = SOURCE_ROOT; };
+		B3A1F2C4D5E6F708 /* LifeBoard/Domain/Models/AchievementCatalog.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/AchievementCatalog.swift; sourceTree = SOURCE_ROOT; };
+		B3A1F2C4D5E6F709 /* LifeBoard/View/BadgeGalleryView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/View/BadgeGalleryView.swift; sourceTree = SOURCE_ROOT; };
+		B3A1F2C4D5E6F70A /* LifeBoard/View/LevelUpCelebrationView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/View/LevelUpCelebrationView.swift; sourceTree = SOURCE_ROOT; };
+		B3A1F2C4D5E6F70B /* LifeBoard/View/MilestoneCelebrationView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/View/MilestoneCelebrationView.swift; sourceTree = SOURCE_ROOT; };
+		B3A1F2C4D5E6F70C /* LifeBoard/View/BadgeDetailSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/View/BadgeDetailSheet.swift; sourceTree = SOURCE_ROOT; };
+		B3A7A770EE9760A923219618 /* LifeBoard/Onboarding/Models/StarterTaskTemplate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/StarterTaskTemplate.swift; sourceTree = SOURCE_ROOT; };
+		B3CBE8CE6330FA556306A57F /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+HabitMutations.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+HabitMutations.swift"; sourceTree = SOURCE_ROOT; };
 		B3DFC4F80E1254139A27C0C5 /* HomeDailySummaryModalSupport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeDailySummaryModalSupport.swift; sourceTree = "<group>"; };
-		B4599EE24B534345B7E5F063 /* WeeklyScoreboardWidget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoardWidgets/WeeklyScoreboardWidget.swift; sourceTree = SOURCE_ROOT; };
-		B4A711DF246A39E6B7030180 /* LifeManagementProjectIconPicker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementProjectIconPicker.swift; sourceTree = SOURCE_ROOT; };
+		B4599EE24B534345B7E5F063 /* LifeBoardWidgets/WeeklyScoreboardWidget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoardWidgets/WeeklyScoreboardWidget.swift; sourceTree = SOURCE_ROOT; };
+		B4A711DF246A39E6B7030180 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementProjectIconPicker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementProjectIconPicker.swift; sourceTree = SOURCE_ROOT; };
 		B4D7E8213A4F5C6D7E8F9011 /* V3TestHarness.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = V3TestHarness.swift; sourceTree = "<group>"; };
-		B515F171FB9C556BBCA40366 /* AppOnboardingAccessibilityID.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/AppOnboardingAccessibilityID.swift; sourceTree = SOURCE_ROOT; };
-		B543DD59DC3D9705F73261A4 /* OverdueRescuePlant.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescuePlant.swift; sourceTree = SOURCE_ROOT; };
-		B6AA12D4A60EA9B1E6A316B7 /* lifeManagementAreaPaletteOptions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/lifeManagementAreaPaletteOptions.swift; sourceTree = SOURCE_ROOT; };
-		B700950871CD345DFF559A61 /* OverdueRescueQuickEditSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueQuickEditSheet.swift; sourceTree = SOURCE_ROOT; };
-		B72A4F99B2064E4A639A6264 /* EvaDayTaskHeaderView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Conversation/EvaDayTaskHeaderView.swift; sourceTree = SOURCE_ROOT; };
+		B4D7E8213A4F5C6D7E8F9015 /* SharedColorTestHelpers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SharedColorTestHelpers.swift; sourceTree = "<group>"; };
+		B515F171FB9C556BBCA40366 /* LifeBoard/Onboarding/Models/AppOnboardingAccessibilityID.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/AppOnboardingAccessibilityID.swift; sourceTree = SOURCE_ROOT; };
+		B543DD59DC3D9705F73261A4 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescuePlant.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescuePlant.swift; sourceTree = SOURCE_ROOT; };
+		B6AA12D4A60EA9B1E6A316B7 /* LifeBoard/Views/Settings/LifeManagement/lifeManagementAreaPaletteOptions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/lifeManagementAreaPaletteOptions.swift; sourceTree = SOURCE_ROOT; };
+		B700950871CD345DFF559A61 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueQuickEditSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueQuickEditSheet.swift; sourceTree = SOURCE_ROOT; };
+		B72A4F99B2064E4A639A6264 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayTaskHeaderView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Conversation/EvaDayTaskHeaderView.swift; sourceTree = SOURCE_ROOT; };
 		B7C8D9E0F1A2233445566778 /* OverdueAgeFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverdueAgeFormatter.swift; sourceTree = "<group>"; };
 		B7C8D9E0F1A223344556677A /* OverdueAgeFormatterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OverdueAgeFormatterTests.swift; sourceTree = "<group>"; };
 		B7C8D9E0F1A223344556677C /* SunriseFocusZoneStatusTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SunriseFocusZoneStatusTests.swift; sourceTree = "<group>"; };
@@ -1955,38 +1957,38 @@
 		B7C8D9E12F6A100100ABC123 /* ChatPlanApplyUndoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatPlanApplyUndoTests.swift; sourceTree = "<group>"; };
 		B7C8D9E32F6A100100ABC123 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		B812E7A0B879607C95C0571B /* ColorTokens.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ColorTokens.swift; sourceTree = "<group>"; };
-		B822ABD8182F921799838D39 /* TimelineSpineMounting.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineSpineMounting.swift; sourceTree = SOURCE_ROOT; };
+		B822ABD8182F921799838D39 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineSpineMounting.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineSpineMounting.swift; sourceTree = SOURCE_ROOT; };
 		B8E100002F70000100A0A001 /* LifeBoardCTABezel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoardCTABezel.swift; sourceTree = "<group>"; };
-		B8E100022F70000100A0A001 /* LifeBoardCTABezel.metal */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.metal; path = Effects/LifeBoardCTABezel.metal; sourceTree = "<group>"; };
+		B8E100022F70000100A0A001 /* Effects/LifeBoardCTABezel.metal */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.metal; path = Effects/LifeBoardCTABezel.metal; sourceTree = "<group>"; };
 		B8E100042F70000100A0A001 /* LifeBoardCTABezelResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoardCTABezelResolverTests.swift; sourceTree = "<group>"; };
 		B8F9A0B1C2D3E4F506172838 /* LLMPersonalMemoryStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLMPersonalMemoryStoreTests.swift; sourceTree = "<group>"; };
-		B9115CDED706EB4E49B732A6 /* TimelineTaskMarkerRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineTaskMarkerRow.swift; sourceTree = SOURCE_ROOT; };
-		B95AB168FC420F7EE412CB09 /* CelebrationRouter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/CelebrationRouter.swift; sourceTree = SOURCE_ROOT; };
-		B9CD88BD827717D7C56D112A /* OnboardingFrictionProfile.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingFrictionProfile.swift; sourceTree = SOURCE_ROOT; };
+		B9115CDED706EB4E49B732A6 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineTaskMarkerRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineTaskMarkerRow.swift; sourceTree = SOURCE_ROOT; };
+		B95AB168FC420F7EE412CB09 /* LifeBoard/Presentation/ViewModels/Home/CelebrationRouter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/CelebrationRouter.swift; sourceTree = SOURCE_ROOT; };
+		B9CD88BD827717D7C56D112A /* LifeBoard/Onboarding/Models/OnboardingFrictionProfile.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingFrictionProfile.swift; sourceTree = SOURCE_ROOT; };
 		B9F0161DC62BDB27BEE93C1D /* HomeViewController+RenderPipeline.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "HomeViewController+RenderPipeline.swift"; sourceTree = "<group>"; };
-		B9F2A10C3D4E5F60718293AA /* WriteClosedRepositoryAdapters.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Sync/WriteClosedRepositoryAdapters.swift; sourceTree = SOURCE_ROOT; };
+		B9F2A10C3D4E5F60718293AA /* LifeBoard/State/Sync/WriteClosedRepositoryAdapters.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Sync/WriteClosedRepositoryAdapters.swift; sourceTree = SOURCE_ROOT; };
 		BA3610ABC404898F73D042EA /* LifeBoardWatchApp.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoardWatchApp.swift; sourceTree = "<group>"; };
-		BA66AB0570744BB33285402E /* HomeTaskMutationEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeTaskMutationEvent.swift; sourceTree = SOURCE_ROOT; };
-		BA878C13E4A9CF39A3D86B40 /* OnboardingChecklistCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingChecklistCard.swift; sourceTree = SOURCE_ROOT; };
-		BAD49D68C47ABAA22C239873 /* AppOnboardingJourneyView+OutcomeDraftsAndActions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Onboarding/Views/AppOnboardingJourneyView+OutcomeDraftsAndActions.swift"; sourceTree = SOURCE_ROOT; };
-		BAED50033BDBC1C4321DF9AA /* DailyTimelineAgendaView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/DailyTimelineAgendaView.swift; sourceTree = SOURCE_ROOT; };
-		BC8C39098BF0A10AE6CC5EE3 /* EvaChiefOfStaffGuideView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Chrome/EvaChiefOfStaffGuideView.swift; sourceTree = SOURCE_ROOT; };
+		BA66AB0570744BB33285402E /* LifeBoard/Presentation/ViewModels/Home/HomeTaskMutationEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeTaskMutationEvent.swift; sourceTree = SOURCE_ROOT; };
+		BA878C13E4A9CF39A3D86B40 /* LifeBoard/Onboarding/Components/OnboardingChecklistCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingChecklistCard.swift; sourceTree = SOURCE_ROOT; };
+		BAD49D68C47ABAA22C239873 /* LifeBoard/Onboarding/Views/AppOnboardingJourneyView+OutcomeDraftsAndActions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Onboarding/Views/AppOnboardingJourneyView+OutcomeDraftsAndActions.swift"; sourceTree = SOURCE_ROOT; };
+		BAED50033BDBC1C4321DF9AA /* LifeBoard/Presentation/Home/Timeline/Surface/DailyTimelineAgendaView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/DailyTimelineAgendaView.swift; sourceTree = SOURCE_ROOT; };
+		BC8C39098BF0A10AE6CC5EE3 /* LifeBoard/LLM/Views/Chat/Chrome/EvaChiefOfStaffGuideView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Chrome/EvaChiefOfStaffGuideView.swift; sourceTree = SOURCE_ROOT; };
 		BC92DC6157EF1B9AAB1422D9 /* SettingsRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRootView.swift; sourceTree = "<group>"; };
 		BCD0B9C7DEE094DB1B55D5BD /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
-		BDD85FEB40E7B6C3538EA14A /* TimelineInboxPlanningCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineInboxPlanningCard.swift; sourceTree = SOURCE_ROOT; };
-		BDED467BEDE45453B0C91BEF /* EvaLiveWorkingStatusView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Conversation/EvaLiveWorkingStatusView.swift; sourceTree = SOURCE_ROOT; };
-		BED7C8A4030249843AED943D /* DeleteAreaSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/DeleteAreaSheet.swift; sourceTree = SOURCE_ROOT; };
-		BF3952602FF1A9D756382492 /* LifeManagementTreeInteractionMode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementTreeInteractionMode.swift; sourceTree = SOURCE_ROOT; };
+		BDD85FEB40E7B6C3538EA14A /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineInboxPlanningCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineInboxPlanningCard.swift; sourceTree = SOURCE_ROOT; };
+		BDED467BEDE45453B0C91BEF /* LifeBoard/LLM/Views/Chat/Conversation/EvaLiveWorkingStatusView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Conversation/EvaLiveWorkingStatusView.swift; sourceTree = SOURCE_ROOT; };
+		BED7C8A4030249843AED943D /* LifeBoard/Views/Settings/LifeManagement/DeleteAreaSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/DeleteAreaSheet.swift; sourceTree = SOURCE_ROOT; };
+		BF3952602FF1A9D756382492 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementTreeInteractionMode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementTreeInteractionMode.swift; sourceTree = SOURCE_ROOT; };
 		BF5D7161411B42651DF00D60 /* SunriseAppShellView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SunriseAppShellView.swift; sourceTree = "<group>"; };
-		C041D826927F12B5D4A445BA /* SunriseAppShellView+SearchSurface.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+SearchSurface.swift"; sourceTree = SOURCE_ROOT; };
+		C041D826927F12B5D4A445BA /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+SearchSurface.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+SearchSurface.swift"; sourceTree = SOURCE_ROOT; };
 		C0D48163BE7D31AF707E99B7 /* HomeArchitectureProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeArchitectureProtocols.swift; sourceTree = "<group>"; };
-		C1256A6FF63A60FC9D9E82C2 /* LifeBoardWidgetBundle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoardWidgets/LifeBoardWidgetBundle.swift; sourceTree = SOURCE_ROOT; };
+		C1256A6FF63A60FC9D9E82C2 /* LifeBoardWidgets/LifeBoardWidgetBundle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoardWidgets/LifeBoardWidgetBundle.swift; sourceTree = SOURCE_ROOT; };
 		C1429E78D48CAF30D016B671 /* NotificationTypesCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationTypesCard.swift; sourceTree = "<group>"; };
-		C16F9565F3F8F2F079B9CE76 /* OnboardingStarterHabitPreference.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingStarterHabitPreference.swift; sourceTree = SOURCE_ROOT; };
-		C1A100000000000000000001 /* HabitRuntimeReadRepositoryProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Interfaces/HabitRuntimeReadRepositoryProtocol.swift; sourceTree = SOURCE_ROOT; };
-		C1A100000000000000000002 /* HabitTypes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/HabitTypes.swift; sourceTree = SOURCE_ROOT; };
-		C1A100000000000000000003 /* HabitRuntimeUseCases.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Habit/HabitRuntimeUseCases.swift; sourceTree = SOURCE_ROOT; };
-		C1A100000000000000000004 /* CoreDataHabitRuntimeReadRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Repositories/CoreDataHabitRuntimeReadRepository.swift; sourceTree = SOURCE_ROOT; };
+		C16F9565F3F8F2F079B9CE76 /* LifeBoard/Onboarding/Models/OnboardingStarterHabitPreference.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingStarterHabitPreference.swift; sourceTree = SOURCE_ROOT; };
+		C1A100000000000000000001 /* LifeBoard/Domain/Interfaces/HabitRuntimeReadRepositoryProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Interfaces/HabitRuntimeReadRepositoryProtocol.swift; sourceTree = SOURCE_ROOT; };
+		C1A100000000000000000002 /* LifeBoard/Domain/Models/HabitTypes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/HabitTypes.swift; sourceTree = SOURCE_ROOT; };
+		C1A100000000000000000003 /* LifeBoard/UseCases/Habit/HabitRuntimeUseCases.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Habit/HabitRuntimeUseCases.swift; sourceTree = SOURCE_ROOT; };
+		C1A100000000000000000004 /* LifeBoard/State/Repositories/CoreDataHabitRuntimeReadRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Repositories/CoreDataHabitRuntimeReadRepository.swift; sourceTree = SOURCE_ROOT; };
 		C1A2B3C4D5E6F70011223345 /* LLMRuntimeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLMRuntimeCoordinator.swift; sourceTree = "<group>"; };
 		C1A2B3C4D5E6F70011223347 /* LLMProjectionTimeout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLMProjectionTimeout.swift; sourceTree = "<group>"; };
 		C1A2B3C4D5E6F70011223349 /* LLMRuntimeCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLMRuntimeCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -1994,22 +1996,22 @@
 		C1A2B3C4D5E6F70011223351 /* LLMInferenceEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLMInferenceEngine.swift; sourceTree = "<group>"; };
 		C1A2B3C4D5E6F70011223353 /* ChatTranscriptSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTranscriptSnapshot.swift; sourceTree = "<group>"; };
 		C1A2B3C4D5E6F70011223355 /* ChatTranscriptSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTranscriptSnapshotTests.swift; sourceTree = "<group>"; };
-		C1B100000000000000000101 /* HabitBoardPresentationBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Habits/HabitBoardPresentationBuilder.swift; sourceTree = SOURCE_ROOT; };
-		C1B100000000000000000103 /* HabitBoardViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/HabitBoardViewModel.swift; sourceTree = SOURCE_ROOT; };
-		C1B100000000000000000105 /* HabitBoardViews.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/View/HabitBoardViews.swift; sourceTree = SOURCE_ROOT; };
+		C1B100000000000000000101 /* LifeBoard/Presentation/Habits/HabitBoardPresentationBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Habits/HabitBoardPresentationBuilder.swift; sourceTree = SOURCE_ROOT; };
+		C1B100000000000000000103 /* LifeBoard/Presentation/ViewModels/HabitBoardViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/HabitBoardViewModel.swift; sourceTree = SOURCE_ROOT; };
+		C1B100000000000000000105 /* LifeBoard/View/HabitBoardViews.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/View/HabitBoardViews.swift; sourceTree = SOURCE_ROOT; };
 		C1B2C3D4E5F60718293A4B5C /* LifeManagementDestructiveFlowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeManagementDestructiveFlowCoordinator.swift; sourceTree = "<group>"; };
-		C20400B4B017F188A0F00344 /* OverdueRescueDeckState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDeckState.swift; sourceTree = SOURCE_ROOT; };
-		C2BC103F549E15D1F888996A /* OnboardingPastelPalette.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingPastelPalette.swift; sourceTree = SOURCE_ROOT; };
-		C2C66FE334854F296A4203FD /* TagDefinition.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/TagDefinition.swift; sourceTree = SOURCE_ROOT; };
+		C20400B4B017F188A0F00344 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDeckState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDeckState.swift; sourceTree = SOURCE_ROOT; };
+		C2BC103F549E15D1F888996A /* LifeBoard/Onboarding/Models/OnboardingPastelPalette.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingPastelPalette.swift; sourceTree = SOURCE_ROOT; };
+		C2C66FE334854F296A4203FD /* LifeBoard/Domain/Models/TagDefinition.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/TagDefinition.swift; sourceTree = SOURCE_ROOT; };
 		C2D3E4F5061728394A5B6C7C /* DeleteTaskDefinitionUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteTaskDefinitionUseCaseTests.swift; sourceTree = "<group>"; };
-		C2D47EF8C1159050CDCE28D6 /* EvaChatSunriseBackground.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Chrome/EvaChatSunriseBackground.swift; sourceTree = SOURCE_ROOT; };
-		C2FC9E261B9D943C48C8EEC4 /* HomeTimelineCalendarSignature.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeTimelineCalendarSignature.swift; sourceTree = SOURCE_ROOT; };
-		C30956B2414E9EE5EACA5A60 /* HomeViewModel+FocusRankingAndWidgetSnapshot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+FocusRankingAndWidgetSnapshot.swift"; sourceTree = SOURCE_ROOT; };
+		C2D47EF8C1159050CDCE28D6 /* LifeBoard/LLM/Views/Chat/Chrome/EvaChatSunriseBackground.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Chrome/EvaChatSunriseBackground.swift; sourceTree = SOURCE_ROOT; };
+		C2FC9E261B9D943C48C8EEC4 /* LifeBoard/Presentation/ViewModels/Home/HomeTimelineCalendarSignature.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeTimelineCalendarSignature.swift; sourceTree = SOURCE_ROOT; };
+		C30956B2414E9EE5EACA5A60 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+FocusRankingAndWidgetSnapshot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+FocusRankingAndWidgetSnapshot.swift"; sourceTree = SOURCE_ROOT; };
 		C39FDE21811FCBE733038318 /* GetHomeFilteredTasksUseCaseTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GetHomeFilteredTasksUseCaseTests.swift; sourceTree = "<group>"; };
-		C3D2A8B1ED9E802D3D13F58F /* gapPromptTint.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/gapPromptTint.swift; sourceTree = SOURCE_ROOT; };
+		C3D2A8B1ED9E802D3D13F58F /* LifeBoard/Presentation/Home/Timeline/Surface/gapPromptTint.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/gapPromptTint.swift; sourceTree = SOURCE_ROOT; };
 		C3D8D5167F9519588886C38B /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/WatchOS.platform/Developer/SDKs/WatchOS11.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		C4A9726955E0A1C39832E736 /* HomeNotificationNameExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeNotificationNameExtension.swift; sourceTree = SOURCE_ROOT; };
-		C4AF3952DBA8C2ACE185FEF0 /* DailyXPAggregateDefinition.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/DailyXPAggregateDefinition.swift; sourceTree = SOURCE_ROOT; };
+		C4A9726955E0A1C39832E736 /* LifeBoard/Presentation/ViewModels/Home/HomeNotificationNameExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeNotificationNameExtension.swift; sourceTree = SOURCE_ROOT; };
+		C4AF3952DBA8C2ACE185FEF0 /* LifeBoard/Domain/Models/DailyXPAggregateDefinition.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/DailyXPAggregateDefinition.swift; sourceTree = SOURCE_ROOT; };
 		C4C3F70CE989FCF07417B5EE /* TaskReadModelRepositoryProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TaskReadModelRepositoryProtocol.swift; sourceTree = "<group>"; };
 		C4D5E6F70891A2B3C4D5E700 /* TaskScheduleEditor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TaskScheduleEditor.swift; sourceTree = "<group>"; };
 		C4D5E6F70891A2B3C4D5E703 /* SunriseTaskDetailScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SunriseTaskDetailScreen.swift; sourceTree = "<group>"; };
@@ -2019,9 +2021,9 @@
 		C4D5E6F70891A2B3C4D5E70D /* TimelineAnchorRitualModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TimelineAnchorRitualModel.swift; sourceTree = "<group>"; };
 		C4D5E6F70891A2B3C4D5E70E /* TimelineAnchorWaveShape.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TimelineAnchorWaveShape.swift; sourceTree = "<group>"; };
 		C4D5E6F70891A2B3C4D5E70F /* TimelineAnchorRitualSheetView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TimelineAnchorRitualSheetView.swift; sourceTree = "<group>"; };
-		C4E67C5C94F45D6D66D5E526 /* AccentIconBadge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/AccentIconBadge.swift; sourceTree = SOURCE_ROOT; };
-		C53A20FDEE1A1CCD05E76506 /* ViewExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/ViewExtension.swift; sourceTree = SOURCE_ROOT; };
-		C58C70A0C8851CAB1139F1E7 /* OverdueRescueViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueViewModel.swift; sourceTree = SOURCE_ROOT; };
+		C4E67C5C94F45D6D66D5E526 /* LifeBoard/Views/Settings/LifeManagement/AccentIconBadge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/AccentIconBadge.swift; sourceTree = SOURCE_ROOT; };
+		C53A20FDEE1A1CCD05E76506 /* LifeBoard/Onboarding/Components/ViewExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/ViewExtension.swift; sourceTree = SOURCE_ROOT; };
+		C58C70A0C8851CAB1139F1E7 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueViewModel.swift; sourceTree = SOURCE_ROOT; };
 		C5A1D20E3F4B6789ABCDEF01 /* AddTaskCreateButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTaskCreateButton.swift; sourceTree = "<group>"; };
 		C5A1D20E3F4B6789ABCDEF02 /* AddTaskDescriptionField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTaskDescriptionField.swift; sourceTree = "<group>"; };
 		C5A1D20E3F4B6789ABCDEF03 /* AddTaskInlineCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTaskInlineCreator.swift; sourceTree = "<group>"; };
@@ -2037,54 +2039,54 @@
 		C5A1D20E3F4B6789ABCDEF0E /* SunriseAddHabitSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SunriseAddHabitSheetView.swift; sourceTree = "<group>"; };
 		C5A1D20E3F4B6789ABCDEF0F /* CreationPresentationContracts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreationPresentationContracts.swift; sourceTree = "<group>"; };
 		C5A1D20E3F4B6789ABCDEF10 /* CreationSharedComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreationSharedComponents.swift; sourceTree = "<group>"; };
-		C5AE575AEC28DEC3F5464818 /* SunriseTimelineSurfaceRoot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/SunriseTimelineSurfaceRoot.swift; sourceTree = SOURCE_ROOT; };
+		C5AE575AEC28DEC3F5464818 /* LifeBoard/Presentation/Home/Timeline/Surface/SunriseTimelineSurfaceRoot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/SunriseTimelineSurfaceRoot.swift; sourceTree = SOURCE_ROOT; };
 		C5DC4383109EA7E312BED57A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		C63740651E231116AA556D8F /* MarkDailyReflectionCompleteUseCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Gamification/MarkDailyReflectionCompleteUseCase.swift; sourceTree = SOURCE_ROOT; };
-		C701CAA6DB1096F5F422F9AC /* TimelineAgendaAnchorRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineAgendaAnchorRow.swift; sourceTree = SOURCE_ROOT; };
+		C63740651E231116AA556D8F /* LifeBoard/UseCases/Gamification/MarkDailyReflectionCompleteUseCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Gamification/MarkDailyReflectionCompleteUseCase.swift; sourceTree = SOURCE_ROOT; };
+		C701CAA6DB1096F5F422F9AC /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineAgendaAnchorRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineAgendaAnchorRow.swift; sourceTree = SOURCE_ROOT; };
 		C7A200000000000000000002 /* ChatGenerationCancellationPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatGenerationCancellationPolicy.swift; sourceTree = "<group>"; };
 		C7A200000000000000000004 /* ChatCancellationPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatCancellationPolicyTests.swift; sourceTree = "<group>"; };
 		C7A200000000000000000006 /* LockedResultAccumulator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockedResultAccumulator.swift; sourceTree = "<group>"; };
 		C7A200000000000000000008 /* HomeTriageAndTop3Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTriageAndTop3Tests.swift; sourceTree = "<group>"; };
-		C7A6D85F245E9F672238D9E0 /* ChatComposerView+StructuredComposer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/LLM/Views/Chat/Chrome/ChatComposerView+StructuredComposer.swift"; sourceTree = SOURCE_ROOT; };
-		C81997132A898566B3451D49 /* EvaDayStatusChipsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Conversation/EvaDayStatusChipsView.swift; sourceTree = SOURCE_ROOT; };
-		C869F0E1F0337702AD2AF780 /* TimelineCompactConnector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompactConnector.swift; sourceTree = SOURCE_ROOT; };
+		C7A6D85F245E9F672238D9E0 /* LifeBoard/LLM/Views/Chat/Chrome/ChatComposerView+StructuredComposer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/LLM/Views/Chat/Chrome/ChatComposerView+StructuredComposer.swift"; sourceTree = SOURCE_ROOT; };
+		C81997132A898566B3451D49 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayStatusChipsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Conversation/EvaDayStatusChipsView.swift; sourceTree = SOURCE_ROOT; };
+		C869F0E1F0337702AD2AF780 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompactConnector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompactConnector.swift; sourceTree = SOURCE_ROOT; };
 		C8A4F1023D6E4B7A91C2D301 /* HabitBoardViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HabitBoardViewModelTests.swift; sourceTree = "<group>"; };
 		C8A4F1023D6E4B7A91C2D303 /* HabitBoardUITests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HabitBoardUITests.swift; sourceTree = "<group>"; };
-		C8E1864B29C7801E433C2D11 /* HomeViewModel+TaskActions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+TaskActions.swift"; sourceTree = SOURCE_ROOT; };
-		C8F9A299A8C725C1852BB744 /* OnboardingPromptBackground.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingPromptBackground.swift; sourceTree = SOURCE_ROOT; };
-		C95AF729D85C65D636AF500A /* TimelineBackdropWeekView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineBackdropWeekView.swift; sourceTree = SOURCE_ROOT; };
-		C96EA41B0CDC25339F1E726E /* OverdueRescueViewModel+CardActions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueViewModel+CardActions.swift"; sourceTree = SOURCE_ROOT; };
-		C9F3897EC91C68C4A79F81A8 /* TimelineRailLabelKind.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailLabelKind.swift; sourceTree = SOURCE_ROOT; };
-		CA1A20000000000000000001 /* CalendarEventsProviderProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Interfaces/CalendarEventsProviderProtocol.swift; sourceTree = SOURCE_ROOT; };
-		CA1A20000000000000000002 /* CalendarIntegrationModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/CalendarIntegrationModels.swift; sourceTree = SOURCE_ROOT; };
-		CA1A20000000000000000003 /* CalendarComputationUseCases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Calendar/CalendarComputationUseCases.swift; sourceTree = SOURCE_ROOT; };
-		CA1A20000000000000000004 /* EventKitCalendarEventsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Services/EventKitCalendarEventsProvider.swift; sourceTree = SOURCE_ROOT; };
-		CA1A20000000000000000005 /* CalendarIntegrationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Services/CalendarIntegrationService.swift; sourceTree = SOURCE_ROOT; };
-		CA1A20000000000000000006 /* EventKitCalendarChooserSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/View/Calendar/EventKitCalendarChooserSheet.swift; sourceTree = SOURCE_ROOT; };
-		CA1A20000000000000000007 /* EventKitEventDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/View/Calendar/EventKitEventDetailView.swift; sourceTree = SOURCE_ROOT; };
+		C8E1864B29C7801E433C2D11 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+TaskActions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+TaskActions.swift"; sourceTree = SOURCE_ROOT; };
+		C8F9A299A8C725C1852BB744 /* LifeBoard/Onboarding/Components/OnboardingPromptBackground.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingPromptBackground.swift; sourceTree = SOURCE_ROOT; };
+		C95AF729D85C65D636AF500A /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineBackdropWeekView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineBackdropWeekView.swift; sourceTree = SOURCE_ROOT; };
+		C96EA41B0CDC25339F1E726E /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueViewModel+CardActions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueViewModel+CardActions.swift"; sourceTree = SOURCE_ROOT; };
+		C9F3897EC91C68C4A79F81A8 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailLabelKind.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailLabelKind.swift; sourceTree = SOURCE_ROOT; };
+		CA1A20000000000000000001 /* LifeBoard/Domain/Interfaces/CalendarEventsProviderProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Interfaces/CalendarEventsProviderProtocol.swift; sourceTree = SOURCE_ROOT; };
+		CA1A20000000000000000002 /* LifeBoard/Domain/Models/CalendarIntegrationModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/CalendarIntegrationModels.swift; sourceTree = SOURCE_ROOT; };
+		CA1A20000000000000000003 /* LifeBoard/UseCases/Calendar/CalendarComputationUseCases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Calendar/CalendarComputationUseCases.swift; sourceTree = SOURCE_ROOT; };
+		CA1A20000000000000000004 /* LifeBoard/State/Services/EventKitCalendarEventsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Services/EventKitCalendarEventsProvider.swift; sourceTree = SOURCE_ROOT; };
+		CA1A20000000000000000005 /* LifeBoard/State/Services/CalendarIntegrationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Services/CalendarIntegrationService.swift; sourceTree = SOURCE_ROOT; };
+		CA1A20000000000000000006 /* LifeBoard/View/Calendar/EventKitCalendarChooserSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/View/Calendar/EventKitCalendarChooserSheet.swift; sourceTree = SOURCE_ROOT; };
+		CA1A20000000000000000007 /* LifeBoard/View/Calendar/EventKitEventDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/View/Calendar/EventKitEventDetailView.swift; sourceTree = SOURCE_ROOT; };
 		CA1A20000000000000000009 /* CalendarComputationUseCasesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarComputationUseCasesTests.swift; sourceTree = "<group>"; };
 		CA1A2000000000000000000A /* CalendarIntegrationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarIntegrationServiceTests.swift; sourceTree = "<group>"; };
 		CA1A2000000000000000000B /* HomeCalendarIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCalendarIntegrationTests.swift; sourceTree = "<group>"; };
 		CA1A2000000000000000000C /* CalendarTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarTestSupport.swift; sourceTree = "<group>"; };
 		CA1A2000000000000000000D /* HomeCalendarModuleUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCalendarModuleUITests.swift; sourceTree = "<group>"; };
 		CA35E641ED7341169B9EC48D /* TypographyTokens.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TypographyTokens.swift; sourceTree = "<group>"; };
-		CA4596A02DBC4C81BD5D267F /* HomeViewModel+ProjectionInvalidation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+ProjectionInvalidation.swift"; sourceTree = SOURCE_ROOT; };
-		CB037D639903A5E22295113F /* OverdueRescueDeckView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDeckView.swift; sourceTree = SOURCE_ROOT; };
-		CB45FAF57431067D93F59BA3 /* SunriseAppShellView+FocusTimersAndReflection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+FocusTimersAndReflection.swift"; sourceTree = SOURCE_ROOT; };
-		CC4A401D3FB5682FC6804B6F /* OnboardingTaskPreviewCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingTaskPreviewCard.swift; sourceTree = SOURCE_ROOT; };
+		CA4596A02DBC4C81BD5D267F /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+ProjectionInvalidation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+ProjectionInvalidation.swift"; sourceTree = SOURCE_ROOT; };
+		CB037D639903A5E22295113F /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDeckView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDeckView.swift; sourceTree = SOURCE_ROOT; };
+		CB45FAF57431067D93F59BA3 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+FocusTimersAndReflection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+FocusTimersAndReflection.swift"; sourceTree = SOURCE_ROOT; };
+		CC4A401D3FB5682FC6804B6F /* LifeBoard/Onboarding/Components/OnboardingTaskPreviewCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingTaskPreviewCard.swift; sourceTree = SOURCE_ROOT; };
 		CCBCDF94E1BBCA170FD4E6C2 /* HomeQuickView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeQuickView.swift; sourceTree = "<group>"; };
-		CD059BC932A17FD845CAC6CD /* TombstoneMapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Mappers/TombstoneMapper.swift; sourceTree = SOURCE_ROOT; };
-		CD51EED85A7A2713DD596393 /* OnboardingFlowModel+LifeAreaHabitTaskSetup.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Onboarding/Services/OnboardingFlowModel+LifeAreaHabitTaskSetup.swift"; sourceTree = SOURCE_ROOT; };
-		CD8641383368773B407AE249 /* SunriseAppShellView+HomeScreenComposition.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+HomeScreenComposition.swift"; sourceTree = SOURCE_ROOT; };
-		CDB9D4FD3A636968AEBF5DB7 /* AppOnboardingCoordinator+Presentation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Onboarding/Coordinator/AppOnboardingCoordinator+Presentation.swift"; sourceTree = SOURCE_ROOT; };
-		CF4E3B7EAAC54AE18553A302 /* OnboardingEligibility.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingEligibility.swift; sourceTree = SOURCE_ROOT; };
+		CD059BC932A17FD845CAC6CD /* LifeBoard/Domain/Mappers/TombstoneMapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Mappers/TombstoneMapper.swift; sourceTree = SOURCE_ROOT; };
+		CD51EED85A7A2713DD596393 /* LifeBoard/Onboarding/Services/OnboardingFlowModel+LifeAreaHabitTaskSetup.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Onboarding/Services/OnboardingFlowModel+LifeAreaHabitTaskSetup.swift"; sourceTree = SOURCE_ROOT; };
+		CD8641383368773B407AE249 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+HomeScreenComposition.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+HomeScreenComposition.swift"; sourceTree = SOURCE_ROOT; };
+		CDB9D4FD3A636968AEBF5DB7 /* LifeBoard/Onboarding/Coordinator/AppOnboardingCoordinator+Presentation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Onboarding/Coordinator/AppOnboardingCoordinator+Presentation.swift"; sourceTree = SOURCE_ROOT; };
+		CF4E3B7EAAC54AE18553A302 /* LifeBoard/Onboarding/Models/OnboardingEligibility.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingEligibility.swift; sourceTree = SOURCE_ROOT; };
 		CFBD3BC2B501293FC35C162C /* HomeViewController+SurfacePreparation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "HomeViewController+SurfacePreparation.swift"; sourceTree = "<group>"; };
-		CFC525E06BF11EBA6D7A5BC3 /* OnboardingHeroVideoView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Views/OnboardingHeroVideoView.swift; sourceTree = SOURCE_ROOT; };
+		CFC525E06BF11EBA6D7A5BC3 /* LifeBoard/Onboarding/Views/OnboardingHeroVideoView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Views/OnboardingHeroVideoView.swift; sourceTree = SOURCE_ROOT; };
 		CFF019E9E7D0253D5D139030 /* WeeklyCalendarStripView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WeeklyCalendarStripView.swift; sourceTree = "<group>"; };
 		CFF75A05368C0CA0356AC4F7 /* HomeTimelineViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeTimelineViewModel.swift; sourceTree = "<group>"; };
-		CFFC54215415EB867E73F6BC /* HomeViewControllerExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/HomeViewControllerExtension.swift; sourceTree = SOURCE_ROOT; };
-		D07E18D71C702586CD89133E /* lifeManagementNormalizedHex.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/lifeManagementNormalizedHex.swift; sourceTree = SOURCE_ROOT; };
-		D115AC1607F718EC014575BE /* XPCalculationEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/XPCalculationEngine.swift; sourceTree = SOURCE_ROOT; };
+		CFFC54215415EB867E73F6BC /* LifeBoard/Onboarding/Components/HomeViewControllerExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/HomeViewControllerExtension.swift; sourceTree = SOURCE_ROOT; };
+		D07E18D71C702586CD89133E /* LifeBoard/Views/Settings/LifeManagement/lifeManagementNormalizedHex.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/lifeManagementNormalizedHex.swift; sourceTree = SOURCE_ROOT; };
+		D115AC1607F718EC014575BE /* LifeBoard/Domain/Models/XPCalculationEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/XPCalculationEngine.swift; sourceTree = SOURCE_ROOT; };
 		D1A100000000000000000001 /* HomeChromeSnapshot+Presentation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "HomeChromeSnapshot+Presentation.swift"; sourceTree = "<group>"; };
 		D1A100000000000000000002 /* HomeScopeSummaryButtonView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeScopeSummaryButtonView.swift; sourceTree = "<group>"; };
 		D1A100000000000000000003 /* HomeBackToTodayButtonView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeBackToTodayButtonView.swift; sourceTree = "<group>"; };
@@ -2094,31 +2096,31 @@
 		D1A100000000000000000007 /* HomeMomentumSummaryCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeMomentumSummaryCard.swift; sourceTree = "<group>"; };
 		D1A100000000000000000008 /* HomeMomentumProgressBar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeMomentumProgressBar.swift; sourceTree = "<group>"; };
 		D1A100000000000000000009 /* HomeEvaChatTopChromeView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeEvaChatTopChromeView.swift; sourceTree = "<group>"; };
-		D29E5D918391FC0B0AFC174A /* OverdueRescueUndoRecord.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueUndoRecord.swift; sourceTree = SOURCE_ROOT; };
-		D2A100000000000000000001 /* QuietTrackingComposerSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Models/QuietTrackingComposerSnapshot.swift; sourceTree = SOURCE_ROOT; };
-		D2A100000000000000000003 /* SunriseQuietTrackingComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/View/SunriseQuietTrackingComposerView.swift; sourceTree = SOURCE_ROOT; };
+		D29E5D918391FC0B0AFC174A /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueUndoRecord.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueUndoRecord.swift; sourceTree = SOURCE_ROOT; };
+		D2A100000000000000000001 /* LifeBoard/Presentation/Models/QuietTrackingComposerSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Models/QuietTrackingComposerSnapshot.swift; sourceTree = SOURCE_ROOT; };
+		D2A100000000000000000003 /* LifeBoard/View/SunriseQuietTrackingComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/View/SunriseQuietTrackingComposerView.swift; sourceTree = SOURCE_ROOT; };
 		D2A100000000000000000005 /* QuietTrackingUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuietTrackingUITests.swift; sourceTree = "<group>"; };
-		D2ABCBECDD204257AB9B9506 /* OnboardingFlowModel+EvaPreferencesAndDemo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Onboarding/Services/OnboardingFlowModel+EvaPreferencesAndDemo.swift"; sourceTree = SOURCE_ROOT; };
-		D2D63CF8E5D155F2AF44EF2A /* OnboardingSuccessHero.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingSuccessHero.swift; sourceTree = SOURCE_ROOT; };
-		D32B0321DD6413CCDC888416 /* TagMapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Mappers/TagMapper.swift; sourceTree = SOURCE_ROOT; };
-		D3343BCF778595F2114EE830 /* InlineToneBadge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/InlineToneBadge.swift; sourceTree = SOURCE_ROOT; };
+		D2ABCBECDD204257AB9B9506 /* LifeBoard/Onboarding/Services/OnboardingFlowModel+EvaPreferencesAndDemo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Onboarding/Services/OnboardingFlowModel+EvaPreferencesAndDemo.swift"; sourceTree = SOURCE_ROOT; };
+		D2D63CF8E5D155F2AF44EF2A /* LifeBoard/Onboarding/Components/OnboardingSuccessHero.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingSuccessHero.swift; sourceTree = SOURCE_ROOT; };
+		D32B0321DD6413CCDC888416 /* LifeBoard/Domain/Mappers/TagMapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Mappers/TagMapper.swift; sourceTree = SOURCE_ROOT; };
+		D3343BCF778595F2114EE830 /* LifeBoard/Views/Settings/LifeManagement/InlineToneBadge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/InlineToneBadge.swift; sourceTree = SOURCE_ROOT; };
 		D379A868382E81C83D874E36 /* SunriseTaskRowView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SunriseTaskRowView.swift; sourceTree = "<group>"; };
 		D39BBE25D96F4BE6E41320B1 /* SpacingTokens.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SpacingTokens.swift; sourceTree = "<group>"; };
-		D3FE2E5497D838BF7ACBA002 /* logOnboardingError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/logOnboardingError.swift; sourceTree = SOURCE_ROOT; };
-		D42FAE002A15C49C424D0C95 /* DailyTimelineCanvas+ItemRendering.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Timeline/Surface/DailyTimelineCanvas+ItemRendering.swift"; sourceTree = SOURCE_ROOT; };
+		D3FE2E5497D838BF7ACBA002 /* LifeBoard/Onboarding/Models/logOnboardingError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/logOnboardingError.swift; sourceTree = SOURCE_ROOT; };
+		D42FAE002A15C49C424D0C95 /* LifeBoard/Presentation/Home/Timeline/Surface/DailyTimelineCanvas+ItemRendering.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Timeline/Surface/DailyTimelineCanvas+ItemRendering.swift"; sourceTree = SOURCE_ROOT; };
 		D48E4DB12D2E1FE5A90FC97D /* GamificationTokens.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GamificationTokens.swift; sourceTree = "<group>"; };
 		D4E5F6A7B8C9D0E1F2030405 /* TaskModelV3_Habits.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = TaskModelV3_Habits.xcdatamodel; sourceTree = "<group>"; };
 		D4E5F6A7B8C9D0E1F2030406 /* TaskModelV3_WeeklyPlanning.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = TaskModelV3_WeeklyPlanning.xcdatamodel; sourceTree = "<group>"; };
 		D4E5F6A7B8C9D0E1F2030407 /* TaskModelV3_TaskIcons.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = TaskModelV3_TaskIcons.xcdatamodel; sourceTree = "<group>"; };
-		D4EE9804CB09C71523D27F9D /* AppOnboardingJourneyView+DemoPermissionsAndDock.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Onboarding/Views/AppOnboardingJourneyView+DemoPermissionsAndDock.swift"; sourceTree = SOURCE_ROOT; };
+		D4EE9804CB09C71523D27F9D /* LifeBoard/Onboarding/Views/AppOnboardingJourneyView+DemoPermissionsAndDock.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Onboarding/Views/AppOnboardingJourneyView+DemoPermissionsAndDock.swift"; sourceTree = SOURCE_ROOT; };
 		D4F100000000000000000101 /* TaskPlanningBucket.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TaskPlanningBucket.swift; sourceTree = "<group>"; };
 		D4F100000000000000000102 /* WeeklyPlan.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WeeklyPlan.swift; sourceTree = "<group>"; };
 		D4F100000000000000000103 /* WeeklyOutcome.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WeeklyOutcome.swift; sourceTree = "<group>"; };
 		D4F100000000000000000104 /* WeeklyReview.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WeeklyReview.swift; sourceTree = "<group>"; };
 		D4F100000000000000000105 /* ReflectionNote.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReflectionNote.swift; sourceTree = "<group>"; };
 		D4F100000000000000000106 /* WeeklyMomentumSummary.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WeeklyMomentumSummary.swift; sourceTree = "<group>"; };
-		D4F100000000000000000107 /* CoreDataWeeklyRepositories.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Repositories/CoreDataWeeklyRepositories.swift; sourceTree = SOURCE_ROOT; };
-		D4F100000000000000000108 /* WeeklyOperatingUseCases.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Weekly/WeeklyOperatingUseCases.swift; sourceTree = SOURCE_ROOT; };
+		D4F100000000000000000107 /* LifeBoard/State/Repositories/CoreDataWeeklyRepositories.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Repositories/CoreDataWeeklyRepositories.swift; sourceTree = SOURCE_ROOT; };
+		D4F100000000000000000108 /* LifeBoard/UseCases/Weekly/WeeklyOperatingUseCases.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Weekly/WeeklyOperatingUseCases.swift; sourceTree = SOURCE_ROOT; };
 		D4F100000000000000000109 /* WeeklyPlannerViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WeeklyPlannerViewModel.swift; sourceTree = "<group>"; };
 		D4F10000000000000000010A /* WeeklyReviewViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WeeklyReviewViewModel.swift; sourceTree = "<group>"; };
 		D4F10000000000000000010B /* HomeWeeklySummaryCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeWeeklySummaryCard.swift; sourceTree = "<group>"; };
@@ -2131,9 +2133,9 @@
 		D4F200000000000000000120 /* HomeAIActionCoordinatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeAIActionCoordinatorTests.swift; sourceTree = "<group>"; };
 		D4F200000000000000000121 /* XPCalculationEngineWeeklyCategoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = XPCalculationEngineWeeklyCategoryTests.swift; sourceTree = "<group>"; };
 		D4F200000000000000000124 /* WeeklyOperatingLayerViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WeeklyOperatingLayerViewModelTests.swift; sourceTree = "<group>"; };
-		D4F300000000000000000131 /* DailyReflectionLoadCoordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Gamification/DailyReflectionLoadCoordinator.swift; sourceTree = SOURCE_ROOT; };
-		D4F400000000000000000202 /* SunriseTimelineSurface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/View/SunriseTimelineSurface.swift; sourceTree = SOURCE_ROOT; };
-		D5669D5D0E7B125A137EBF66 /* EvaDayHabitOverlayState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitOverlayState.swift; sourceTree = SOURCE_ROOT; };
+		D4F300000000000000000131 /* LifeBoard/UseCases/Gamification/DailyReflectionLoadCoordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Gamification/DailyReflectionLoadCoordinator.swift; sourceTree = SOURCE_ROOT; };
+		D4F400000000000000000202 /* LifeBoard/View/SunriseTimelineSurface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/View/SunriseTimelineSurface.swift; sourceTree = SOURCE_ROOT; };
+		D5669D5D0E7B125A137EBF66 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitOverlayState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitOverlayState.swift; sourceTree = SOURCE_ROOT; };
 		D5A100000000000000000001 /* ReflectPlanStyle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReflectPlanStyle.swift; sourceTree = "<group>"; };
 		D5A100000000000000000002 /* SunriseReflectPlanScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SunriseReflectPlanScreen.swift; sourceTree = "<group>"; };
 		D5A100000000000000000003 /* ReflectPlanHeader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReflectPlanHeader.swift; sourceTree = "<group>"; };
@@ -2150,34 +2152,34 @@
 		D5A10000000000000000000E /* ReflectPlanWrappingHStackLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReflectPlanWrappingHStackLayout.swift; sourceTree = "<group>"; };
 		D5A10000000000000000000F /* StickySaveButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StickySaveButton.swift; sourceTree = "<group>"; };
 		D5A100000000000000000010 /* SwapTaskPicker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SwapTaskPicker.swift; sourceTree = "<group>"; };
-		D5A9A2796943621DC66C4703 /* Tombstone.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/Tombstone.swift; sourceTree = SOURCE_ROOT; };
+		D5A9A2796943621DC66C4703 /* LifeBoard/Domain/Models/Tombstone.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/Tombstone.swift; sourceTree = SOURCE_ROOT; };
 		D5E7A8B92F3C4D5E0067A1B2 /* DailySummaryModalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailySummaryModalTests.swift; sourceTree = "<group>"; };
-		D6248E090BE231D70E41F08C /* CoreDataScheduleRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Repositories/CoreDataScheduleRepository.swift; sourceTree = SOURCE_ROOT; };
-		D69B4ECB89C44E275D829577 /* TagRepositoryProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Interfaces/TagRepositoryProtocol.swift; sourceTree = SOURCE_ROOT; };
-		D721CBA93E7A9DDD50E1C65C /* TimelineStreamDirection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamDirection.swift; sourceTree = SOURCE_ROOT; };
-		D7334CB65043757E017D7AE4 /* TimelineEmptyStateActionTone.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineEmptyStateActionTone.swift; sourceTree = SOURCE_ROOT; };
-		D7697952AC65F15B0B831D63 /* HomeViewModel+RescueUndo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+RescueUndo.swift"; sourceTree = SOURCE_ROOT; };
-		D76C10CD61388AF076BFDDB5 /* TimelineStreamInfluenceKind.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamInfluenceKind.swift; sourceTree = SOURCE_ROOT; };
+		D6248E090BE231D70E41F08C /* LifeBoard/State/Repositories/CoreDataScheduleRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Repositories/CoreDataScheduleRepository.swift; sourceTree = SOURCE_ROOT; };
+		D69B4ECB89C44E275D829577 /* LifeBoard/Domain/Interfaces/TagRepositoryProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Interfaces/TagRepositoryProtocol.swift; sourceTree = SOURCE_ROOT; };
+		D721CBA93E7A9DDD50E1C65C /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamDirection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamDirection.swift; sourceTree = SOURCE_ROOT; };
+		D7334CB65043757E017D7AE4 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineEmptyStateActionTone.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineEmptyStateActionTone.swift; sourceTree = SOURCE_ROOT; };
+		D7697952AC65F15B0B831D63 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+RescueUndo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+RescueUndo.swift"; sourceTree = SOURCE_ROOT; };
+		D76C10CD61388AF076BFDDB5 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamInfluenceKind.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamInfluenceKind.swift; sourceTree = SOURCE_ROOT; };
 		D7A500000000000000000101 /* LifeBoardLaunchSplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoardLaunchSplashView.swift; sourceTree = "<group>"; };
 		D7A500000000000000000201 /* HomeViewControllerLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewControllerLifecycleTests.swift; sourceTree = "<group>"; };
 		D7C5BD9B9BA76D61F7F044BD /* LifeBoardSnackbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoardSnackbar.swift; sourceTree = "<group>"; };
-		D7E431C4A4980AE71FE5AB35 /* lifeManagementHabitStatusText.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/lifeManagementHabitStatusText.swift; sourceTree = SOURCE_ROOT; };
-		D934D251750D7055D55AD060 /* EvaDayTaskActionsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Conversation/EvaDayTaskActionsView.swift; sourceTree = SOURCE_ROOT; };
-		D974CDFA2F5A901967B485D2 /* ChatScaffoldView+NavigationChrome.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/LLM/Views/Chat/Chrome/ChatScaffoldView+NavigationChrome.swift"; sourceTree = SOURCE_ROOT; };
+		D7E431C4A4980AE71FE5AB35 /* LifeBoard/Views/Settings/LifeManagement/lifeManagementHabitStatusText.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/lifeManagementHabitStatusText.swift; sourceTree = SOURCE_ROOT; };
+		D934D251750D7055D55AD060 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayTaskActionsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Conversation/EvaDayTaskActionsView.swift; sourceTree = SOURCE_ROOT; };
+		D974CDFA2F5A901967B485D2 /* LifeBoard/LLM/Views/Chat/Chrome/ChatScaffoldView+NavigationChrome.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/LLM/Views/Chat/Chrome/ChatScaffoldView+NavigationChrome.swift"; sourceTree = SOURCE_ROOT; };
 		D9A0B1C2D3E4F506172839AB /* InsightsModuleVisibilityPlannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsModuleVisibilityPlannerTests.swift; sourceTree = "<group>"; };
-		D9A0B1C2D3E4F506172839AE /* InsightsModuleVisibilityPlanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Models/InsightsModuleVisibilityPlanner.swift; sourceTree = SOURCE_ROOT; };
-		DB3046F068EDB7B40DCD6825 /* HomeViewModel+CompletionProjection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+CompletionProjection.swift"; sourceTree = SOURCE_ROOT; };
-		DBA49A78931E2752ADDE59CA /* OnboardingFrictionOptionCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingFrictionOptionCard.swift; sourceTree = SOURCE_ROOT; };
+		D9A0B1C2D3E4F506172839AE /* LifeBoard/Presentation/Models/InsightsModuleVisibilityPlanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Models/InsightsModuleVisibilityPlanner.swift; sourceTree = SOURCE_ROOT; };
+		DB3046F068EDB7B40DCD6825 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+CompletionProjection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+CompletionProjection.swift"; sourceTree = SOURCE_ROOT; };
+		DBA49A78931E2752ADDE59CA /* LifeBoard/Onboarding/Components/OnboardingFrictionOptionCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingFrictionOptionCard.swift; sourceTree = SOURCE_ROOT; };
 		DBF5FA356354C0F76959A4CF /* SettingsProfileHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsProfileHeaderView.swift; sourceTree = "<group>"; };
-		DC10C732F02AD5EBF16333E3 /* HomeReplanUndoEntry.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeReplanUndoEntry.swift; sourceTree = SOURCE_ROOT; };
-		DD7B0A79A3EE19D37B1FE1CA /* OverdueRescueSunriseHero.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSunriseHero.swift; sourceTree = SOURCE_ROOT; };
+		DC10C732F02AD5EBF16333E3 /* LifeBoard/Presentation/ViewModels/Home/HomeReplanUndoEntry.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeReplanUndoEntry.swift; sourceTree = SOURCE_ROOT; };
+		DD7B0A79A3EE19D37B1FE1CA /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSunriseHero.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSunriseHero.swift; sourceTree = SOURCE_ROOT; };
 		DDFDBE1A33B827BB4D7FD04A /* AddTaskPriorityPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTaskPriorityPicker.swift; sourceTree = "<group>"; };
-		DE2CDAC6D56F874D92E1DD4D /* HomeViewModelRoot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeViewModelRoot.swift; sourceTree = SOURCE_ROOT; };
-		DE748EA399CF4D774ECEE086 /* OnboardingConcentricTransitionLayer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingConcentricTransitionLayer.swift; sourceTree = SOURCE_ROOT; };
-		DEE50736401EDD2F9A73FC90 /* ChatStorageDegradedBanner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Chrome/ChatStorageDegradedBanner.swift; sourceTree = SOURCE_ROOT; };
-		DF57C7F694B30CF25D4C71B7 /* HomeViewModel+Bindings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+Bindings.swift"; sourceTree = SOURCE_ROOT; };
-		E05701BAFA3071AD793273F1 /* StringExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/StringExtension.swift; sourceTree = SOURCE_ROOT; };
-		E06E18805C2401359A9B0F5B /* ManageLifeAreasUseCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/LifeArea/ManageLifeAreasUseCase.swift; sourceTree = SOURCE_ROOT; };
+		DE2CDAC6D56F874D92E1DD4D /* LifeBoard/Presentation/ViewModels/Home/HomeViewModelRoot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeViewModelRoot.swift; sourceTree = SOURCE_ROOT; };
+		DE748EA399CF4D774ECEE086 /* LifeBoard/Onboarding/Models/OnboardingConcentricTransitionLayer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingConcentricTransitionLayer.swift; sourceTree = SOURCE_ROOT; };
+		DEE50736401EDD2F9A73FC90 /* LifeBoard/LLM/Views/Chat/Chrome/ChatStorageDegradedBanner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Chrome/ChatStorageDegradedBanner.swift; sourceTree = SOURCE_ROOT; };
+		DF57C7F694B30CF25D4C71B7 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+Bindings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+Bindings.swift"; sourceTree = SOURCE_ROOT; };
+		E05701BAFA3071AD793273F1 /* LifeBoard/Views/Settings/LifeManagement/StringExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/StringExtension.swift; sourceTree = SOURCE_ROOT; };
+		E06E18805C2401359A9B0F5B /* LifeBoard/UseCases/LifeArea/ManageLifeAreasUseCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/LifeArea/ManageLifeAreasUseCase.swift; sourceTree = SOURCE_ROOT; };
 		E0A100000000000000000101 /* EvaActivationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaActivationCoordinator.swift; sourceTree = "<group>"; };
 		E0A100000000000000000102 /* EvaActivationIntroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaActivationIntroView.swift; sourceTree = "<group>"; };
 		E0A100000000000000000103 /* EvaActivationRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaActivationRootView.swift; sourceTree = "<group>"; };
@@ -2195,20 +2197,20 @@
 		E0A100000000000000000302 /* EvaActivationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaActivationTests.swift; sourceTree = "<group>"; };
 		E0A100000000000000000402 /* SettingsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModelTests.swift; sourceTree = "<group>"; };
 		E0A100000000000000000502 /* EvaHomeIntelligenceUseCasesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaHomeIntelligenceUseCasesTests.swift; sourceTree = "<group>"; };
-		E150AE4B6341CE9C52EA4AF0 /* ResolvedLifeAreaSelection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/ResolvedLifeAreaSelection.swift; sourceTree = SOURCE_ROOT; };
+		E150AE4B6341CE9C52EA4AF0 /* LifeBoard/Onboarding/Models/ResolvedLifeAreaSelection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/ResolvedLifeAreaSelection.swift; sourceTree = SOURCE_ROOT; };
 		E1A200000000000000000001 /* HomeReplanDayUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeReplanDayUITests.swift; sourceTree = "<group>"; };
-		E1C5A4B1D2E3F4012345678C /* UpdateTaskDefinitionUseCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Task/UpdateTaskDefinitionUseCase.swift; sourceTree = SOURCE_ROOT; };
-		E1C5A4B1D2E3F4012345678D /* DeleteTaskDefinitionUseCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Task/DeleteTaskDefinitionUseCase.swift; sourceTree = SOURCE_ROOT; };
-		E1C5A4B1D2E3F4012345678E /* RescheduleTaskDefinitionUseCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Task/RescheduleTaskDefinitionUseCase.swift; sourceTree = SOURCE_ROOT; };
-		E1EA03651FCE790FF4C8E5EB /* HomeViewModel+HabitActionShortcuts.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+HabitActionShortcuts.swift"; sourceTree = SOURCE_ROOT; };
-		E2BA3F253548BE9F1EE2AB4B /* SunriseDailyReflectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/View/SunriseDailyReflectionView.swift; sourceTree = SOURCE_ROOT; };
-		E3971F5A044B9EC46E27BEC2 /* HomeHabitRowPlacementBucket.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeHabitRowPlacementBucket.swift; sourceTree = SOURCE_ROOT; };
-		E3A4158C229844DD97182926 /* TimelineStreamGlintPresentation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamGlintPresentation.swift; sourceTree = SOURCE_ROOT; };
-		E3B60B862E237D7380EE1948 /* OverdueRescueDeckCopy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDeckCopy.swift; sourceTree = SOURCE_ROOT; };
-		E40C44F474B7E5FCB7349186 /* SunriseAppShellView+TimelineSurface.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+TimelineSurface.swift"; sourceTree = SOURCE_ROOT; };
-		E46838AD356183D58300A941 /* SectionRepositoryProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Interfaces/SectionRepositoryProtocol.swift; sourceTree = SOURCE_ROOT; };
+		E1C5A4B1D2E3F4012345678C /* LifeBoard/UseCases/Task/UpdateTaskDefinitionUseCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Task/UpdateTaskDefinitionUseCase.swift; sourceTree = SOURCE_ROOT; };
+		E1C5A4B1D2E3F4012345678D /* LifeBoard/UseCases/Task/DeleteTaskDefinitionUseCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Task/DeleteTaskDefinitionUseCase.swift; sourceTree = SOURCE_ROOT; };
+		E1C5A4B1D2E3F4012345678E /* LifeBoard/UseCases/Task/RescheduleTaskDefinitionUseCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Task/RescheduleTaskDefinitionUseCase.swift; sourceTree = SOURCE_ROOT; };
+		E1EA03651FCE790FF4C8E5EB /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+HabitActionShortcuts.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+HabitActionShortcuts.swift"; sourceTree = SOURCE_ROOT; };
+		E2BA3F253548BE9F1EE2AB4B /* LifeBoard/View/SunriseDailyReflectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/View/SunriseDailyReflectionView.swift; sourceTree = SOURCE_ROOT; };
+		E3971F5A044B9EC46E27BEC2 /* LifeBoard/Presentation/ViewModels/Home/HomeHabitRowPlacementBucket.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeHabitRowPlacementBucket.swift; sourceTree = SOURCE_ROOT; };
+		E3A4158C229844DD97182926 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamGlintPresentation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamGlintPresentation.swift; sourceTree = SOURCE_ROOT; };
+		E3B60B862E237D7380EE1948 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDeckCopy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDeckCopy.swift; sourceTree = SOURCE_ROOT; };
+		E40C44F474B7E5FCB7349186 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+TimelineSurface.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+TimelineSurface.swift"; sourceTree = SOURCE_ROOT; };
+		E46838AD356183D58300A941 /* LifeBoard/Domain/Interfaces/SectionRepositoryProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Interfaces/SectionRepositoryProtocol.swift; sourceTree = SOURCE_ROOT; };
 		E4B4D0D6C85806F24EEF40AD /* LifeBoardWatch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LifeBoardWatch.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		E4F394C64907F22C89881E3A /* ReminderDefinition.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/ReminderDefinition.swift; sourceTree = SOURCE_ROOT; };
+		E4F394C64907F22C89881E3A /* LifeBoard/Domain/Models/ReminderDefinition.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/ReminderDefinition.swift; sourceTree = SOURCE_ROOT; };
 		E50000000000000000000000 /* LBSunriseHeroArtwork.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LBSunriseHeroArtwork.swift; sourceTree = "<group>"; };
 		E50000000000000000000002 /* SunriseHeaderView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SunriseHeaderView.swift; sourceTree = "<group>"; };
 		E50000000000000000000004 /* TimeOfDayHeaderAsset.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TimeOfDayHeaderAsset.swift; sourceTree = "<group>"; };
@@ -2238,42 +2240,42 @@
 		E50000000000000000000034 /* LBSpacingTokens.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LBSpacingTokens.swift; sourceTree = "<group>"; };
 		E50000000000000000000036 /* LBTypographyTokens.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LBTypographyTokens.swift; sourceTree = "<group>"; };
 		E50000000000000000000038 /* SunriseScheduleScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SunriseScheduleScreen.swift; sourceTree = "<group>"; };
-		E508CD28D9365DD6B35FE330 /* MessageView+AssistantAndUserBubble.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/LLM/Views/Chat/Conversation/MessageView+AssistantAndUserBubble.swift"; sourceTree = SOURCE_ROOT; };
+		E508CD28D9365DD6B35FE330 /* LifeBoard/LLM/Views/Chat/Conversation/MessageView+AssistantAndUserBubble.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/LLM/Views/Chat/Conversation/MessageView+AssistantAndUserBubble.swift"; sourceTree = SOURCE_ROOT; };
 		E526F0CB3E9299C87861646E /* SunriseTaskListView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SunriseTaskListView.swift; sourceTree = "<group>"; };
-		E54A7695DD06B755561CDB3D /* LifeManagementColorSwatchButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementColorSwatchButton.swift; sourceTree = SOURCE_ROOT; };
+		E54A7695DD06B755561CDB3D /* LifeBoard/Views/Settings/LifeManagement/LifeManagementColorSwatchButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementColorSwatchButton.swift; sourceTree = SOURCE_ROOT; };
 		E5F000000000000000000001 /* SunriseImages */ = {isa = PBXFileReference; lastKnownFileType = folder; path = SunriseImages; sourceTree = SOURCE_ROOT; };
 		E6095F80ED6FB73CD69363AC /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = Info.plist; path = LifeBoardWidgets/Info.plist; sourceTree = "<group>"; };
-		E6747A1FAF23571C7A3DA320 /* CoreDataAssistantActionRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Repositories/CoreDataAssistantActionRepository.swift; sourceTree = SOURCE_ROOT; };
+		E6747A1FAF23571C7A3DA320 /* LifeBoard/State/Repositories/CoreDataAssistantActionRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Repositories/CoreDataAssistantActionRepository.swift; sourceTree = SOURCE_ROOT; };
 		E6A100000000000000000001 /* SunriseHeaderAssetTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SunriseHeaderAssetTests.swift; sourceTree = "<group>"; };
-		E76B472B10FBCD33AF5BF327 /* HomeViewModel+DailyReflectionPreview.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+DailyReflectionPreview.swift"; sourceTree = SOURCE_ROOT; };
-		E78CA56E2EAD1B448EFED377 /* AssistantAction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/AssistantAction.swift; sourceTree = SOURCE_ROOT; };
-		E97E787881F510FC540EC5B8 /* MessageView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Conversation/MessageView.swift; sourceTree = SOURCE_ROOT; };
-		E98C6DC8C0DE10D010A97DC6 /* SunriseAppShellView+CalendarFooterAndTrackingRail.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+CalendarFooterAndTrackingRail.swift"; sourceTree = SOURCE_ROOT; };
-		E9EF3524C96CA56E66C86177 /* ResolveOccurrenceUseCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Schedule/ResolveOccurrenceUseCase.swift; sourceTree = SOURCE_ROOT; };
-		E9FBA211F8998587F17C8785 /* HomeViewModel+TaskDetailMetadata.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+TaskDetailMetadata.swift"; sourceTree = SOURCE_ROOT; };
+		E76B472B10FBCD33AF5BF327 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+DailyReflectionPreview.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+DailyReflectionPreview.swift"; sourceTree = SOURCE_ROOT; };
+		E78CA56E2EAD1B448EFED377 /* LifeBoard/Domain/Models/AssistantAction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/AssistantAction.swift; sourceTree = SOURCE_ROOT; };
+		E97E787881F510FC540EC5B8 /* LifeBoard/LLM/Views/Chat/Conversation/MessageView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Conversation/MessageView.swift; sourceTree = SOURCE_ROOT; };
+		E98C6DC8C0DE10D010A97DC6 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+CalendarFooterAndTrackingRail.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+CalendarFooterAndTrackingRail.swift"; sourceTree = SOURCE_ROOT; };
+		E9EF3524C96CA56E66C86177 /* LifeBoard/UseCases/Schedule/ResolveOccurrenceUseCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/UseCases/Schedule/ResolveOccurrenceUseCase.swift; sourceTree = SOURCE_ROOT; };
+		E9FBA211F8998587F17C8785 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+TaskDetailMetadata.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+TaskDetailMetadata.swift"; sourceTree = SOURCE_ROOT; };
 		EA1AC6826CEC438ED475A25E /* HomeViewController+AdaptivePresentation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "HomeViewController+AdaptivePresentation.swift"; sourceTree = "<group>"; };
-		EA45AF6FFE4463E49D8FEA68 /* TaskDefinitionRepositoryProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Interfaces/TaskDefinitionRepositoryProtocol.swift; sourceTree = SOURCE_ROOT; };
+		EA45AF6FFE4463E49D8FEA68 /* LifeBoard/Domain/Interfaces/TaskDefinitionRepositoryProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Interfaces/TaskDefinitionRepositoryProtocol.swift; sourceTree = SOURCE_ROOT; };
 		EA9D6B0D45CD7BA946FCF6F3 /* AddTaskDatePresetRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTaskDatePresetRow.swift; sourceTree = "<group>"; };
-		EAB5C7F1C2483D8E113DBBA7 /* TimelineCurrentTimeRule.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineCurrentTimeRule.swift; sourceTree = SOURCE_ROOT; };
-		EB860C7A16B4805F8EC56AF7 /* TimelineNowBeadView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineNowBeadView.swift; sourceTree = SOURCE_ROOT; };
-		EB8BC6F60B76437F2E6148F7 /* CodingKeys.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/CodingKeys.swift; sourceTree = SOURCE_ROOT; };
-		EC2F92D22CA429D62EFD9F46 /* OnboardingHabitStreakPreviewCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingHabitStreakPreviewCard.swift; sourceTree = SOURCE_ROOT; };
-		EC4E24E658AA95B6A485F4AA /* RecurrenceInstanceSnapshot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/RecurrenceInstanceSnapshot.swift; sourceTree = SOURCE_ROOT; };
-		EC5308F1488478AD34963168 /* ChatTimeIntervalExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Conversation/ChatTimeIntervalExtension.swift; sourceTree = SOURCE_ROOT; };
-		EC8C891FA22F9B04EA07D70E /* HomeViewModel+EvaFocus.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+EvaFocus.swift"; sourceTree = SOURCE_ROOT; };
-		ECB224DA34C6529E86C73875 /* LifeAreaMapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Mappers/LifeAreaMapper.swift; sourceTree = SOURCE_ROOT; };
-		ECDCDBED7855DBFB44F46DFD /* OverdueRescueViewModel+SessionPersistence.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueViewModel+SessionPersistence.swift"; sourceTree = SOURCE_ROOT; };
-		ED51698C3FB7D6F725184D46 /* timelineMetaText.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/timelineMetaText.swift; sourceTree = SOURCE_ROOT; };
-		ED9726B0BA993B4BD3887748 /* OnboardingFloatingNextAction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingFloatingNextAction.swift; sourceTree = SOURCE_ROOT; };
-		EE0E5A5DE6FF2E8EEACA4280 /* EvaWorkingStatusLibrary.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Conversation/EvaWorkingStatusLibrary.swift; sourceTree = SOURCE_ROOT; };
-		EE2C41DCBFDB00CEEAF73CC0 /* EvaDayHabitMetadataView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitMetadataView.swift; sourceTree = SOURCE_ROOT; };
-		EE642CCFDAF7BBFD6AD34B98 /* OnboardingFrictionSelectorLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingFrictionSelectorLayout.swift; sourceTree = SOURCE_ROOT; };
-		EED3244A5684CA3C412C1AA1 /* AreaSummaryRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/AreaSummaryRow.swift; sourceTree = SOURCE_ROOT; };
-		EED5CBC96B81618B5D5B1C6D /* LifeManagementComposerMetricTile.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerMetricTile.swift; sourceTree = SOURCE_ROOT; };
-		EFD0A8DA9F2060C50BF6DA52 /* EvaChiefOfStaffGuideSection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Chrome/EvaChiefOfStaffGuideSection.swift; sourceTree = SOURCE_ROOT; };
+		EAB5C7F1C2483D8E113DBBA7 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCurrentTimeRule.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineCurrentTimeRule.swift; sourceTree = SOURCE_ROOT; };
+		EB860C7A16B4805F8EC56AF7 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineNowBeadView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineNowBeadView.swift; sourceTree = SOURCE_ROOT; };
+		EB8BC6F60B76437F2E6148F7 /* LifeBoard/Onboarding/Models/CodingKeys.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/CodingKeys.swift; sourceTree = SOURCE_ROOT; };
+		EC2F92D22CA429D62EFD9F46 /* LifeBoard/Onboarding/Components/OnboardingHabitStreakPreviewCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingHabitStreakPreviewCard.swift; sourceTree = SOURCE_ROOT; };
+		EC4E24E658AA95B6A485F4AA /* LifeBoard/Presentation/Home/Modals/OverdueRescue/RecurrenceInstanceSnapshot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/RecurrenceInstanceSnapshot.swift; sourceTree = SOURCE_ROOT; };
+		EC5308F1488478AD34963168 /* LifeBoard/LLM/Views/Chat/Conversation/ChatTimeIntervalExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Conversation/ChatTimeIntervalExtension.swift; sourceTree = SOURCE_ROOT; };
+		EC8C891FA22F9B04EA07D70E /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+EvaFocus.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+EvaFocus.swift"; sourceTree = SOURCE_ROOT; };
+		ECB224DA34C6529E86C73875 /* LifeBoard/Domain/Mappers/LifeAreaMapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Mappers/LifeAreaMapper.swift; sourceTree = SOURCE_ROOT; };
+		ECDCDBED7855DBFB44F46DFD /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueViewModel+SessionPersistence.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueViewModel+SessionPersistence.swift"; sourceTree = SOURCE_ROOT; };
+		ED51698C3FB7D6F725184D46 /* LifeBoard/Presentation/Home/Timeline/Surface/timelineMetaText.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/timelineMetaText.swift; sourceTree = SOURCE_ROOT; };
+		ED9726B0BA993B4BD3887748 /* LifeBoard/Onboarding/Models/OnboardingFloatingNextAction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingFloatingNextAction.swift; sourceTree = SOURCE_ROOT; };
+		EE0E5A5DE6FF2E8EEACA4280 /* LifeBoard/LLM/Views/Chat/Conversation/EvaWorkingStatusLibrary.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Conversation/EvaWorkingStatusLibrary.swift; sourceTree = SOURCE_ROOT; };
+		EE2C41DCBFDB00CEEAF73CC0 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitMetadataView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitMetadataView.swift; sourceTree = SOURCE_ROOT; };
+		EE642CCFDAF7BBFD6AD34B98 /* LifeBoard/Onboarding/Components/OnboardingFrictionSelectorLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingFrictionSelectorLayout.swift; sourceTree = SOURCE_ROOT; };
+		EED3244A5684CA3C412C1AA1 /* LifeBoard/Views/Settings/LifeManagement/AreaSummaryRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/AreaSummaryRow.swift; sourceTree = SOURCE_ROOT; };
+		EED5CBC96B81618B5D5B1C6D /* LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerMetricTile.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerMetricTile.swift; sourceTree = SOURCE_ROOT; };
+		EFD0A8DA9F2060C50BF6DA52 /* LifeBoard/LLM/Views/Chat/Chrome/EvaChiefOfStaffGuideSection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/LLM/Views/Chat/Chrome/EvaChiefOfStaffGuideSection.swift; sourceTree = SOURCE_ROOT; };
 		F00D00000000000000001001 /* TaskDetailPresentationContracts.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TaskDetailPresentationContracts.swift; sourceTree = "<group>"; };
-		F00D00000000000000001005 /* CalendarSchedulePresentationContracts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/View/Calendar/CalendarSchedulePresentationContracts.swift; sourceTree = SOURCE_ROOT; };
-		F00D00000000000000001007 /* CalendarTimelinePresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/View/Calendar/CalendarTimelinePresentation.swift; sourceTree = SOURCE_ROOT; };
+		F00D00000000000000001005 /* LifeBoard/View/Calendar/CalendarSchedulePresentationContracts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/View/Calendar/CalendarSchedulePresentationContracts.swift; sourceTree = SOURCE_ROOT; };
+		F00D00000000000000001007 /* LifeBoard/View/Calendar/CalendarTimelinePresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoard/View/Calendar/CalendarTimelinePresentation.swift; sourceTree = SOURCE_ROOT; };
 		F0A100000000000000000102 /* SeededFeaturePages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeededFeaturePages.swift; sourceTree = "<group>"; };
 		F0A100000000000000000202 /* OverdueRescueSeededUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverdueRescueSeededUITests.swift; sourceTree = "<group>"; };
 		F0A100000000000000000302 /* ReflectPlanSeededUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReflectPlanSeededUITests.swift; sourceTree = "<group>"; };
@@ -2283,63 +2285,63 @@
 		F0A1B2C3D4E5F60718293A4D /* HomeFilterStateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeFilterStateTests.swift; sourceTree = "<group>"; };
 		F0A1B2C3D4E5F60718293A4E /* HomeTaskSectionBuilderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeTaskSectionBuilderTests.swift; sourceTree = "<group>"; };
 		F0A1B2C3D4E5F60718293A4F /* HomeViewModelPersistenceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeViewModelPersistenceTests.swift; sourceTree = "<group>"; };
-		F0E3799E6AD3B71C2BCAA18D /* CoreDataSectionRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Repositories/CoreDataSectionRepository.swift; sourceTree = SOURCE_ROOT; };
-		F0F0A3F8D6B8C5CB34F82DA0 /* lifeManagementAreaPaletteMatch.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/lifeManagementAreaPaletteMatch.swift; sourceTree = SOURCE_ROOT; };
+		F0E3799E6AD3B71C2BCAA18D /* LifeBoard/State/Repositories/CoreDataSectionRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Repositories/CoreDataSectionRepository.swift; sourceTree = SOURCE_ROOT; };
+		F0F0A3F8D6B8C5CB34F82DA0 /* LifeBoard/Views/Settings/LifeManagement/lifeManagementAreaPaletteMatch.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/lifeManagementAreaPaletteMatch.swift; sourceTree = SOURCE_ROOT; };
 		F10A00000000000000000002 /* TimelineRoutineAnchorVisualStyle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TimelineRoutineAnchorVisualStyle.swift; sourceTree = "<group>"; };
 		F10A00000000000000000004 /* TimelineRoutineAnchorCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TimelineRoutineAnchorCard.swift; sourceTree = "<group>"; };
-		F1A2B3C4D5E6F708192A3B4D /* WidgetBrand.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoardWidgets/WidgetBrand.swift; sourceTree = SOURCE_ROOT; };
+		F1A2B3C4D5E6F708192A3B4D /* LifeBoardWidgets/WidgetBrand.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoardWidgets/WidgetBrand.swift; sourceTree = SOURCE_ROOT; };
 		F1A2B3C4D5E6F7A8B9C0D1E2 /* LifeBoardTheme+SwiftUI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoardTheme+SwiftUI.swift"; sourceTree = "<group>"; };
 		F1A2B3C4D5E6F7A8B9C0D1E4 /* LifeBoardAnimations.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoardAnimations.swift; sourceTree = "<group>"; };
 		F1C0A1234B56789000ABCD01 /* TaskDetailViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskDetailViewModelTests.swift; sourceTree = "<group>"; };
-		F1DD1A6ABC050A464C7B4397 /* OnboardingPainPoint.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingPainPoint.swift; sourceTree = SOURCE_ROOT; };
+		F1DD1A6ABC050A464C7B4397 /* LifeBoard/Onboarding/Models/OnboardingPainPoint.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingPainPoint.swift; sourceTree = SOURCE_ROOT; };
 		F1EF5E391342B1FBE7864081 /* HomeViewController+Snackbar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "HomeViewController+Snackbar.swift"; sourceTree = "<group>"; };
-		F21D047990188A6B02C70A9F /* HomeHabitRowPlacement.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeHabitRowPlacement.swift; sourceTree = SOURCE_ROOT; };
-		F22284F558A304A7D18F56C1 /* HabitDefinitionMapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Mappers/HabitDefinitionMapper.swift; sourceTree = SOURCE_ROOT; };
-		F280FDE93AC86C0D82E9C51E /* OnboardingConcentricColorField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingConcentricColorField.swift; sourceTree = SOURCE_ROOT; };
-		F29A008521575A41C80A3750 /* OnboardingPromptPrimaryCTAButtonStyle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingPromptPrimaryCTAButtonStyle.swift; sourceTree = SOURCE_ROOT; };
+		F21D047990188A6B02C70A9F /* LifeBoard/Presentation/ViewModels/Home/HomeHabitRowPlacement.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeHabitRowPlacement.swift; sourceTree = SOURCE_ROOT; };
+		F22284F558A304A7D18F56C1 /* LifeBoard/Domain/Mappers/HabitDefinitionMapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Mappers/HabitDefinitionMapper.swift; sourceTree = SOURCE_ROOT; };
+		F280FDE93AC86C0D82E9C51E /* LifeBoard/Onboarding/Models/OnboardingConcentricColorField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingConcentricColorField.swift; sourceTree = SOURCE_ROOT; };
+		F29A008521575A41C80A3750 /* LifeBoard/Onboarding/Components/OnboardingPromptPrimaryCTAButtonStyle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Components/OnboardingPromptPrimaryCTAButtonStyle.swift; sourceTree = SOURCE_ROOT; };
 		F2A1B2C3D4E5F60718293A50 /* HomeBottomBarItem.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeBottomBarItem.swift; sourceTree = "<group>"; };
 		F2A1B2C3D4E5F60718293A51 /* HomeBottomBarState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeBottomBarState.swift; sourceTree = "<group>"; };
 		F2A1B2C3D4E5F60718293A53 /* HomeBottomBarStateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeBottomBarStateTests.swift; sourceTree = "<group>"; };
 		F2A1B2C3D4E5F60718293A54 /* HomeViewModelXPScoreRegressionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeViewModelXPScoreRegressionTests.swift; sourceTree = "<group>"; };
-		F311D68194F7FDAA5BAD7ADA /* CoreSchedulingEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Services/CoreSchedulingEngine.swift; sourceTree = SOURCE_ROOT; };
-		F37CC3576F638C63EB2D1943 /* TimelineNormalItemCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineNormalItemCard.swift; sourceTree = SOURCE_ROOT; };
+		F311D68194F7FDAA5BAD7ADA /* LifeBoard/State/Services/CoreSchedulingEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Services/CoreSchedulingEngine.swift; sourceTree = SOURCE_ROOT; };
+		F37CC3576F638C63EB2D1943 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineNormalItemCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineNormalItemCard.swift; sourceTree = SOURCE_ROOT; };
 		F3A1B2C3D4E5F60718293A55 /* HomeSunriseLayoutMetricsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeSunriseLayoutMetricsTests.swift; sourceTree = "<group>"; };
-		F4687654CCFC97DCFDA3E695 /* CoreDataTaskDefinitionRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Repositories/CoreDataTaskDefinitionRepository.swift; sourceTree = SOURCE_ROOT; };
+		F4687654CCFC97DCFDA3E695 /* LifeBoard/State/Repositories/CoreDataTaskDefinitionRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/State/Repositories/CoreDataTaskDefinitionRepository.swift; sourceTree = SOURCE_ROOT; };
 		F4A1B2C3D4E5F60718293A56 /* HomeSunriseHintEligibilityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeSunriseHintEligibilityTests.swift; sourceTree = "<group>"; };
 		F4AB324AE764BB56051B2AA8 /* AddTaskEnumPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTaskEnumPicker.swift; sourceTree = "<group>"; };
-		F51E8DFC25DB5CED3BB58615 /* LifeBoardCancellableDispatchWorkItem.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/LifeBoardCancellableDispatchWorkItem.swift; sourceTree = SOURCE_ROOT; };
+		F51E8DFC25DB5CED3BB58615 /* LifeBoard/Presentation/ViewModels/Home/LifeBoardCancellableDispatchWorkItem.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/LifeBoardCancellableDispatchWorkItem.swift; sourceTree = SOURCE_ROOT; };
 		F5A100002F6A200100ABC001 /* LifeBoardAppShortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoardAppShortcuts.swift; sourceTree = "<group>"; };
 		F5A100022F6A200100ABC001 /* LifeBoardAppShortcutsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeBoardAppShortcutsTests.swift; sourceTree = "<group>"; };
-		F63D95372962F61A5E50E9F9 /* OverdueRescueDeleteOverlay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDeleteOverlay.swift; sourceTree = SOURCE_ROOT; };
-		F65EA7E811D99F9A2999C0D5 /* AppOnboardingJourneyView+SetupSteps.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Onboarding/Views/AppOnboardingJourneyView+SetupSteps.swift"; sourceTree = SOURCE_ROOT; };
-		F66EEF4F24A54CD971C9612A /* OnboardingFlowModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Services/OnboardingFlowModel.swift; sourceTree = SOURCE_ROOT; };
+		F63D95372962F61A5E50E9F9 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDeleteOverlay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDeleteOverlay.swift; sourceTree = SOURCE_ROOT; };
+		F65EA7E811D99F9A2999C0D5 /* LifeBoard/Onboarding/Views/AppOnboardingJourneyView+SetupSteps.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Onboarding/Views/AppOnboardingJourneyView+SetupSteps.swift"; sourceTree = SOURCE_ROOT; };
+		F66EEF4F24A54CD971C9612A /* LifeBoard/Onboarding/Services/OnboardingFlowModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Services/OnboardingFlowModel.swift; sourceTree = SOURCE_ROOT; };
 		F6A1B2C3D4E5F60718293A57 /* HomeChromeSnapshotPresentationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomeChromeSnapshotPresentationTests.swift; sourceTree = "<group>"; };
-		F7DB2D794295069B7EB073D1 /* NotificationServiceProtocolExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Services/NotificationServiceProtocolExtension.swift; sourceTree = SOURCE_ROOT; };
-		F7DF103FD6883BAB8A15A117 /* HomeViewModel+ReloadBatchingAndReplanLauncher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+ReloadBatchingAndReplanLauncher.swift"; sourceTree = SOURCE_ROOT; };
-		F830E25037454377EFF1BF94 /* OverdueRescueCupHero.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueCupHero.swift; sourceTree = SOURCE_ROOT; };
-		F85C5DBA19B19B9611E7B283 /* OverdueRescueDeckLayoutMetrics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDeckLayoutMetrics.swift; sourceTree = SOURCE_ROOT; };
-		F8B34D157D734D31C764453F /* LifeManagementComposerPreviewCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerPreviewCard.swift; sourceTree = SOURCE_ROOT; };
+		F7DB2D794295069B7EB073D1 /* LifeBoard/Onboarding/Services/NotificationServiceProtocolExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Services/NotificationServiceProtocolExtension.swift; sourceTree = SOURCE_ROOT; };
+		F7DF103FD6883BAB8A15A117 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+ReloadBatchingAndReplanLauncher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+ReloadBatchingAndReplanLauncher.swift"; sourceTree = SOURCE_ROOT; };
+		F830E25037454377EFF1BF94 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueCupHero.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueCupHero.swift; sourceTree = SOURCE_ROOT; };
+		F85C5DBA19B19B9611E7B283 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDeckLayoutMetrics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDeckLayoutMetrics.swift; sourceTree = SOURCE_ROOT; };
+		F8B34D157D734D31C764453F /* LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerPreviewCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerPreviewCard.swift; sourceTree = SOURCE_ROOT; };
 		F8C1A0019AB24E01A11C1001 /* TaskIconSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskIconSupport.swift; sourceTree = "<group>"; };
 		F8C1A0019AB24E01A11C1002 /* TaskIconSymbolManifest.generated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskIconSymbolManifest.generated.swift; sourceTree = "<group>"; };
 		F8C1A0019AB24E01A11C1003 /* TaskIconSymbolManifest.generated.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = TaskIconSymbolManifest.generated.json; sourceTree = "<group>"; };
-		F8F234318A9DB1B304DDACC7 /* TimelineCapsule.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineCapsule.swift; sourceTree = SOURCE_ROOT; };
-		F92AEE830976A394F39CC8ED /* HomeDueTodayAgendaLoadState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeDueTodayAgendaLoadState.swift; sourceTree = SOURCE_ROOT; };
-		F98E00AF77E03AB54CB0D948 /* HomeReloadScope.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeReloadScope.swift; sourceTree = SOURCE_ROOT; };
+		F8F234318A9DB1B304DDACC7 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCapsule.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineCapsule.swift; sourceTree = SOURCE_ROOT; };
+		F92AEE830976A394F39CC8ED /* LifeBoard/Presentation/ViewModels/Home/HomeDueTodayAgendaLoadState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeDueTodayAgendaLoadState.swift; sourceTree = SOURCE_ROOT; };
+		F98E00AF77E03AB54CB0D948 /* LifeBoard/Presentation/ViewModels/Home/HomeReloadScope.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeReloadScope.swift; sourceTree = SOURCE_ROOT; };
 		F9A8B91DCC93833939CAE3C6 /* LifeBoardWidgets.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = LifeBoardWidgets.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		FA1DA9F6A39882873264672B /* QuietHoursCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuietHoursCard.swift; sourceTree = "<group>"; };
-		FAF2AECE194CB6DF20940C57 /* ScheduleTemplate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/ScheduleTemplate.swift; sourceTree = SOURCE_ROOT; };
-		FB2B2C9DCA8513C631F384DA /* SunriseAppShellView+HabitsAgendaAndFocusStrip.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+HabitsAgendaAndFocusStrip.swift"; sourceTree = SOURCE_ROOT; };
-		FB92AF0F70C629B9BB0501F5 /* HomeDerivedTaskRowsCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeDerivedTaskRowsCache.swift; sourceTree = SOURCE_ROOT; };
+		FAF2AECE194CB6DF20940C57 /* LifeBoard/Domain/Models/ScheduleTemplate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Models/ScheduleTemplate.swift; sourceTree = SOURCE_ROOT; };
+		FB2B2C9DCA8513C631F384DA /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+HabitsAgendaAndFocusStrip.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+HabitsAgendaAndFocusStrip.swift"; sourceTree = SOURCE_ROOT; };
+		FB92AF0F70C629B9BB0501F5 /* LifeBoard/Presentation/ViewModels/Home/HomeDerivedTaskRowsCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/ViewModels/Home/HomeDerivedTaskRowsCache.swift; sourceTree = SOURCE_ROOT; };
 		FB9BE07CCB7761E186498D8C /* LifeBoardTheme.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoardTheme.swift; sourceTree = "<group>"; };
-		FCFE4928C0407CAB71ECC1B9 /* TimelineSurfaceMetrics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineSurfaceMetrics.swift; sourceTree = SOURCE_ROOT; };
-		FD02F6BCA0F7A29431C308E2 /* AppOnboardingJourneyView+LayoutWelcomeAndGoal.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Onboarding/Views/AppOnboardingJourneyView+LayoutWelcomeAndGoal.swift"; sourceTree = SOURCE_ROOT; };
-		FD3BCAD6C5A546608629F532 /* FocusSeedWidget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoardWidgets/FocusSeedWidget.swift; sourceTree = SOURCE_ROOT; };
-		FD40BE88D4061AEA79953253 /* OnboardingStep.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingStep.swift; sourceTree = SOURCE_ROOT; };
-		FDAEF0D7419DC76585760D6E /* TimelinePlacementDock.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelinePlacementDock.swift; sourceTree = SOURCE_ROOT; };
-		FE19A169E4D9F72754B6E3E8 /* LifeManagementComposerInlineMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerInlineMessage.swift; sourceTree = SOURCE_ROOT; };
-		FEB129D0203ADC132EE57051 /* TimelineStreamLayerSpec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamLayerSpec.swift; sourceTree = SOURCE_ROOT; };
-		FEB72F108D49DD4AE2B58A99 /* HomeViewModel+AnalyticsRefresh.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+AnalyticsRefresh.swift"; sourceTree = SOURCE_ROOT; };
-		FEC0DEA9E6D02E2F991F11A1 /* HabitRepositoryProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Interfaces/HabitRepositoryProtocol.swift; sourceTree = SOURCE_ROOT; };
+		FCFE4928C0407CAB71ECC1B9 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineSurfaceMetrics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineSurfaceMetrics.swift; sourceTree = SOURCE_ROOT; };
+		FD02F6BCA0F7A29431C308E2 /* LifeBoard/Onboarding/Views/AppOnboardingJourneyView+LayoutWelcomeAndGoal.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Onboarding/Views/AppOnboardingJourneyView+LayoutWelcomeAndGoal.swift"; sourceTree = SOURCE_ROOT; };
+		FD3BCAD6C5A546608629F532 /* LifeBoardWidgets/FocusSeedWidget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoardWidgets/FocusSeedWidget.swift; sourceTree = SOURCE_ROOT; };
+		FD40BE88D4061AEA79953253 /* LifeBoard/Onboarding/Models/OnboardingStep.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Onboarding/Models/OnboardingStep.swift; sourceTree = SOURCE_ROOT; };
+		FDAEF0D7419DC76585760D6E /* LifeBoard/Presentation/Home/Timeline/Surface/TimelinePlacementDock.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelinePlacementDock.swift; sourceTree = SOURCE_ROOT; };
+		FE19A169E4D9F72754B6E3E8 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerInlineMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerInlineMessage.swift; sourceTree = SOURCE_ROOT; };
+		FEB129D0203ADC132EE57051 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamLayerSpec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamLayerSpec.swift; sourceTree = SOURCE_ROOT; };
+		FEB72F108D49DD4AE2B58A99 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+AnalyticsRefresh.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LifeBoard/Presentation/ViewModels/Home/HomeViewModel+AnalyticsRefresh.swift"; sourceTree = SOURCE_ROOT; };
+		FEC0DEA9E6D02E2F991F11A1 /* LifeBoard/Domain/Interfaces/HabitRepositoryProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LifeBoard/Domain/Interfaces/HabitRepositoryProtocol.swift; sourceTree = SOURCE_ROOT; };
 		FF7B2CAF2B3D23AD9512B999 /* LifeBoardWidgets.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; name = LifeBoardWidgets.entitlements; path = LifeBoardWidgets/LifeBoardWidgets.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -2430,19 +2432,19 @@
 		05554359AC0AA7171B2351B8 /* LifeBoardWidgets */ = {
 			isa = PBXGroup;
 			children = (
-				C1256A6FF63A60FC9D9E82C2 /* LifeBoardWidgetBundle.swift */,
-				B1C2D3E72F90000100AA1001 /* TaskWidgetFoundation.swift */,
-				B1C2D3E82F90000100AA1001 /* TaskWidgetHomeViews.swift */,
-				B1C2D3E92F90000100AA1001 /* TaskWidgetAccessoryViews.swift */,
-				B1C2D3EB2F90000100AA1001 /* TaskWidgetDesignSystemCompat.swift */,
-				B1C2D3ED2F90000100AA1001 /* HomeCalendarWidgetView.swift */,
-				B1C2D3F02F90000100AA1001 /* HomeTimelineWidgetView.swift */,
-				3A74DF0E9DCAEB8A8179F375 /* TodayXPWidget.swift */,
-				B4599EE24B534345B7E5F063 /* WeeklyScoreboardWidget.swift */,
-				89676F376DC27DF3823AB623 /* NextMilestoneWidget.swift */,
-				9BBE8CE1B13AA2877F4BBCAE /* StreakResilienceWidget.swift */,
-				FD3BCAD6C5A546608629F532 /* FocusSeedWidget.swift */,
-				F1A2B3C4D5E6F708192A3B4D /* WidgetBrand.swift */,
+				C1256A6FF63A60FC9D9E82C2 /* LifeBoardWidgets/LifeBoardWidgetBundle.swift */,
+				B1C2D3E72F90000100AA1001 /* LifeBoardWidgets/TaskWidgetFoundation.swift */,
+				B1C2D3E82F90000100AA1001 /* LifeBoardWidgets/TaskWidgetHomeViews.swift */,
+				B1C2D3E92F90000100AA1001 /* LifeBoardWidgets/TaskWidgetAccessoryViews.swift */,
+				B1C2D3EB2F90000100AA1001 /* LifeBoardWidgets/TaskWidgetDesignSystemCompat.swift */,
+				B1C2D3ED2F90000100AA1001 /* LifeBoardWidgets/HomeCalendarWidgetView.swift */,
+				B1C2D3F02F90000100AA1001 /* LifeBoardWidgets/HomeTimelineWidgetView.swift */,
+				3A74DF0E9DCAEB8A8179F375 /* LifeBoardWidgets/TodayXPWidget.swift */,
+				B4599EE24B534345B7E5F063 /* LifeBoardWidgets/WeeklyScoreboardWidget.swift */,
+				89676F376DC27DF3823AB623 /* LifeBoardWidgets/NextMilestoneWidget.swift */,
+				9BBE8CE1B13AA2877F4BBCAE /* LifeBoardWidgets/StreakResilienceWidget.swift */,
+				FD3BCAD6C5A546608629F532 /* LifeBoardWidgets/FocusSeedWidget.swift */,
+				F1A2B3C4D5E6F708192A3B4D /* LifeBoardWidgets/WidgetBrand.swift */,
 				E6095F80ED6FB73CD69363AC /* Info.plist */,
 				FF7B2CAF2B3D23AD9512B999 /* LifeBoardWidgets.entitlements */,
 			);
@@ -2463,11 +2465,11 @@
 		0F156103AF2D844C6B6EE11B /* Gamification */ = {
 			isa = PBXGroup;
 			children = (
-				05E5245EF6140902F09F99CA /* RecordXPUseCase.swift */,
-				1C5FAE972A10C45BCDDB0142 /* GamificationEngine.swift */,
-				7CC4B584282446580AA72B44 /* FocusSessionUseCase.swift */,
-				D4F300000000000000000131 /* DailyReflectionLoadCoordinator.swift */,
-				C63740651E231116AA556D8F /* MarkDailyReflectionCompleteUseCase.swift */,
+				05E5245EF6140902F09F99CA /* LifeBoard/UseCases/Gamification/RecordXPUseCase.swift */,
+				1C5FAE972A10C45BCDDB0142 /* LifeBoard/UseCases/Gamification/GamificationEngine.swift */,
+				7CC4B584282446580AA72B44 /* LifeBoard/UseCases/Gamification/FocusSessionUseCase.swift */,
+				D4F300000000000000000131 /* LifeBoard/UseCases/Gamification/DailyReflectionLoadCoordinator.swift */,
+				C63740651E231116AA556D8F /* LifeBoard/UseCases/Gamification/MarkDailyReflectionCompleteUseCase.swift */,
 			);
 			name = Gamification;
 			sourceTree = "<group>";
@@ -2475,8 +2477,8 @@
 		14C7999D61C4732E90991035 /* LLM */ = {
 			isa = PBXGroup;
 			children = (
-				98955AE7E300D2E682AE486B /* AssistantActionPipelineUseCase.swift */,
-				A8699B1ED0E60EAAE73AE2E3 /* AssistantCommandExecutor.swift */,
+				98955AE7E300D2E682AE486B /* LifeBoard/UseCases/LLM/AssistantActionPipelineUseCase.swift */,
+				A8699B1ED0E60EAAE73AE2E3 /* LifeBoard/UseCases/LLM/AssistantCommandExecutor.swift */,
 			);
 			name = LLM;
 			sourceTree = "<group>";
@@ -2484,8 +2486,8 @@
 		1E4BB5010CAE2AAB6D697F15 /* Habit */ = {
 			isa = PBXGroup;
 			children = (
-				B0B69EFFAB72804AE4A38EB3 /* ManageHabitsUseCase.swift */,
-				C1A100000000000000000003 /* HabitRuntimeUseCases.swift */,
+				B0B69EFFAB72804AE4A38EB3 /* LifeBoard/UseCases/Habit/ManageHabitsUseCase.swift */,
+				C1A100000000000000000003 /* LifeBoard/UseCases/Habit/HabitRuntimeUseCases.swift */,
 			);
 			name = Habit;
 			sourceTree = "<group>";
@@ -2493,7 +2495,7 @@
 		2431DF37906098E0829C80B7 /* Section */ = {
 			isa = PBXGroup;
 			children = (
-				9334755BADE444C8A77BCA3E /* ManageSectionsUseCase.swift */,
+				9334755BADE444C8A77BCA3E /* LifeBoard/UseCases/Section/ManageSectionsUseCase.swift */,
 			);
 			name = Section;
 			sourceTree = "<group>";
@@ -2501,7 +2503,7 @@
 		2700B0B51FFB7EF653E2C7EF /* LifeArea */ = {
 			isa = PBXGroup;
 			children = (
-				E06E18805C2401359A9B0F5B /* ManageLifeAreasUseCase.swift */,
+				E06E18805C2401359A9B0F5B /* LifeBoard/UseCases/LifeArea/ManageLifeAreasUseCase.swift */,
 			);
 			name = LifeArea;
 			sourceTree = "<group>";
@@ -2516,7 +2518,7 @@
 		2E192B5E7D0C3D8FEE45ED41 /* Reminder */ = {
 			isa = PBXGroup;
 			children = (
-				7DD613471ECDE5AFB1BB199B /* ScheduleReminderUseCase.swift */,
+				7DD613471ECDE5AFB1BB199B /* LifeBoard/UseCases/Reminder/ScheduleReminderUseCase.swift */,
 			);
 			name = Reminder;
 			sourceTree = "<group>";
@@ -2524,8 +2526,8 @@
 		3B24EBE5479BE8A48150DCFE /* Services */ = {
 			isa = PBXGroup;
 			children = (
-				F311D68194F7FDAA5BAD7ADA /* CoreSchedulingEngine.swift */,
-				A1E5C40F2F1A4B9D9C1E8A13 /* EventKitAppleRemindersProvider.swift */,
+				F311D68194F7FDAA5BAD7ADA /* LifeBoard/State/Services/CoreSchedulingEngine.swift */,
+				A1E5C40F2F1A4B9D9C1E8A13 /* LifeBoard/State/Services/EventKitAppleRemindersProvider.swift */,
 			);
 			name = Services;
 			sourceTree = "<group>";
@@ -2533,8 +2535,8 @@
 		4BDE4D4721AB3214B6F9804E /* Insights */ = {
 			isa = PBXGroup;
 			children = (
-				7C915FFCD3814E051A506B72 /* InsightsTabView.swift */,
-				5E7A10000000000000000002 /* SunriseInsightsView.swift */,
+				7C915FFCD3814E051A506B72 /* LifeBoard/View/Insights/InsightsTabView.swift */,
+				5E7A10000000000000000002 /* LifeBoard/View/Insights/SunriseInsightsView.swift */,
 				5E7A20000000000000000002 /* SunriseInsightsHeaderView.swift */,
 				5E7A20000000000000000004 /* SunriseInsightsHeroCard.swift */,
 			);
@@ -2544,9 +2546,9 @@
 		4D9CF163F23980743B576923 /* Schedule */ = {
 			isa = PBXGroup;
 			children = (
-				2F80480EA58FB983550B882B /* GenerateOccurrencesUseCase.swift */,
-				E9EF3524C96CA56E66C86177 /* ResolveOccurrenceUseCase.swift */,
-				9251C0BF9A1E5D8BB7B9FC05 /* MaintainOccurrencesUseCase.swift */,
+				2F80480EA58FB983550B882B /* LifeBoard/UseCases/Schedule/GenerateOccurrencesUseCase.swift */,
+				E9EF3524C96CA56E66C86177 /* LifeBoard/UseCases/Schedule/ResolveOccurrenceUseCase.swift */,
+				9251C0BF9A1E5D8BB7B9FC05 /* LifeBoard/UseCases/Schedule/MaintainOccurrencesUseCase.swift */,
 			);
 			name = Schedule;
 			sourceTree = "<group>";
@@ -2567,7 +2569,7 @@
 		529D23B7A8E56B55B3A03C07 /* Tag */ = {
 			isa = PBXGroup;
 			children = (
-				0643A03092D9D90FE7DC26D4 /* ManageTagsUseCase.swift */,
+				0643A03092D9D90FE7DC26D4 /* LifeBoard/UseCases/Tag/ManageTagsUseCase.swift */,
 			);
 			name = Tag;
 			sourceTree = "<group>";
@@ -2626,9 +2628,9 @@
 		61F94D8CE7F219567608A5F7 /* Sync */ = {
 			isa = PBXGroup;
 			children = (
-				4C109B5D75A091971FB33633 /* LinkExternalRemindersUseCase.swift */,
-				22B025D510428B62C47FBE05 /* ReconcileExternalRemindersUseCase.swift */,
-				9AE41E54BA355D96A678CBF7 /* ReminderMergeEngine.swift */,
+				4C109B5D75A091971FB33633 /* LifeBoard/UseCases/Sync/LinkExternalRemindersUseCase.swift */,
+				22B025D510428B62C47FBE05 /* LifeBoard/UseCases/Sync/ReconcileExternalRemindersUseCase.swift */,
+				9AE41E54BA355D96A678CBF7 /* LifeBoard/UseCases/Sync/ReminderMergeEngine.swift */,
 			);
 			name = Sync;
 			sourceTree = "<group>";
@@ -2673,17 +2675,17 @@
 				F8C1A0019AB24E01A11C1002 /* TaskIconSymbolManifest.generated.swift */,
 				F8C1A0019AB24E01A11C1003 /* TaskIconSymbolManifest.generated.json */,
 				ABCD00000000000000000021 /* AddHabitViewModel.swift */,
-				ABCD00000000000000000023 /* HabitIconCatalog.swift */,
-				C1B100000000000000000101 /* HabitBoardPresentationBuilder.swift */,
+				ABCD00000000000000000023 /* LifeBoard/Presentation/Habits/HabitIconCatalog.swift */,
+				C1B100000000000000000101 /* LifeBoard/Presentation/Habits/HabitBoardPresentationBuilder.swift */,
 				A1B2C3D62F90000100AA1001 /* TaskEditorSection.swift */,
 				7509A00D2F13D806009162CD /* HomeViewModel.swift */,
 				7509A0FF2F13D806009162CD /* HomeNeedsReplanViewModel.swift */,
-				C1B100000000000000000103 /* HabitBoardViewModel.swift */,
+				C1B100000000000000000103 /* LifeBoard/Presentation/ViewModels/HabitBoardViewModel.swift */,
 				A7B8C9D12F13D806009162CD /* TaskDetailViewModel.swift */,
 				7509A00E2F13D806009162CD /* ProjectManagementViewModel.swift */,
 				A91F8E142F44420100AB11C1 /* LifeManagementViewModel.swift */,
 				B1A1C1D1E1F1020304050605 /* ProjectSelectionViewModel.swift */,
-				52EDFF0556DE6F60CD19AA39 /* InsightsViewModel.swift */,
+				52EDFF0556DE6F60CD19AA39 /* LifeBoard/Presentation/ViewModels/InsightsViewModel.swift */,
 				D4F100000000000000000109 /* WeeklyPlannerViewModel.swift */,
 				D4F10000000000000000010A /* WeeklyReviewViewModel.swift */,
 				D4F100000000000000000110 /* HomeAIActionCoordinator.swift */,
@@ -2711,13 +2713,13 @@
 		751074EB2DEE24EA00AC7F22 /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				B2E100000000000000000101 /* HomeTodayRow.swift */,
-				B2E100000000000000000107 /* HomeTaskTintResolver.swift */,
-				B2E100000000000000000102 /* HomeHabitRow.swift */,
-				B2E100000000000000000106 /* HomeHabitLastCellInteraction.swift */,
-				B2E100000000000000000105 /* HomeSectionState.swift */,
-				D2A100000000000000000001 /* QuietTrackingComposerSnapshot.swift */,
-				D9A0B1C2D3E4F506172839AE /* InsightsModuleVisibilityPlanner.swift */,
+				B2E100000000000000000101 /* LifeBoard/Presentation/Models/HomeTodayRow.swift */,
+				B2E100000000000000000107 /* LifeBoard/Presentation/Models/HomeTaskTintResolver.swift */,
+				B2E100000000000000000102 /* LifeBoard/Presentation/Models/HomeHabitRow.swift */,
+				B2E100000000000000000106 /* LifeBoard/Presentation/Models/HomeHabitLastCellInteraction.swift */,
+				B2E100000000000000000105 /* LifeBoard/Presentation/Models/HomeSectionState.swift */,
+				D2A100000000000000000001 /* LifeBoard/Presentation/Models/QuietTrackingComposerSnapshot.swift */,
+				D9A0B1C2D3E4F506172839AE /* LifeBoard/Presentation/Models/InsightsModuleVisibilityPlanner.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -3023,22 +3025,493 @@
 		755F74D72F46270F0046BBE9 /* Recovered References */ = {
 			isa = PBXGroup;
 			children = (
-				A10B1C2D3E4F506172839401 /* StateLifeAreaMapper.swift */,
-				A10B1C2D3E4F506172839402 /* StateSectionMapper.swift */,
-				A10B1C2D3E4F506172839403 /* StateTagMapper.swift */,
-				A10B1C2D3E4F506172839404 /* StateTombstoneMapper.swift */,
-				A10B1C2D3E4F506172839405 /* StateHabitDefinitionMapper.swift */,
-				A10B1C2D3E4F506172839407 /* StateTaskDefinitionMapper.swift */,
-				A10B1C2D3E4F506172839408 /* StateProjectMapper.swift */,
-				CA1A20000000000000000001 /* CalendarEventsProviderProtocol.swift */,
-				CA1A20000000000000000002 /* CalendarIntegrationModels.swift */,
-				CA1A20000000000000000006 /* EventKitCalendarChooserSheet.swift */,
-				CA1A20000000000000000007 /* EventKitEventDetailView.swift */,
-				F00D00000000000000001005 /* CalendarSchedulePresentationContracts.swift */,
-				F00D00000000000000001007 /* CalendarTimelinePresentation.swift */,
-				CA1A20000000000000000004 /* EventKitCalendarEventsProvider.swift */,
-				CA1A20000000000000000005 /* CalendarIntegrationService.swift */,
-				CA1A20000000000000000003 /* CalendarComputationUseCases.swift */,
+				A10B1C2D3E4F506172839401 /* LifeBoard/State/Mappers/StateLifeAreaMapper.swift */,
+				A10B1C2D3E4F506172839402 /* LifeBoard/State/Mappers/StateSectionMapper.swift */,
+				A10B1C2D3E4F506172839403 /* LifeBoard/State/Mappers/StateTagMapper.swift */,
+				A10B1C2D3E4F506172839404 /* LifeBoard/State/Mappers/StateTombstoneMapper.swift */,
+				A10B1C2D3E4F506172839405 /* LifeBoard/State/Mappers/StateHabitDefinitionMapper.swift */,
+				A10B1C2D3E4F506172839407 /* LifeBoard/State/Mappers/StateTaskDefinitionMapper.swift */,
+				A10B1C2D3E4F506172839408 /* LifeBoard/State/Mappers/StateProjectMapper.swift */,
+				CA1A20000000000000000001 /* LifeBoard/Domain/Interfaces/CalendarEventsProviderProtocol.swift */,
+				CA1A20000000000000000002 /* LifeBoard/Domain/Models/CalendarIntegrationModels.swift */,
+				CA1A20000000000000000006 /* LifeBoard/View/Calendar/EventKitCalendarChooserSheet.swift */,
+				CA1A20000000000000000007 /* LifeBoard/View/Calendar/EventKitEventDetailView.swift */,
+				F00D00000000000000001005 /* LifeBoard/View/Calendar/CalendarSchedulePresentationContracts.swift */,
+				F00D00000000000000001007 /* LifeBoard/View/Calendar/CalendarTimelinePresentation.swift */,
+				CA1A20000000000000000004 /* LifeBoard/State/Services/EventKitCalendarEventsProvider.swift */,
+				CA1A20000000000000000005 /* LifeBoard/State/Services/CalendarIntegrationService.swift */,
+				CA1A20000000000000000003 /* LifeBoard/UseCases/Calendar/CalendarComputationUseCases.swift */,
+				70CF1C88BCCEBC000C9FEC38 /* LifeBoard/Onboarding/Models/OnboardingNotificationNameExtension.swift */,
+				B515F171FB9C556BBCA40366 /* LifeBoard/Onboarding/Models/AppOnboardingAccessibilityID.swift */,
+				4D1039EA2610A24D8D430EAD /* LifeBoard/Onboarding/Models/OnboardingCopy.swift */,
+				3ACB1F98FD6BA7DDDC213D7B /* LifeBoard/Onboarding/Models/OnboardingProgress.swift */,
+				12B9F0A506329D6FA33A3932 /* LifeBoard/Onboarding/Models/onboardingLogLine.swift */,
+				AB34BB65B7298F039E9C6A1C /* LifeBoard/Onboarding/Models/logOnboardingInfo.swift */,
+				D3FE2E5497D838BF7ACBA002 /* LifeBoard/Onboarding/Models/logOnboardingError.swift */,
+				6396B895E176C6D9B55C30EC /* LifeBoard/Onboarding/Models/OnboardingOutcome.swift */,
+				FD40BE88D4061AEA79953253 /* LifeBoard/Onboarding/Models/OnboardingStep.swift */,
+				61B03639156A8E2D31701235 /* LifeBoard/Onboarding/Models/OnboardingPrimaryGoal.swift */,
+				F1DD1A6ABC050A464C7B4397 /* LifeBoard/Onboarding/Models/OnboardingPainPoint.swift */,
+				C16F9565F3F8F2F079B9CE76 /* LifeBoard/Onboarding/Models/OnboardingStarterHabitPreference.swift */,
+				2D16AF9130E446C22AB65042 /* LifeBoard/Onboarding/Models/OnboardingEvaPreparationPhase.swift */,
+				40541FE4F6750C143582AC0D /* LifeBoard/Onboarding/Models/OnboardingEvaPreparationState.swift */,
+				6C4934047F3DBEA1EF645AC1 /* LifeBoard/Onboarding/Models/OnboardingNetworkClass.swift */,
+				B9CD88BD827717D7C56D112A /* LifeBoard/Onboarding/Models/OnboardingFrictionProfile.swift */,
+				37DD8CAB8F66109195DD8D31 /* LifeBoard/Onboarding/Models/OnboardingMode.swift */,
+				9632B2C3609C7092AB65BFF4 /* LifeBoard/Onboarding/Models/OnboardingEntryContext.swift */,
+				098E6EFC49514867101BA977 /* LifeBoard/Onboarding/Models/OnboardingTaskTemplateState.swift */,
+				80E4F64519A39289AF03A73C /* LifeBoard/Onboarding/Models/OnboardingHabitTemplateState.swift */,
+				4A391C151F9BE79B12EAF441 /* LifeBoard/Onboarding/Models/OnboardingReminderPromptState.swift */,
+				A07B9FA858B4AFC05615FCFA /* LifeBoard/Onboarding/Models/WelcomeIntroPhase.swift */,
+				862166F085A7F815ADA70872 /* LifeBoard/Onboarding/Models/OnboardingWorkspaceSnapshot.swift */,
+				CF4E3B7EAAC54AE18553A302 /* LifeBoard/Onboarding/Models/OnboardingEligibility.swift */,
+				1859F3D260EADFEA49FDBA98 /* LifeBoard/Onboarding/Models/AppOnboardingSummary.swift */,
+				EB8BC6F60B76437F2E6148F7 /* LifeBoard/Onboarding/Models/CodingKeys.swift */,
+				93DB4D12EFFDD4985EEBD374 /* LifeBoard/Onboarding/Models/OnboardingBreakdownStep.swift */,
+				98AB62BE5A27121F39C5F499 /* LifeBoard/Onboarding/Models/OnboardingProjectDraft.swift */,
+				E150AE4B6341CE9C52EA4AF0 /* LifeBoard/Onboarding/Models/ResolvedLifeAreaSelection.swift */,
+				1A81F8713DDE19EF4F956288 /* LifeBoard/Onboarding/Models/ResolvedProjectSelection.swift */,
+				7163B97F4D083B9AB6B24476 /* LifeBoard/Onboarding/Models/OnboardingJourneySnapshot.swift */,
+				75DD317FAC37A8674392A5B6 /* LifeBoard/Onboarding/Models/CodingKeys2.swift */,
+				4AADEA1EA2E960494BF2F708 /* LifeBoard/Onboarding/Models/AppOnboardingState.swift */,
+				0D09C9507B3C691C73DA808A /* LifeBoard/Onboarding/Models/PendingOnboardingPresentation.swift */,
+				2139792A102DCF4971E889CC /* LifeBoard/Onboarding/Models/OnboardingPresentationQueue.swift */,
+				9762A762CB36A9A40F919329 /* LifeBoard/Onboarding/Services/AppOnboardingStateStore.swift */,
+				B3A7A770EE9760A923219618 /* LifeBoard/Onboarding/Models/StarterTaskTemplate.swift */,
+				9C18263F8735AB2DC17840F5 /* LifeBoard/Onboarding/Models/StarterHabitTemplate.swift */,
+				782F77DA4E5822C3A8AF4305 /* LifeBoard/Onboarding/Models/StarterProjectTemplate.swift */,
+				1BD2CC14C16ACDED405C7814 /* LifeBoard/Onboarding/Models/StarterLifeAreaTemplate.swift */,
+				98E3FDAB970DF9A475E91D5F /* LifeBoard/Onboarding/Models/StarterWorkspaceCatalog.swift */,
+				940BF66B5480A201F5424FC9 /* LifeBoard/Onboarding/Services/OnboardingEligibilityService.swift */,
+				0D9B95BD66FD5C98B9AB37AE /* LifeBoard/Onboarding/Services/HomeOnboardingGuidanceModel.swift */,
+				8037E33E14B5471548D66C82 /* LifeBoard/Onboarding/Services/OnboardingFeedbackController.swift */,
+				F66EEF4F24A54CD971C9612A /* LifeBoard/Onboarding/Services/OnboardingFlowModel.swift */,
+				079A43F8E9012BEFEACB658C /* LifeBoard/Onboarding/Services/OnboardingFlowModel+CatalogPresentation.swift */,
+				CD51EED85A7A2713DD596393 /* LifeBoard/Onboarding/Services/OnboardingFlowModel+LifeAreaHabitTaskSetup.swift */,
+				D2ABCBECDD204257AB9B9506 /* LifeBoard/Onboarding/Services/OnboardingFlowModel+EvaPreferencesAndDemo.swift */,
+				5A7FAC655E04AFF0711F5AD2 /* LifeBoard/Onboarding/Services/OnboardingFlowModel+NavigationPersistence.swift */,
+				256FD8E6876C56256C606CBF /* LifeBoard/Onboarding/Services/OnboardingFlowModel+EvaActivationPreparation.swift */,
+				ABDC5FDB10DF919EB7B94CC4 /* LifeBoard/Onboarding/Coordinator/AppOnboardingHostAdapter.swift */,
+				CFFC54215415EB867E73F6BC /* LifeBoard/Onboarding/Components/HomeViewControllerExtension.swift */,
+				9D9D661B4914CE34AEA2DD30 /* LifeBoard/Onboarding/Coordinator/AppOnboardingCoordinator.swift */,
+				CDB9D4FD3A636968AEBF5DB7 /* LifeBoard/Onboarding/Coordinator/AppOnboardingCoordinator+Presentation.swift */,
+				0782589C1467EBE5827782EF /* LifeBoard/Onboarding/Models/OnboardingInputField.swift */,
+				030D7ED39864D654D71BF1CE /* LifeBoard/Onboarding/Views/AppOnboardingJourneyView.swift */,
+				FD02F6BCA0F7A29431C308E2 /* LifeBoard/Onboarding/Views/AppOnboardingJourneyView+LayoutWelcomeAndGoal.swift */,
+				F65EA7E811D99F9A2999C0D5 /* LifeBoard/Onboarding/Views/AppOnboardingJourneyView+SetupSteps.swift */,
+				D4EE9804CB09C71523D27F9D /* LifeBoard/Onboarding/Views/AppOnboardingJourneyView+DemoPermissionsAndDock.swift */,
+				BAD49D68C47ABAA22C239873 /* LifeBoard/Onboarding/Views/AppOnboardingJourneyView+OutcomeDraftsAndActions.swift */,
+				9B526F1E51EB6600E103374A /* LifeBoard/Onboarding/Views/AppOnboardingPromptSheetView.swift */,
+				C8F9A299A8C725C1852BB744 /* LifeBoard/Onboarding/Components/OnboardingPromptBackground.swift */,
+				3206AE8D772083ABEFFE26DA /* LifeBoard/Onboarding/Components/OnboardingPromptChecklistCard.swift */,
+				0D9FE88AEA020FF9DA3791C7 /* LifeBoard/Onboarding/Models/OnboardingPromptTheme.swift */,
+				ABA8BBA9B91A5587A8389B33 /* LifeBoard/Onboarding/Components/OnboardingPromptValueCard.swift */,
+				F29A008521575A41C80A3750 /* LifeBoard/Onboarding/Components/OnboardingPromptPrimaryCTAButtonStyle.swift */,
+				4F67F2F26774817EB86045D0 /* LifeBoard/Onboarding/Models/OnboardingPromptGlassPanelModifier.swift */,
+				102FF39D56775B7335081882 /* LifeBoard/Onboarding/Models/OnboardingPromptFooterMaterialModifier.swift */,
+				B1D4A4EDAF6692D9D7819FF1 /* LifeBoard/Onboarding/Components/HomeOnboardingGuidanceBanner.swift */,
+				04856A49C5F0944D2A558B4F /* LifeBoard/Onboarding/Models/OnboardingTheme.swift */,
+				C2BC103F549E15D1F888996A /* LifeBoard/Onboarding/Models/OnboardingPastelPalette.swift */,
+				38BF65FECAAA9E50000FFA9E /* LifeBoard/Onboarding/Models/OnboardingStepVisualTheme.swift */,
+				F280FDE93AC86C0D82E9C51E /* LifeBoard/Onboarding/Models/OnboardingConcentricColorField.swift */,
+				DE748EA399CF4D774ECEE086 /* LifeBoard/Onboarding/Models/OnboardingConcentricTransitionLayer.swift */,
+				ED9726B0BA993B4BD3887748 /* LifeBoard/Onboarding/Models/OnboardingFloatingNextAction.swift */,
+				076D0B0C6429D3BED7BCBF7A /* LifeBoard/Onboarding/Components/OnboardingFloatingNextButton.swift */,
+				78CBCB775F9593EF36C11AB8 /* LifeBoard/Onboarding/Views/AppOnboardingBackground.swift */,
+				4B5776D8C36FD7BB8FC91DA6 /* LifeBoard/Onboarding/Models/OnboardingSectionHeader.swift */,
+				87FF3FCE748CD6D1CC8DD64D /* LifeBoard/Onboarding/Models/OnboardingEyebrowLabel.swift */,
+				351390B6BEADE2277EF6ECBA /* LifeBoard/Onboarding/Components/OnboardingTrustRow.swift */,
+				98FB866510908516712F3407 /* LifeBoard/Onboarding/Components/OnboardingHeroMediaAsset.swift */,
+				5AA802C6A00F24E4A28E8E77 /* LifeBoard/Onboarding/Components/OnboardingCinematicBackdrop.swift */,
+				5B274BA1A3D3146A9178FFC7 /* LifeBoard/Onboarding/Models/OnboardingAccessibilityMarker.swift */,
+				8CB5F00E7099AA872CD49634 /* LifeBoard/Onboarding/Views/OnboardingAccessibilityMarkerView.swift */,
+				91DC2B1EAEE6DF2FDE3242F1 /* LifeBoard/Onboarding/Models/OnboardingWelcomeCinematicOverlay.swift */,
+				377436A41D3BA36DD06E3C58 /* LifeBoard/Onboarding/Models/OnboardingWelcomeIntroLine.swift */,
+				CFC525E06BF11EBA6D7A5BC3 /* LifeBoard/Onboarding/Views/OnboardingHeroVideoView.swift */,
+				B37462636B49FEA555BA9E24 /* LifeBoard/Onboarding/Views/OnboardingLoopingPlayerView.swift */,
+				74E0C50451A57E60BB0E3EC8 /* LifeBoard/Onboarding/Components/OnboardingFrictionSelector.swift */,
+				EE642CCFDAF7BBFD6AD34B98 /* LifeBoard/Onboarding/Components/OnboardingFrictionSelectorLayout.swift */,
+				2689E7BAE48C3D0915401020 /* LifeBoard/Onboarding/Components/OnboardingFrictionSelectorWidthPreferenceKey.swift */,
+				7F70E654847A2B4F0458F49F /* LifeBoard/Onboarding/Components/OnboardingSelectionSummaryCard.swift */,
+				83B4B8D198A7243A6496C809 /* LifeBoard/Onboarding/Models/OnboardingMascotCarousel.swift */,
+				96F9262E57D935FD98FFDE2C /* LifeBoard/Onboarding/Components/OnboardingCustomEntryRow.swift */,
+				68E8BC7F87ABDAD6C5B79CE0 /* LifeBoard/Onboarding/Components/OnboardingInlineActionRow.swift */,
+				16CA0CB88D6BCF379DD02183 /* LifeBoard/Onboarding/Models/OnboardingDownloadStatusStrip.swift */,
+				61DB2B7298DBBD959D03B5D5 /* LifeBoard/Onboarding/Models/OnboardingDownloadStatusPill.swift */,
+				4E66ADE238E28DD2BC20A9C7 /* LifeBoard/Onboarding/Components/OnboardingPermissionHeroIcon.swift */,
+				2D98632874AFDD2B129187E0 /* LifeBoard/Onboarding/Models/OnboardingHomeDemoSnapshotFactory.swift */,
+				4F244B959C35562023B24390 /* LifeBoard/Onboarding/Components/OnboardingHomeDemoPreview.swift */,
+				BA878C13E4A9CF39A3D86B40 /* LifeBoard/Onboarding/Components/OnboardingChecklistCard.swift */,
+				83BA608636D6DB86CBE1DC83 /* LifeBoard/Onboarding/Components/OnboardingChecklistRow.swift */,
+				50AA968766A5349A2BB45C61 /* LifeBoard/Onboarding/Components/OnboardingSelectableDetailCard.swift */,
+				5F2067B7B6ACA2A4A2DA6279 /* LifeBoard/Onboarding/Components/OnboardingFilterChip.swift */,
+				EC2F92D22CA429D62EFD9F46 /* LifeBoard/Onboarding/Components/OnboardingHabitStreakPreviewCard.swift */,
+				144D7D155E9471F5D9E1CD62 /* LifeBoard/Onboarding/Models/OnboardingMiniMetric.swift */,
+				CC4A401D3FB5682FC6804B6F /* LifeBoard/Onboarding/Components/OnboardingTaskPreviewCard.swift */,
+				29564FDC651771ED4BB94446 /* LifeBoard/Onboarding/Models/OnboardingCompactHabitRail.swift */,
+				8E16263361281852BA8E5B7F /* LifeBoard/Onboarding/Components/OnboardingEvaStatusCard.swift */,
+				DBA49A78931E2752ADDE59CA /* LifeBoard/Onboarding/Components/OnboardingFrictionOptionCard.swift */,
+				A93FE62F2A34CD25059D4950 /* LifeBoard/Onboarding/Components/OnboardingSelectableCard.swift */,
+				1DB65ADBF6B22879FF33FF66 /* LifeBoard/Onboarding/Components/OnboardingHabitRecommendationCard.swift */,
+				77F82FC408C33F7C6D11BC93 /* LifeBoard/Onboarding/Components/OnboardingTaskRecommendationCard.swift */,
+				78DF4503F0438173C6DC91B8 /* LifeBoard/Onboarding/Components/OnboardingPressScaleButtonStyle.swift */,
+				4811259E3F517E7F0E457DCD /* LifeBoard/Onboarding/Components/OnboardingPrimaryCTAButtonStyle.swift */,
+				598CD23D633F1DA652C429A5 /* LifeBoard/Onboarding/Models/OnboardingInlineBadge.swift */,
+				950F69C7A81EE1B80D656D06 /* LifeBoard/Onboarding/Components/OnboardingFocusHeroCard.swift */,
+				6E48DF58E65C9466AC4E2893 /* LifeBoard/Onboarding/Models/OnboardingFocusTimer.swift */,
+				D2D63CF8E5D155F2AF44EF2A /* LifeBoard/Onboarding/Components/OnboardingSuccessHero.swift */,
+				21E20317B5C516035FAEE85D /* LifeBoard/Onboarding/Components/OnboardingSuccessSummaryCard.swift */,
+				A13C9964C87A904A153CCAC6 /* LifeBoard/Onboarding/Components/OnboardingSuccessSummaryRow.swift */,
+				3C9C1DCD3D8D37AB96401D40 /* LifeBoard/Onboarding/Models/onboardingNaturalLanguageList.swift */,
+				C53A20FDEE1A1CCD05E76506 /* LifeBoard/Onboarding/Components/ViewExtension.swift */,
+				4791B51EBAFFF32DE7642287 /* LifeBoard/Onboarding/Models/LifeAreaRepositoryProtocolExtension.swift */,
+				41DF50E6CD46F6C802CC86EE /* LifeBoard/Onboarding/Models/ProjectRepositoryProtocolExtension.swift */,
+				93E4A4DA88B81666171B5808 /* LifeBoard/Onboarding/Models/HabitRepositoryProtocolExtension.swift */,
+				871E14455069188F7847E1DB /* LifeBoard/Onboarding/Models/TaskDefinitionRepositoryProtocolExtension.swift */,
+				69507E47E2C799073FE4018A /* LifeBoard/Onboarding/Models/ManageLifeAreasUseCaseExtension.swift */,
+				A6F510C5BFB0D534AB441244 /* LifeBoard/Onboarding/Models/ManageProjectsUseCaseExtension.swift */,
+				B2BF76CE760383A7CA3E84F4 /* LifeBoard/Onboarding/Models/CreateTaskDefinitionUseCaseExtension.swift */,
+				27994B950A0F914CFEDC6740 /* LifeBoard/Onboarding/Models/CreateHabitUseCaseExtension.swift */,
+				4E3C7D35C2C5FC1FDEF0A89C /* LifeBoard/Onboarding/Models/ManageHabitsUseCaseExtension.swift */,
+				3E224DFA4DB09C938556B07B /* LifeBoard/Onboarding/Models/CompleteTaskDefinitionUseCaseExtension.swift */,
+				72FC1B3486FA846731E8FCE6 /* LifeBoard/Onboarding/Models/ResolveHabitOccurrenceUseCaseExtension.swift */,
+				B20F2D4962594CB52DC1918C /* LifeBoard/Onboarding/Services/CalendarIntegrationServiceExtension.swift */,
+				F7DB2D794295069B7EB073D1 /* LifeBoard/Onboarding/Services/NotificationServiceProtocolExtension.swift */,
+				F51E8DFC25DB5CED3BB58615 /* LifeBoard/Presentation/ViewModels/Home/LifeBoardCancellableDispatchWorkItem.swift */,
+				B0B60F4DC92BA3ACD065F8D3 /* LifeBoard/Presentation/ViewModels/Home/HomeTaskDetailMetadataState.swift */,
+				3674205CDE72EB0BA59F05D4 /* LifeBoard/Presentation/ViewModels/Home/HomeTaskDetailRelationshipMetadataState.swift */,
+				F92AEE830976A394F39CC8ED /* LifeBoard/Presentation/ViewModels/Home/HomeDueTodayAgendaLoadState.swift */,
+				8B64FFD6CD4BC91A0687E1B2 /* LifeBoard/Presentation/ViewModels/Home/HomeCanonicalHabitMutationLoadState.swift */,
+				36BCF2891531B59B34A6773C /* LifeBoard/Presentation/ViewModels/Home/HomeHabitWidgetRowsState.swift */,
+				8F4F0CDFF4458CFC2FFBA4A5 /* LifeBoard/Presentation/ViewModels/Home/DailySummaryLoadState.swift */,
+				BA66AB0570744BB33285402E /* LifeBoard/Presentation/ViewModels/Home/HomeTaskMutationEvent.swift */,
+				F98E00AF77E03AB54CB0D948 /* LifeBoard/Presentation/ViewModels/Home/HomeReloadScope.swift */,
+				0F491D6AE37A2795AA0485A7 /* LifeBoard/Presentation/ViewModels/Home/HomeDateNavigationSource.swift */,
+				4090E95CAD9BC75484267914 /* LifeBoard/Presentation/ViewModels/Home/HomeDayNavigationDirection.swift */,
+				9EA22869E8CBC680A061ABAC /* LifeBoard/Presentation/ViewModels/Home/HomeDataRevision.swift */,
+				77DC1194E3FDC7C550953B31 /* LifeBoard/Presentation/ViewModels/Home/HomeRenderInvalidation.swift */,
+				6F5CCCB595F2AED7845487FD /* LifeBoard/Presentation/ViewModels/Home/HomeTimelineWorkspacePreferencesSignature.swift */,
+				4EC8D7FF629E27D3B426AD36 /* LifeBoard/Presentation/ViewModels/Home/HomeTimelineEventSignature.swift */,
+				6B6FB0479B78BDE0B210F2E8 /* LifeBoard/Presentation/ViewModels/Home/HomeTimelineSnapshotCacheKey.swift */,
+				C2FC9E261B9D943C48C8EEC4 /* LifeBoard/Presentation/ViewModels/Home/HomeTimelineCalendarSignature.swift */,
+				4ABDFA484783D44FCE389CA8 /* LifeBoard/Presentation/ViewModels/Home/HomeTimelineReplanCandidateSignature.swift */,
+				13E7DC8765CCB903348B7B91 /* LifeBoard/Presentation/ViewModels/Home/HomeTimelineReplanPhaseSignature.swift */,
+				078F0DB7D6806A7A2A660437 /* LifeBoard/Presentation/ViewModels/Home/HomeTimelineReplanStateSignature.swift */,
+				67726D5DDDEB64497FEB21C9 /* LifeBoard/Presentation/ViewModels/Home/HomeReplanResolutionKind.swift */,
+				DC10C732F02AD5EBF16333E3 /* LifeBoard/Presentation/ViewModels/Home/HomeReplanUndoEntry.swift */,
+				4D84FC1284BCFE8A1BB020B5 /* LifeBoard/Presentation/ViewModels/Home/HabitRecoveryReflectionPrompt.swift */,
+				1F47DE38B051783EAE99853E /* LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationFeedbackHaptic.swift */,
+				A07E21E632557DE3A511B5C8 /* LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationFeedback.swift */,
+				917E928680EC00ECB792B118 /* LifeBoard/Presentation/ViewModels/Home/HomeReloadBatchTracker.swift */,
+				3F0DB5144721E54F43222D3D /* LifeBoard/Presentation/ViewModels/Home/NSLockExtension.swift */,
+				3E03A10085F34C95F49402B3 /* LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationRequest.swift */,
+				2AB81062DAE961E3F10652E2 /* LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationKey.swift */,
+				72A5D667C54915B85FDEAA65 /* LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationSnapshot.swift */,
+				FB92AF0F70C629B9BB0501F5 /* LifeBoard/Presentation/ViewModels/Home/HomeDerivedTaskRowsCache.swift */,
+				A06726F28B0B30E18CCF0D3B /* LifeBoard/Presentation/ViewModels/Home/HomeDerivedHabitRowsCache.swift */,
+				677222149F21BD5C04EE2EC2 /* LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationSectionPatch.swift */,
+				E3971F5A044B9EC46E27BEC2 /* LifeBoard/Presentation/ViewModels/Home/HomeHabitRowPlacementBucket.swift */,
+				F21D047990188A6B02C70A9F /* LifeBoard/Presentation/ViewModels/Home/HomeHabitRowPlacement.swift */,
+				8763CA6B0B62B52616869680 /* LifeBoard/Presentation/ViewModels/Home/HomeTaskReloadNotificationEvent.swift */,
+				4F8E82EED2FB2D349E9F3BE9 /* LifeBoard/Presentation/ViewModels/Home/FocusPinResult.swift */,
+				46D86472D55596A7E3DE5FED /* LifeBoard/Presentation/ViewModels/Home/FocusPromotionResult.swift */,
+				C4A9726955E0A1C39832E736 /* LifeBoard/Presentation/ViewModels/Home/HomeNotificationNameExtension.swift */,
+				222C1D1DF983BFFDF4BB651E /* LifeBoard/Presentation/ViewModels/Home/CelebrationKind.swift */,
+				5199C25A108D3EDC5DD5E0D9 /* LifeBoard/Presentation/ViewModels/Home/CelebrationEvent.swift */,
+				875713F2747185071D35BDF9 /* LifeBoard/Presentation/ViewModels/Home/CelebrationPresentation.swift */,
+				B95AB168FC420F7EE412CB09 /* LifeBoard/Presentation/ViewModels/Home/CelebrationRouter.swift */,
+				99ED29FB4D6A1C5E61C6A702 /* LifeBoard/Presentation/ViewModels/Home/DefaultCelebrationRouter.swift */,
+				54D0BEA667E2738CDF713A68 /* LifeBoard/Presentation/ViewModels/Home/InsightsLaunchRequest.swift */,
+				83C12D0895BE1B134C2DEDF5 /* LifeBoard/Presentation/ViewModels/Home/HomeOverdueRescueLauncherState.swift */,
+				DE2CDAC6D56F874D92E1DD4D /* LifeBoard/Presentation/ViewModels/Home/HomeViewModelRoot.swift */,
+				DF57C7F694B30CF25D4C71B7 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+Bindings.swift */,
+				1E69586D6A0661BB639FAE5F /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+RenderTransaction.swift */,
+				FEB72F108D49DD4AE2B58A99 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+AnalyticsRefresh.swift */,
+				E76B472B10FBCD33AF5BF327 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+DailyReflectionPreview.swift */,
+				81B4061464040091D355959D /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+DailySummaryModal.swift */,
+				9A0864533C56B27765DDB7A4 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+DateNavigation.swift */,
+				06C9F0E1B9A7D11A42BEFEB1 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+DueTodayAgenda.swift */,
+				1F9BFCCD7C709FF34D6E5824 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+EvaRescueActions.swift */,
+				66890102B461937BC39F7607 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+FocusPins.swift */,
+				82775C66CDC41F9E7034D949 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+FocusSessions.swift */,
+				34C9C6671884EE8926C32968 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+FocusWhyCandidates.swift */,
+				E1EA03651FCE790FF4C8E5EB /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+HabitActionShortcuts.swift */,
+				2C7BD248BA8AC069F8261EE8 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+HabitReconciliation.swift */,
+				8FC11A075C9E37AF0A3A64C8 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+InitialLoading.swift */,
+				5991B0FA3A61ED01648C82AC /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+InsightsLaunch.swift */,
+				CA4596A02DBC4C81BD5D267F /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+ProjectionInvalidation.swift */,
+				89E23AC0E5DF84E0125F5845 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+RecurringTopUp.swift */,
+				338615107E8C8B6C3389301D /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+ReferenceDataLoading.swift */,
+				391110AA08B7ED7F8ED57B9C /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+RescueEligibility.swift */,
+				E9FBA211F8998587F17C8785 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+TaskDetailMetadata.swift */,
+				3DF9AEF356D3B2242580C561 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+RefreshEntryPoints.swift */,
+				C8E1864B29C7801E433C2D11 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+TaskActions.swift */,
+				41E91E7B08A3DB7F6092C4D4 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+TaskCreationDependencies.swift */,
+				A7E56873BA58AFC39AFB0D20 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+FiltersAndSavedViews.swift */,
+				EC8C891FA22F9B04EA07D70E /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+EvaFocus.swift */,
+				D7697952AC65F15B0B831D63 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+RescueUndo.swift */,
+				1E88A3C9B5309D183423ACF8 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+DailyAnalytics.swift */,
+				B3CBE8CE6330FA556306A57F /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+HabitMutations.swift */,
+				9B303E46398ACDB321C2EC64 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+HabitMutationPatching.swift */,
+				5082229527A40A436284F69E /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+ReloadPipeline.swift */,
+				5A1DE5B5363A7EED7AF42BC8 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+SectionProjection.swift */,
+				C30956B2414E9EE5EACA5A60 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+FocusRankingAndWidgetSnapshot.swift */,
+				F7DF103FD6883BAB8A15A117 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+ReloadBatchingAndReplanLauncher.swift */,
+				03EEB4E98CFC74139C3D08E9 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+NeedsReplanStateAndPlacement.swift */,
+				DB3046F068EDB7B40DCD6825 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+CompletionProjection.swift */,
+				5495D17B3F94C89D74CD407E /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+StateUtilities.swift */,
+				D76C10CD61388AF076BFDDB5 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamInfluenceKind.swift */,
+				52AE529746E4CDD7FB4A8C95 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamInfluence.swift */,
+				272F492CB5085884C2B03F16 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamInfluenceExtension.swift */,
+				D721CBA93E7A9DDD50E1C65C /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamDirection.swift */,
+				4C1759A7E8DB0E5CE0E3384C /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamAnchor.swift */,
+				8F4D92143BA2F3C1FE24BFFE /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamSegment.swift */,
+				A686073CD1BB07971DFD578B /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamSample.swift */,
+				083E8304C4213AFE52640917 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamGeometry.swift */,
+				120C5DB7F91E3BDB4BF9580F /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamGeometry+LaneLayoutAndPaths.swift */,
+				549A929D15B98C035C74BD90 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamGeometry+MassClustering.swift */,
+				FEB129D0203ADC132EE57051 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamLayerSpec.swift */,
+				24A454E67411059893B17309 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineNowBeadPresentation.swift */,
+				4FF17DADC7AB95846135B2EE /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCanvasLayoutPlan.swift */,
+				A66619E14C36928EAAFD471F /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCanvasLayoutPlan+VisualTimeMapping.swift */,
+				6A85EFA2BA71673BE1DDF31C /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCanvasLayoutPlan+Positioning.swift */,
+				AC0C44769FFD55EF43FB1B63 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompactLayoutPlan.swift */,
+				5EA1722FAD5507224C2ED584 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineFormatting.swift */,
+				6DA154258145A6BBE62580E5 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineItemVisuals.swift */,
+				439335894506149A6B79E4A7 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineDayRelation.swift */,
+				36F7B2A4D32F9921BBA51449 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineDayStablePresentation.swift */,
+				01EE7EB5F53129BCEE1A8679 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineDayCurrentState.swift */,
+				1E09A984D40ECCC16F14B36F /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineDayPresentation.swift */,
+				A109D2B957E1D5A47149A0D9 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineVisualTokens.swift */,
+				FCFE4928C0407CAB71ECC1B9 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineSurfaceMetrics.swift */,
+				8DE0001352EA0BD0110E4A7F /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailMetrics.swift */,
+				B822ABD8182F921799838D39 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineSpineMounting.swift */,
+				C9F3897EC91C68C4A79F81A8 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailLabelKind.swift */,
+				433D1B69B2B63A326822F611 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailTypography.swift */,
+				683FBF4822AC0FD20D70E253 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailTimeFormatter.swift */,
+				5B1528CAF56D71468F82A432 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineRoutineTextFormatter.swift */,
+				526C43C6A27A7D7271C5528E /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineBottomProtectionBudget.swift */,
+				884AE8F47B1E2B1F9D346956 /* LifeBoard/Presentation/Home/Timeline/Surface/timelineDisplayedNow.swift */,
+				91B7A1ACCF6D1219FEF880EC /* LifeBoard/Presentation/Home/Timeline/Surface/timelineSuggestedAddDate.swift */,
+				ED51698C3FB7D6F725184D46 /* LifeBoard/Presentation/Home/Timeline/Surface/timelineMetaText.swift */,
+				85DF0433A9683E2365552FC2 /* LifeBoard/Presentation/Home/Timeline/Surface/timelineMetaColor.swift */,
+				3A455CC1761B05C261D2051B /* LifeBoard/Presentation/Home/Timeline/Surface/timelineTitleColor.swift */,
+				05709BBC85C1A6062231609B /* LifeBoard/Presentation/Home/Timeline/Surface/timelineRingColor.swift */,
+				04BB26CD286E91AABB2ECF5B /* LifeBoard/Presentation/Home/Timeline/Surface/timelineAccessibilityLabel.swift */,
+				7B6CF6BCC0828B64D4447931 /* LifeBoard/Presentation/Home/Timeline/Surface/timelineAccessibilityIdentifier.swift */,
+				AD6F79B4F4AF4D2B4E34CD17 /* LifeBoard/Presentation/Home/Timeline/Surface/timelineRailText.swift */,
+				0AA18F175EDA0C022217BD98 /* LifeBoard/Presentation/Home/Timeline/Surface/timelineStemColor.swift */,
+				55440275F14F44B2492C3CAC /* LifeBoard/Presentation/Home/Timeline/Surface/timelineGapPromptText.swift */,
+				C3D2A8B1ED9E802D3D13F58F /* LifeBoard/Presentation/Home/Timeline/Surface/gapPromptTint.swift */,
+				33167B1E5D148BC1B8907161 /* LifeBoard/Presentation/Home/Timeline/Surface/timelineCapsuleHeight.swift */,
+				73F5AC60FF99A3BFD8D843C7 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineUtilityItemExtension.swift */,
+				431D37A2C5059760CA9637D5 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailPresentationSpec.swift */,
+				C5AE575AEC28DEC3F5464818 /* LifeBoard/Presentation/Home/Timeline/Surface/SunriseTimelineSurfaceRoot.swift */,
+				51669681D49905D56C3864BD /* LifeBoard/Presentation/Home/Timeline/Surface/SunriseTimelineSurface+PlacementHelpers.swift */,
+				9A7730F5637D23CE103B743B /* LifeBoard/Presentation/Home/Timeline/Surface/TimelinePlacementPrompt.swift */,
+				FDAEF0D7419DC76585760D6E /* LifeBoard/Presentation/Home/Timeline/Surface/TimelinePlacementDock.swift */,
+				1B764C348624AC32EFC9F04F /* LifeBoard/Presentation/Home/Timeline/Surface/TimelinePalette.swift */,
+				4CF79ECF04752304C36B28F8 /* LifeBoard/Presentation/Home/Timeline/Surface/SunriseTimelineBar.swift */,
+				0791A21C5814ADEF3277BAB1 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelinePlanningShelf.swift */,
+				2BA91AA8F90D4C022C4E890E /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineShelfItemCard.swift */,
+				BDD85FEB40E7B6C3538EA14A /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineInboxPlanningCard.swift */,
+				EAB5C7F1C2483D8E113DBBA7 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCurrentTimeRule.swift */,
+				1B271BB8000F7BA9D183AA5F /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCurrentTimeMarker.swift */,
+				953E5DF656076B7D7969E40B /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailLabel.swift */,
+				A061843E78EAF882FA911295 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineSpineEndView.swift */,
+				093C76FA2FAF1A80BE897904 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamPalette.swift */,
+				E3A4158C229844DD97182926 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamGlintPresentation.swift */,
+				341974EF0AE031E749EE396D /* LifeBoard/Presentation/Home/Timeline/Surface/CurvingDayStreamView.swift */,
+				EB860C7A16B4805F8EC56AF7 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineNowBeadView.swift */,
+				9F71AFCC54832F564B2D7CED /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineLongGapIndicator.swift */,
+				7694AF03A3EBC6AF9B70F6D5 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineEndAddMarker.swift */,
+				77551CB92362A8FB48666198 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineEmptyStateCard.swift */,
+				D7334CB65043757E017D7AE4 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineEmptyStateActionTone.swift */,
+				687C38FA46273E45A8A46143 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineDenseTitleFormatter.swift */,
+				F37CC3576F638C63EB2D1943 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineNormalItemCard.swift */,
+				4FAA78F353FFECD73FA8011A /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineTaskMarkerLayout.swift */,
+				B9115CDED706EB4E49B732A6 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineTaskMarkerRow.swift */,
+				9B9E9E50F4A0FB453B025B6A /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineFlockBlock.swift */,
+				5B59067D0E3C92CC8F6B5A1B /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineFlockRowView.swift */,
+				79F16587DB80654C936066F5 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineOverlapClusterCard.swift */,
+				3B5B7AA06E3FAF9CBF2A49AE /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineOverlapItemCard.swift */,
+				655BA9C40207D74248D209EE /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineTimeBlockCard.swift */,
+				B2190A6A5BA73A78CB6CE64A /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineTaskBlockRow.swift */,
+				A09AAB294BC776DE3EEF7673 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineMeetingBlockRow.swift */,
+				41F67EC4C592FE8E37C3B456 /* LifeBoard/Presentation/Home/Timeline/Surface/DailyTimelineCanvas.swift */,
+				62AFC1C2CACBCE0FD8CD0EB9 /* LifeBoard/Presentation/Home/Timeline/Surface/DailyTimelineCanvas+RailAndCanvas.swift */,
+				D42FAE002A15C49C424D0C95 /* LifeBoard/Presentation/Home/Timeline/Surface/DailyTimelineCanvas+ItemRendering.swift */,
+				0C6A23DC0DB1740CCDF6D30F /* LifeBoard/Presentation/Home/Timeline/Surface/DailyTimelineCompactView.swift */,
+				6492AC4EA233D9F3AA0FAA30 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompactAnchorRow.swift */,
+				4033ABAF3ABB94CB6771C4CC /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompactItemRow.swift */,
+				16D60461249FA816620C956F /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompactGapRow.swift */,
+				C869F0E1F0337702AD2AF780 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompactConnector.swift */,
+				BAED50033BDBC1C4321DF9AA /* LifeBoard/Presentation/Home/Timeline/Surface/DailyTimelineAgendaView.swift */,
+				C701CAA6DB1096F5F422F9AC /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineAgendaAnchorRow.swift */,
+				5F98057DD16FA2790EB04A47 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineAgendaItemRow.swift */,
+				7E2736E49AF3234FCB39F354 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStemSegments.swift */,
+				4ABE9BAD19D384E04867D9B2 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineUtilityRow.swift */,
+				F8F234318A9DB1B304DDACC7 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCapsule.swift */,
+				2E5F5580FE6F9B4D29FFAA14 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompletionRing.swift */,
+				80785BB956EE3DB3802D9858 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineGapPrompt.swift */,
+				82CED5AEF0E893280880972E /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineGapExtension.swift */,
+				C95AF729D85C65D636AF500A /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineBackdropWeekView.swift */,
+				90F01E2761C0C86CBDFA7BB9 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineWeekDayCell.swift */,
+				4D16CF764ED2CECF5A9AFDF3 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeTimeIntervalExtension.swift */,
+				1160613FFDAE3936EA841FD2 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomePerformanceSignposts.swift */,
+				425B8A685EE2C485783B0578 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeHabitSectionCardHost.swift */,
+				16B708DAB6EC819BECE9B5A8 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeCalendarEventDetailSelection.swift */,
+				7B6F00C3944DB39EBB0DDA55 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeCalendarEventDetailSheet.swift */,
+				6425309F28BBC7C61C9C58F3 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseHomeDatePickerPopover.swift */,
+				83540D1FFD9826270275D74A /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellViewRoot.swift */,
+				4D27FF67FB1DB3066CA04D50 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+DerivedState.swift */,
+				8FDA708D6EFE103BE7B725E0 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+RescueOverlays.swift */,
+				CD8641383368773B407AE249 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+HomeScreenComposition.swift */,
+				608542355F067EA88F7E716F /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+ObserversSearchAndBackdrop.swift */,
+				855AD3CAAA08B951BDD134FD /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+FacesAndSearchChat.swift */,
+				C041D826927F12B5D4A445BA /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+SearchSurface.swift */,
+				2113ED4006493C0B58760C99 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+TaskListAndDaySwipe.swift */,
+				E40C44F474B7E5FCB7349186 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+TimelineSurface.swift */,
+				E98C6DC8C0DE10D010A97DC6 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+CalendarFooterAndTrackingRail.swift */,
+				FB2B2C9DCA8513C631F384DA /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+HabitsAgendaAndFocusStrip.swift */,
+				704D674D0BE292CD679FE13E /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+FocusInsightsAndRouting.swift */,
+				CB45FAF57431067D93F59BA3 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+FocusTimersAndReflection.swift */,
+				02140BA5618285E3AC49CA18 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/CalendarCardChromeModifier.swift */,
+				B010C6D75FA3187BE754B3BF /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/InsightsActionIntentExtension.swift */,
+				4D3A6556C5C49F5516DB6ECC /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeStaggerModifier.swift */,
+				786CACDAB366EB8BCBB657A3 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeDenseSurfaceModifier.swift */,
+				525792156B7DB238F8089667 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/QuietTrackingRailStreakWidget.swift */,
+				8AA0626EE55DAF0FA5CD8995 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/OverdueRescueLauncherOverlayView.swift */,
+				C20400B4B017F188A0F00344 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDeckState.swift */,
+				2F86906A0E4C13F4F10D0C6B /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDecisionSource.swift */,
+				510B0D69D4D3766C988BF637 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDecisionAction.swift */,
+				EC4E24E658AA95B6A485F4AA /* LifeBoard/Presentation/Home/Modals/OverdueRescue/RecurrenceInstanceSnapshot.swift */,
+				D29E5D918391FC0B0AFC174A /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueUndoRecord.swift */,
+				8332C14C05A3610EB0ECA84B /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSummary.swift */,
+				44367A0F426BE6D78CC89655 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSessionScope.swift */,
+				9D1C89561D17B2073AFA6BC1 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSessionState.swift */,
+				571642516EA3BF4BB335B24A /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSessionStore.swift */,
+				032B26704AEC551E42E3A08D /* LifeBoard/Presentation/Home/Modals/OverdueRescue/UserDefaultsOverdueRescueSessionStore.swift */,
+				A3CC802FBBE9AFA39AF7CCFA /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueStateMachine.swift */,
+				F85C5DBA19B19B9611E7B283 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDeckLayoutMetrics.swift */,
+				E3B60B862E237D7380EE1948 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDeckCopy.swift */,
+				AC4E931BD28EB1FD4F7E2671 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescuePalette.swift */,
+				78AC645DDBDFE8BDCA4826F7 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueVisualSpec.swift */,
+				4BD3AB84121002B80128D5F3 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSwipeRevealKind.swift */,
+				175B3F0CAAFBA0E5E38D57EE /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDragResolution.swift */,
+				793E605571E4D4EDFCC2E4DE /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDragResolver.swift */,
+				AE79C7D2227A80F8ECDFDFD2 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueCardModel.swift */,
+				315FEE8A1F6EB8E3768FAEF0 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueMoveLaterResolver.swift */,
+				09813915E7878C1392C791D0 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueEligibilityService.swift */,
+				C58C70A0C8851CAB1139F1E7 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueViewModel.swift */,
+				C96EA41B0CDC25339F1E726E /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueViewModel+CardActions.swift */,
+				ECDCDBED7855DBFB44F46DFD /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueViewModel+SessionPersistence.swift */,
+				035ACE6073D062BB622B9CF2 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueEditDraft.swift */,
+				269A705710B0EA3EFEDCBE82 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/EvaOverdueRescueSheetV2Root.swift */,
+				CB037D639903A5E22295113F /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDeckView.swift */,
+				51A57B08A1BB4BC36FE63B9B /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueBackCards.swift */,
+				931896F94542B69EC7D8FCB7 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueTaskCard.swift */,
+				7E3E682A3285FAAED37BACB0 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueRevealPanel.swift */,
+				F63D95372962F61A5E50E9F9 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDeleteOverlay.swift */,
+				7DDAE6004CD5111C2C273E69 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSwipeHint.swift */,
+				79F6BFD855ABC89559135C56 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueActionGrid.swift */,
+				B700950871CD345DFF559A61 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueQuickEditSheet.swift */,
+				6E8131362E7A314733E26CDF /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSafeFixesView.swift */,
+				29787A3C205793132F924985 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescuePauseView.swift */,
+				583A0C544A5AEEE50CB3B870 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueCompletionView.swift */,
+				70EF7AB518C2C6E6AB41487E /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueLargeStackView.swift */,
+				2152A62EA1C5CBB8557A37E7 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueErrorView.swift */,
+				8DC33D900FB020DE25E9BA33 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueBackground.swift */,
+				B543DD59DC3D9705F73261A4 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescuePlant.swift */,
+				F830E25037454377EFF1BF94 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueCupHero.swift */,
+				4A5A3E8C899A8C9FB0694171 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueShieldHero.swift */,
+				DD7B0A79A3EE19D37B1FE1CA /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSunriseHero.swift */,
+				400A0C43B52E9F1509D5EC4C /* LifeBoard/Presentation/Home/Modals/OverdueRescue/LifeBoardProgressBar.swift */,
+				5BD755574209F1D4DACEFE20 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerRoute.swift */,
+				BF3952602FF1A9D756382492 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementTreeInteractionMode.swift */,
+				4051577E3E4D5CC85DA57B2C /* LifeBoard/Views/Settings/LifeManagement/LifeManagementViewRoot.swift */,
+				3F730ADFEFDF0357ECA49761 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementView+BrowserAndTree.swift */,
+				5F09F509547AC4BD86E3CC9A /* LifeBoard/Views/Settings/LifeManagement/LifeManagementView+DetailsComposerAndOverlays.swift */,
+				6D2BF6A90C40333A4450474A /* LifeBoard/Views/Settings/LifeManagement/LifeManagementMenuLabel.swift */,
+				43CB43D27ACFD36EEFFDD829 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementAppearanceLine.swift */,
+				D7E431C4A4980AE71FE5AB35 /* LifeBoard/Views/Settings/LifeManagement/lifeManagementHabitStatusText.swift */,
+				3F6049AC20F10CEBF79F8BAD /* LifeBoard/Views/Settings/LifeManagement/lifeManagementAreaAccentHex.swift */,
+				286C6F6CD6B150C5152666E2 /* LifeBoard/Views/Settings/LifeManagement/lifeManagementHabitCadenceLabel.swift */,
+				51840B6F63D4405BC246D786 /* LifeBoard/Views/Settings/LifeManagement/AreaListRow.swift */,
+				EED3244A5684CA3C412C1AA1 /* LifeBoard/Views/Settings/LifeManagement/AreaSummaryRow.swift */,
+				76771B9AECD05123393780BE /* LifeBoard/Views/Settings/LifeManagement/ProjectListRow.swift */,
+				AB8C1BB0D0F72004D8CD5497 /* LifeBoard/Views/Settings/LifeManagement/ProjectSummaryRow.swift */,
+				903BFF6DB72A0D515603C771 /* LifeBoard/Views/Settings/LifeManagement/HabitListRow.swift */,
+				7AE36332DC107A6F5A9A4AF2 /* LifeBoard/Views/Settings/LifeManagement/HabitSummaryRow.swift */,
+				9E17B1D7658A53B43A03A2DB /* LifeBoard/Views/Settings/LifeManagement/HabitArchiveRow.swift */,
+				C4E67C5C94F45D6D66D5E526 /* LifeBoard/Views/Settings/LifeManagement/AccentIconBadge.swift */,
+				D3343BCF778595F2114EE830 /* LifeBoard/Views/Settings/LifeManagement/InlineToneBadge.swift */,
+				AFAECD01C463CF2E65F669CB /* LifeBoard/Views/Settings/LifeManagement/LifeManagementAreaDetailView.swift */,
+				10E031C3127045DB0AF8ACF9 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementProjectDetailView.swift */,
+				382D7A14C1F519D843A2365D /* LifeBoard/Views/Settings/LifeManagement/LifeManagementAreaComposerView.swift */,
+				5C959E191431AD6350132F1D /* LifeBoard/Views/Settings/LifeManagement/LifeManagementProjectComposerView.swift */,
+				856DDB017465F5A7BA124E09 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerPreviewMetric.swift */,
+				3F73F08CE7AF7398D7835E7F /* LifeBoard/Views/Settings/LifeManagement/LifeManagementAreaPaletteOption.swift */,
+				F8B34D157D734D31C764453F /* LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerPreviewCard.swift */,
+				EED5CBC96B81618B5D5B1C6D /* LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerMetricTile.swift */,
+				7433F7F7707CF6A0DA1A58B2 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerSectionCard.swift */,
+				4D285845FE9143539A3C857A /* LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerFieldLabel.swift */,
+				FE19A169E4D9F72754B6E3E8 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerInlineMessage.swift */,
+				8824EFA2E628DF9525F13411 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementAreaSwatchPicker.swift */,
+				2FAC5C958944C25B7E561037 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementProjectColorPicker.swift */,
+				E54A7695DD06B755561CDB3D /* LifeBoard/Views/Settings/LifeManagement/LifeManagementColorSwatchButton.swift */,
+				5DEE0B3DA1576389071E8CEA /* LifeBoard/Views/Settings/LifeManagement/LifeManagementAreaIconPicker.swift */,
+				B4A711DF246A39E6B7030180 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementProjectIconPicker.swift */,
+				9E4273FD3FE15CC3F6892741 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementIconTile.swift */,
+				B6AA12D4A60EA9B1E6A316B7 /* LifeBoard/Views/Settings/LifeManagement/lifeManagementAreaPaletteOptions.swift */,
+				F0F0A3F8D6B8C5CB34F82DA0 /* LifeBoard/Views/Settings/LifeManagement/lifeManagementAreaPaletteMatch.swift */,
+				50AA42860707B829E6114218 /* LifeBoard/Views/Settings/LifeManagement/lifeManagementResolvedColor.swift */,
+				8F0354062DD8AECC3D1B17C4 /* LifeBoard/Views/Settings/LifeManagement/lifeManagementResolvedHex.swift */,
+				D07E18D71C702586CD89133E /* LifeBoard/Views/Settings/LifeManagement/lifeManagementNormalizedHex.swift */,
+				533CCDBADB8997DD528CFE0A /* LifeBoard/Views/Settings/LifeManagement/lifeManagementAreaIconLabel.swift */,
+				3C66EE511C59B0C5DAAAEA30 /* LifeBoard/Views/Settings/LifeManagement/ProjectMoveSheet.swift */,
+				BED7C8A4030249843AED943D /* LifeBoard/Views/Settings/LifeManagement/DeleteAreaSheet.swift */,
+				8565ACC6D97DD8CCE34EA3E0 /* LifeBoard/Views/Settings/LifeManagement/DeleteProjectSheet.swift */,
+				E05701BAFA3071AD793273F1 /* LifeBoard/Views/Settings/LifeManagement/StringExtension.swift */,
+				EC5308F1488478AD34963168 /* LifeBoard/LLM/Views/Chat/Conversation/ChatTimeIntervalExtension.swift */,
+				38AE057025E85DF89448752B /* LifeBoard/LLM/Views/Chat/Conversation/TypingIndicator.swift */,
+				EE0E5A5DE6FF2E8EEACA4280 /* LifeBoard/LLM/Views/Chat/Conversation/EvaWorkingStatusLibrary.swift */,
+				BDED467BEDE45453B0C91BEF /* LifeBoard/LLM/Views/Chat/Conversation/EvaLiveWorkingStatusView.swift */,
+				34C247867FBCFF10E376C692 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayTaskOverlayState.swift */,
+				D5669D5D0E7B125A137EBF66 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitOverlayState.swift */,
+				C81997132A898566B3451D49 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayStatusChipsView.swift */,
+				0B33EB5C978F76DF3A6A735C /* LifeBoard/LLM/Views/Chat/Conversation/EvaDaySunriseTaskRowView.swift */,
+				6E411E9CDB93D4BE9EDC7EF0 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitRowView.swift */,
+				B72A4F99B2064E4A639A6264 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayTaskHeaderView.swift */,
+				41FF5D1F1BC2347D454A7768 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayTaskMetadataView.swift */,
+				D934D251750D7055D55AD060 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayTaskActionsView.swift */,
+				3528CDE2C353B77B8CC4EB35 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayTaskActionButtonView.swift */,
+				081764019CFE89EAC4FE6BBD /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitHeaderView.swift */,
+				EE2C41DCBFDB00CEEAF73CC0 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitMetadataView.swift */,
+				56A37591A5FBC6DAD9309A0E /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitActionsView.swift */,
+				97D15C36A06B1399EAC04C8A /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitActionButtonView.swift */,
+				E97E787881F510FC540EC5B8 /* LifeBoard/LLM/Views/Chat/Conversation/MessageView.swift */,
+				E508CD28D9365DD6B35FE330 /* LifeBoard/LLM/Views/Chat/Conversation/MessageView+AssistantAndUserBubble.swift */,
+				80EEB0762BB49B5983079AF3 /* LifeBoard/LLM/Views/Chat/Conversation/MessageView+EvaProposalAndDayOverview.swift */,
+				059D7229E32477D1B282E2A2 /* LifeBoard/LLM/Views/Chat/Conversation/MessageView+DayOverviewAndProposalActions.swift */,
+				69B7C1A4EF10964C5EF4DC33 /* LifeBoard/LLM/Views/Chat/Conversation/MessageView+CommandResultsAndUndo.swift */,
+				045B754842BE69FA3CC11368 /* LifeBoard/LLM/Views/Chat/Conversation/ConversationViewRoot.swift */,
+				6243658CCD3FA73A97B58600 /* LifeBoard/LLM/Views/Chat/Conversation/ConversationView+LiveOutput.swift */,
+				9929F28DF1EA53ABDB5CEE2B /* LifeBoard/LLM/Views/Chat/Chrome/EvaChatNavigationChromeState.swift */,
+				6406FAAF5EBC202BFD7F2588 /* LifeBoard/LLM/Views/Chat/Chrome/EvaChatSunriseGlass.swift */,
+				C2D47EF8C1159050CDCE28D6 /* LifeBoard/LLM/Views/Chat/Chrome/EvaChatSunriseBackground.swift */,
+				35FFAEB5937CA521A5C5C4DC /* LifeBoard/LLM/Views/Chat/Chrome/ChatHeaderView.swift */,
+				509DC1C9038663BEFE00C96F /* LifeBoard/LLM/Views/Chat/Chrome/ChatEmptyStateView.swift */,
+				EFD0A8DA9F2060C50BF6DA52 /* LifeBoard/LLM/Views/Chat/Chrome/EvaChiefOfStaffGuideSection.swift */,
+				384185D0DBC900F3E3B48AF3 /* LifeBoard/LLM/Views/Chat/Chrome/EvaHomePromptChip.swift */,
+				42885152818D9953B13C071B /* LifeBoard/LLM/Views/Chat/Chrome/EvaChiefOfStaffGuideContent.swift */,
+				BC8C39098BF0A10AE6CC5EE3 /* LifeBoard/LLM/Views/Chat/Chrome/EvaChiefOfStaffGuideView.swift */,
+				25FBF99ED821FFD0AF0826C2 /* LifeBoard/LLM/Views/Chat/Chrome/FlowPromptChipsView.swift */,
+				9F5B152C46928DBD19C7ABC5 /* LifeBoard/LLM/Views/Chat/Chrome/ChatComposerView.swift */,
+				C7A6D85F245E9F672238D9E0 /* LifeBoard/LLM/Views/Chat/Chrome/ChatComposerView+StructuredComposer.swift */,
+				DEE50736401EDD2F9A73FC90 /* LifeBoard/LLM/Views/Chat/Chrome/ChatStorageDegradedBanner.swift */,
+				B36F56E947D18C0D1D111E0C /* LifeBoard/LLM/Views/Chat/Chrome/ChatScaffoldView.swift */,
+				D974CDFA2F5A901967B485D2 /* LifeBoard/LLM/Views/Chat/Chrome/ChatScaffoldView+NavigationChrome.swift */,
 			);
 			name = "Recovered References";
 			sourceTree = "<group>";
@@ -3082,8 +3555,8 @@
 				2A7397B50382FF7FB4FAEC5F /* SunriseTaskSectionView.swift */,
 				E526F0CB3E9299C87861646E /* SunriseTaskListView.swift */,
 				F0A1B2C3D4E5F60718293A4C /* HomeTaskSectionBuilder.swift */,
-				B2E100000000000000000104 /* HomeHabitRowView.swift */,
-				C1B100000000000000000105 /* HabitBoardViews.swift */,
+				B2E100000000000000000104 /* LifeBoard/View/HomeHabitRowView.swift */,
+				C1B100000000000000000105 /* LifeBoard/View/HabitBoardViews.swift */,
 				594ECD331C0135DA36357314 /* SunriseAdvancedFilterSheetView.swift */,
 				A10000000000000000000001 /* QuickViewSelector.swift */,
 				A10000000000000000000002 /* NavPieChart.swift */,
@@ -3099,7 +3572,7 @@
 				D1A100000000000000000008 /* HomeMomentumProgressBar.swift */,
 				B1A000000000000000000018 /* FocusCardFlipView.swift */,
 				B1A000000000000000000016 /* SunriseEvaSheets.swift */,
-				17DC0A5BC84D9C6C792B2AB6 /* HomeXPHeroView.swift */,
+				17DC0A5BC84D9C6C792B2AB6 /* LifeBoard/View/HomeXPHeroView.swift */,
 				D4F10000000000000000010B /* HomeWeeklySummaryCard.swift */,
 				BF5D7161411B42651DF00D60 /* SunriseAppShellView.swift */,
 				7551F0000000000000000011 /* SunriseDecorAsset.swift */,
@@ -3110,8 +3583,8 @@
 				A11D5A110000000000000002 /* SunriseDaySwipeData.swift */,
 				A11D5A110000000000000003 /* SunriseDaySwipeWaveShape.swift */,
 				A11D5A110000000000000004 /* SunriseDaySwipeOverlay.swift */,
-				D4F400000000000000000202 /* SunriseTimelineSurface.swift */,
-				D2A100000000000000000003 /* SunriseQuietTrackingComposerView.swift */,
+				D4F400000000000000000202 /* LifeBoard/View/SunriseTimelineSurface.swift */,
+				D2A100000000000000000003 /* LifeBoard/View/SunriseQuietTrackingComposerView.swift */,
 				F2A1B2C3D4E5F60718293A50 /* HomeBottomBarItem.swift */,
 				F2A1B2C3D4E5F60718293A51 /* HomeBottomBarState.swift */,
 				AB12CD34EF5607891234ABCD /* CoverFlipTransition.swift */,
@@ -3152,14 +3625,14 @@
 				95932952BC5EBADE8D30791C /* AddTaskTagMultiSelect.swift */,
 				2D01967BDAF0ABB45A855C29 /* AddTaskTaskPicker.swift */,
 				D7C5BD9B9BA76D61F7F044BD /* LifeBoardSnackbar.swift */,
-				B3A1F2C4D5E6F709 /* BadgeGalleryView.swift */,
-				B3A1F2C4D5E6F70A /* LevelUpCelebrationView.swift */,
-				B3A1F2C4D5E6F70B /* MilestoneCelebrationView.swift */,
-				B3A1F2C4D5E6F70C /* BadgeDetailSheet.swift */,
-				B8E100022F70000100A0A001 /* LifeBoardCTABezel.metal */,
-				37E2466DBE2A76A73458F530 /* SunriseFocusTimerView.swift */,
-				6D63FBA200D736491232884A /* SunriseFocusSessionSummaryView.swift */,
-				E2BA3F253548BE9F1EE2AB4B /* SunriseDailyReflectionView.swift */,
+				B3A1F2C4D5E6F709 /* LifeBoard/View/BadgeGalleryView.swift */,
+				B3A1F2C4D5E6F70A /* LifeBoard/View/LevelUpCelebrationView.swift */,
+				B3A1F2C4D5E6F70B /* LifeBoard/View/MilestoneCelebrationView.swift */,
+				B3A1F2C4D5E6F70C /* LifeBoard/View/BadgeDetailSheet.swift */,
+				B8E100022F70000100A0A001 /* Effects/LifeBoardCTABezel.metal */,
+				37E2466DBE2A76A73458F530 /* LifeBoard/View/SunriseFocusTimerView.swift */,
+				6D63FBA200D736491232884A /* LifeBoard/View/SunriseFocusSessionSummaryView.swift */,
+				E2BA3F253548BE9F1EE2AB4B /* LifeBoard/View/SunriseDailyReflectionView.swift */,
 				D5A100000000000000000001 /* ReflectPlanStyle.swift */,
 				D5A100000000000000000002 /* SunriseReflectPlanScreen.swift */,
 				D5A100000000000000000003 /* ReflectPlanHeader.swift */,
@@ -3277,10 +3750,10 @@
 		75DFF2CF2DF22F8B00EB8850 /* Services */ = {
 			isa = PBXGroup;
 			children = (
-				34CC91CCAA408A3ADB2D8693 /* V2FeatureFlags.swift */,
-				53C94956D526284966A1EEDC /* LocalNotificationService.swift */,
-				7F1B2C3D4E5F60718293A4B6 /* GamificationRemoteKillSwitchService.swift */,
-				7F1B2C3D4E5F60718293A4B8 /* LiquidMetalCTARemoteConfigService.swift */,
+				34CC91CCAA408A3ADB2D8693 /* LifeBoard/Services/V2FeatureFlags.swift */,
+				53C94956D526284966A1EEDC /* LifeBoard/Services/LocalNotificationService.swift */,
+				7F1B2C3D4E5F60718293A4B6 /* LifeBoard/Services/GamificationRemoteKillSwitchService.swift */,
+				7F1B2C3D4E5F60718293A4B8 /* LifeBoard/Services/LiquidMetalCTARemoteConfigService.swift */,
 				7B2B9CCE514C217DC9C76773 /* WatchWidgetSnapshotSync.swift */,
 			);
 			path = Services;
@@ -3328,20 +3801,20 @@
 				75D8274B2E8C8995000F04E1 /* UserRepositoryProtocol.swift */,
 				750894C92E8D3C390037FACE /* AnalyticsRepositoryProtocol.swift */,
 				55C5A46909EF46C27D7B84E3 /* SavedHomeViewRepositoryProtocol.swift */,
-				42AD2BFC988A80E8157AD2B2 /* V2RepositoryProtocols.swift */,
-				C1A100000000000000000001 /* HabitRuntimeReadRepositoryProtocol.swift */,
-				71FDD1869D0A6C117882AD37 /* SchedulingEngineProtocol.swift */,
-				107822EF572057FAE8E0EF37 /* LifeAreaRepositoryProtocol.swift */,
-				E46838AD356183D58300A941 /* SectionRepositoryProtocol.swift */,
-				D69B4ECB89C44E275D829577 /* TagRepositoryProtocol.swift */,
-				EA45AF6FFE4463E49D8FEA68 /* TaskDefinitionRepositoryProtocol.swift */,
-				FEC0DEA9E6D02E2F991F11A1 /* HabitRepositoryProtocol.swift */,
-				712BE2C322E8930A4886933B /* ScheduleRepositoryProtocol.swift */,
-				74615C475C9EB3F67E96D7FE /* OccurrenceRepositoryProtocol.swift */,
-				8D0FFCDBD5039DB8EE185B5E /* ReminderRepositoryProtocol.swift */,
-				220815DD3BB32A14C051A1BF /* GamificationRepositoryProtocol.swift */,
-				432D634291596A7CBBCFA76B /* AssistantActionRepositoryProtocol.swift */,
-				A1E5C40F2F1A4B9D9C1E8A12 /* AppleRemindersProviderProtocol.swift */,
+				42AD2BFC988A80E8157AD2B2 /* LifeBoard/Domain/Interfaces/V2RepositoryProtocols.swift */,
+				C1A100000000000000000001 /* LifeBoard/Domain/Interfaces/HabitRuntimeReadRepositoryProtocol.swift */,
+				71FDD1869D0A6C117882AD37 /* LifeBoard/Domain/Interfaces/SchedulingEngineProtocol.swift */,
+				107822EF572057FAE8E0EF37 /* LifeBoard/Domain/Interfaces/LifeAreaRepositoryProtocol.swift */,
+				E46838AD356183D58300A941 /* LifeBoard/Domain/Interfaces/SectionRepositoryProtocol.swift */,
+				D69B4ECB89C44E275D829577 /* LifeBoard/Domain/Interfaces/TagRepositoryProtocol.swift */,
+				EA45AF6FFE4463E49D8FEA68 /* LifeBoard/Domain/Interfaces/TaskDefinitionRepositoryProtocol.swift */,
+				FEC0DEA9E6D02E2F991F11A1 /* LifeBoard/Domain/Interfaces/HabitRepositoryProtocol.swift */,
+				712BE2C322E8930A4886933B /* LifeBoard/Domain/Interfaces/ScheduleRepositoryProtocol.swift */,
+				74615C475C9EB3F67E96D7FE /* LifeBoard/Domain/Interfaces/OccurrenceRepositoryProtocol.swift */,
+				8D0FFCDBD5039DB8EE185B5E /* LifeBoard/Domain/Interfaces/ReminderRepositoryProtocol.swift */,
+				220815DD3BB32A14C051A1BF /* LifeBoard/Domain/Interfaces/GamificationRepositoryProtocol.swift */,
+				432D634291596A7CBBCFA76B /* LifeBoard/Domain/Interfaces/AssistantActionRepositoryProtocol.swift */,
+				A1E5C40F2F1A4B9D9C1E8A12 /* LifeBoard/Domain/Interfaces/AppleRemindersProviderProtocol.swift */,
 				C4C3F70CE989FCF07417B5EE /* TaskReadModelRepositoryProtocol.swift */,
 			);
 			path = Interfaces;
@@ -3351,12 +3824,12 @@
 			isa = PBXGroup;
 			children = (
 				75E929A52E8C686300207270 /* ProjectMapper.swift */,
-				ECB224DA34C6529E86C73875 /* LifeAreaMapper.swift */,
-				6956BC00E9F0B0BC847DD7AA /* SectionMapper.swift */,
-				D32B0321DD6413CCDC888416 /* TagMapper.swift */,
-				592346DCA3C3FE56E12617C2 /* TaskDefinitionMapper.swift */,
-				F22284F558A304A7D18F56C1 /* HabitDefinitionMapper.swift */,
-				CD059BC932A17FD845CAC6CD /* TombstoneMapper.swift */,
+				ECB224DA34C6529E86C73875 /* LifeBoard/Domain/Mappers/LifeAreaMapper.swift */,
+				6956BC00E9F0B0BC847DD7AA /* LifeBoard/Domain/Mappers/SectionMapper.swift */,
+				D32B0321DD6413CCDC888416 /* LifeBoard/Domain/Mappers/TagMapper.swift */,
+				592346DCA3C3FE56E12617C2 /* LifeBoard/Domain/Mappers/TaskDefinitionMapper.swift */,
+				F22284F558A304A7D18F56C1 /* LifeBoard/Domain/Mappers/HabitDefinitionMapper.swift */,
+				CD059BC932A17FD845CAC6CD /* LifeBoard/Domain/Mappers/TombstoneMapper.swift */,
 			);
 			path = Mappers;
 			sourceTree = "<group>";
@@ -3381,28 +3854,28 @@
 				2E753995C5FB25BE948BE1E9 /* HomeFilterState.swift */,
 				7F7676A13058C4757D1E2718 /* SavedHomeView.swift */,
 				3D233F155B6A87F62F52F845 /* HomeQuickFilterSummary.swift */,
-				34288F9F2CB1DADA41F1673D /* LifeArea.swift */,
-				0D70DF5D3C4DE407EF935B48 /* Section.swift */,
-				C2C66FE334854F296A4203FD /* TagDefinition.swift */,
-				C1A100000000000000000002 /* HabitTypes.swift */,
-				6A30108580052CC2C67D2058 /* HabitDefinition.swift */,
-				D5A9A2796943621DC66C4703 /* Tombstone.swift */,
-				FAF2AECE194CB6DF20940C57 /* ScheduleTemplate.swift */,
-				208608AB50F4EA01C74D2758 /* Occurrence.swift */,
-				E4F394C64907F22C89881E3A /* ReminderDefinition.swift */,
-				A9ADCB5DB568A54708322C8E /* GamificationProfile.swift */,
-				945E754344BF05CE3FA97D8E /* XPEnums.swift */,
-				C4AF3952DBA8C2ACE185FEF0 /* DailyXPAggregateDefinition.swift */,
-				AD2798DFE7058AA45DECE737 /* FocusSessionDefinition.swift */,
-				D115AC1607F718EC014575BE /* XPCalculationEngine.swift */,
-				A4C2E9F12B7D4C5581AA0003 /* HomeTaskMutationPayload.swift */,
-				85F3DEB89B5BEB05F1972CA7 /* XPEvent.swift */,
-				7C900006EE1DF0BACD33342B /* Achievement.swift */,
-				E78CA56E2EAD1B448EFED377 /* AssistantAction.swift */,
-				3CAA3A6573B0FE5C495C67AC /* ExternalSyncModels.swift */,
+				34288F9F2CB1DADA41F1673D /* LifeBoard/Domain/Models/LifeArea.swift */,
+				0D70DF5D3C4DE407EF935B48 /* LifeBoard/Domain/Models/Section.swift */,
+				C2C66FE334854F296A4203FD /* LifeBoard/Domain/Models/TagDefinition.swift */,
+				C1A100000000000000000002 /* LifeBoard/Domain/Models/HabitTypes.swift */,
+				6A30108580052CC2C67D2058 /* LifeBoard/Domain/Models/HabitDefinition.swift */,
+				D5A9A2796943621DC66C4703 /* LifeBoard/Domain/Models/Tombstone.swift */,
+				FAF2AECE194CB6DF20940C57 /* LifeBoard/Domain/Models/ScheduleTemplate.swift */,
+				208608AB50F4EA01C74D2758 /* LifeBoard/Domain/Models/Occurrence.swift */,
+				E4F394C64907F22C89881E3A /* LifeBoard/Domain/Models/ReminderDefinition.swift */,
+				A9ADCB5DB568A54708322C8E /* LifeBoard/Domain/Models/GamificationProfile.swift */,
+				945E754344BF05CE3FA97D8E /* LifeBoard/Domain/Models/XPEnums.swift */,
+				C4AF3952DBA8C2ACE185FEF0 /* LifeBoard/Domain/Models/DailyXPAggregateDefinition.swift */,
+				AD2798DFE7058AA45DECE737 /* LifeBoard/Domain/Models/FocusSessionDefinition.swift */,
+				D115AC1607F718EC014575BE /* LifeBoard/Domain/Models/XPCalculationEngine.swift */,
+				A4C2E9F12B7D4C5581AA0003 /* LifeBoard/Domain/Models/HomeTaskMutationPayload.swift */,
+				85F3DEB89B5BEB05F1972CA7 /* LifeBoard/Domain/Models/XPEvent.swift */,
+				7C900006EE1DF0BACD33342B /* LifeBoard/Domain/Models/Achievement.swift */,
+				E78CA56E2EAD1B448EFED377 /* LifeBoard/Domain/Models/AssistantAction.swift */,
+				3CAA3A6573B0FE5C495C67AC /* LifeBoard/Domain/Models/ExternalSyncModels.swift */,
 				65A7A039AC9CA38845D1E44F /* SyncMergeState.swift */,
 				2856D1EE26429146B60B6633 /* TaskReadQueries.swift */,
-				B3A1F2C4D5E6F708 /* AchievementCatalog.swift */,
+				B3A1F2C4D5E6F708 /* LifeBoard/Domain/Models/AchievementCatalog.swift */,
 				D4F100000000000000000102 /* WeeklyPlan.swift */,
 				D4F100000000000000000103 /* WeeklyOutcome.swift */,
 				D4F100000000000000000104 /* WeeklyReview.swift */,
@@ -3473,11 +3946,11 @@
 				75E92A052E8C82BD00207270 /* GetTasksUseCase.swift */,
 				75E92A082E8C82BD00207270 /* SortTasksUseCase.swift */,
 				9AF308251FE7FA9FEE55702D /* GetHomeFilteredTasksUseCase.swift */,
-				AC4ABAA08D90818447AA6D03 /* CreateTaskDefinitionUseCase.swift */,
-				1265EFBF270FC894A5FCA278 /* CompleteTaskDefinitionUseCase.swift */,
-				E1C5A4B1D2E3F4012345678C /* UpdateTaskDefinitionUseCase.swift */,
-				E1C5A4B1D2E3F4012345678D /* DeleteTaskDefinitionUseCase.swift */,
-				E1C5A4B1D2E3F4012345678E /* RescheduleTaskDefinitionUseCase.swift */,
+				AC4ABAA08D90818447AA6D03 /* LifeBoard/UseCases/Task/CreateTaskDefinitionUseCase.swift */,
+				1265EFBF270FC894A5FCA278 /* LifeBoard/UseCases/Task/CompleteTaskDefinitionUseCase.swift */,
+				E1C5A4B1D2E3F4012345678C /* LifeBoard/UseCases/Task/UpdateTaskDefinitionUseCase.swift */,
+				E1C5A4B1D2E3F4012345678D /* LifeBoard/UseCases/Task/DeleteTaskDefinitionUseCase.swift */,
+				E1C5A4B1D2E3F4012345678E /* LifeBoard/UseCases/Task/RescheduleTaskDefinitionUseCase.swift */,
 			);
 			path = Task;
 			sourceTree = "<group>";
@@ -3493,9 +3966,9 @@
 				2431DF37906098E0829C80B7 /* Section */,
 				529D23B7A8E56B55B3A03C07 /* Tag */,
 				1E4BB5010CAE2AAB6D697F15 /* Habit */,
-				B2E100000000000000000103 /* BuildHomeAgendaUseCase.swift */,
-				B2E10000000000000000010B /* BuildNeedsReplanCandidatesUseCase.swift */,
-				B2E10000000000000000010C /* HomeTimelineProjectionBuilder.swift */,
+				B2E100000000000000000103 /* LifeBoard/UseCases/Home/BuildHomeAgendaUseCase.swift */,
+				B2E10000000000000000010B /* LifeBoard/UseCases/Home/BuildNeedsReplanCandidatesUseCase.swift */,
+				B2E10000000000000000010C /* LifeBoard/UseCases/Home/HomeTimelineProjectionBuilder.swift */,
 				4D9CF163F23980743B576923 /* Schedule */,
 				2E192B5E7D0C3D8FEE45ED41 /* Reminder */,
 				0F156103AF2D844C6B6EE11B /* Gamification */,
@@ -3542,7 +4015,7 @@
 				75F89FB72DFC83EF009EDD8F /* PromptMiddleware.swift */,
 				7529F6F22DFDE9BC000CBE36 /* LLMDataController.swift */,
 				7529F7A92F5D0001000CBE36 /* LLMDebugSmokeRunner.swift */,
-				88EAC5F41DAFB21D34E6790E /* LLMContextProjectionService.swift */,
+				88EAC5F41DAFB21D34E6790E /* LifeBoard/LLM/Models/LLMContextProjectionService.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -3628,7 +4101,7 @@
 		8C250E00E309DD182368FE08 /* Sync */ = {
 			isa = PBXGroup;
 			children = (
-				B9F2A10C3D4E5F60718293AA /* WriteClosedRepositoryAdapters.swift */,
+				B9F2A10C3D4E5F60718293AA /* LifeBoard/State/Sync/WriteClosedRepositoryAdapters.swift */,
 			);
 			name = Sync;
 			sourceTree = "<group>";
@@ -3652,7 +4125,7 @@
 		A4E8C9D32F9A4C3600A1B2C3 /* Integrity */ = {
 			isa = PBXGroup;
 			children = (
-				A4E8C9D22F9A4C3600A1B2C3 /* LifeAreaIdentityRepair.swift */,
+				A4E8C9D22F9A4C3600A1B2C3 /* LifeBoard/State/Integrity/LifeAreaIdentityRepair.swift */,
 			);
 			name = Integrity;
 			path = State/Integrity;
@@ -3676,7 +4149,7 @@
 		AAB000000000000000000006 /* RenderState */ = {
 			isa = PBXGroup;
 			children = (
-				AAB000000000000000000001 /* HomeRenderState.swift */,
+				AAB000000000000000000001 /* LifeBoard/Presentation/Home/RenderState/HomeRenderState.swift */,
 			);
 			path = RenderState;
 			sourceTree = "<group>";
@@ -3684,7 +4157,7 @@
 		AAB000000000000000000007 /* Stores */ = {
 			isa = PBXGroup;
 			children = (
-				AAB000000000000000000003 /* HomeStores.swift */,
+				AAB000000000000000000003 /* LifeBoard/Presentation/Home/Stores/HomeStores.swift */,
 			);
 			path = Stores;
 			sourceTree = "<group>";
@@ -3692,10 +4165,10 @@
 		AAB00000000000000000000A /* Shell */ = {
 			isa = PBXGroup;
 			children = (
-				AAB000000000000000000008 /* HomeShellTypes.swift */,
-				AAB00000000000000000002C /* HomeSunriseLayoutSupport.swift */,
-				AAB00000000000000000002E /* HomeDaySwipeResolver.swift */,
-				AAB000000000000000000025 /* HomeiPadShell.swift */,
+				AAB000000000000000000008 /* LifeBoard/Presentation/Home/Shell/HomeShellTypes.swift */,
+				AAB00000000000000000002C /* LifeBoard/Presentation/Home/Shell/HomeSunriseLayoutSupport.swift */,
+				AAB00000000000000000002E /* LifeBoard/Presentation/Home/Shell/HomeDaySwipeResolver.swift */,
+				AAB000000000000000000025 /* LifeBoard/Presentation/Home/Shell/HomeiPadShell.swift */,
 				26EAC60DD5866D607F966D0E /* HomeSunriseFace.swift */,
 			);
 			path = Shell;
@@ -3704,11 +4177,11 @@
 		AAB00000000000000000000B /* Modals */ = {
 			isa = PBXGroup;
 			children = (
-				AAB00000000000000000000C /* OnboardingTaskDetailDismissBridge.swift */,
-				AAB00000000000000000000E /* RescheduleViewController.swift */,
-				AAB000000000000000000010 /* HomeDailySummaryModalView.swift */,
-				AAB000000000000000000012 /* SunriseRecurringTaskDeleteConfirmationView.swift */,
-				AAB000000000000000000023 /* EvaOverdueRescueSheetV2.swift */,
+				AAB00000000000000000000C /* LifeBoard/Presentation/Home/Modals/OnboardingTaskDetailDismissBridge.swift */,
+				AAB00000000000000000000E /* LifeBoard/Presentation/Home/Modals/RescheduleViewController.swift */,
+				AAB000000000000000000010 /* LifeBoard/Presentation/Home/Modals/HomeDailySummaryModalView.swift */,
+				AAB000000000000000000012 /* LifeBoard/Presentation/Home/Modals/SunriseRecurringTaskDeleteConfirmationView.swift */,
+				AAB000000000000000000023 /* LifeBoard/Presentation/Home/Modals/EvaOverdueRescueSheetV2.swift */,
 			);
 			path = Modals;
 			sourceTree = "<group>";
@@ -3716,7 +4189,7 @@
 		AAB000000000000000000016 /* TestingSupport */ = {
 			isa = PBXGroup;
 			children = (
-				AAB000000000000000000014 /* HomeUITestWorkspaceSeeder.swift */,
+				AAB000000000000000000014 /* LifeBoard/TestingSupport/HomeUITestWorkspaceSeeder.swift */,
 			);
 			path = TestingSupport;
 			sourceTree = "<group>";
@@ -3724,10 +4197,10 @@
 		AAB000000000000000000017 /* Replan */ = {
 			isa = PBXGroup;
 			children = (
-				AAB000000000000000000018 /* NeedsReplanTrayView.swift */,
-				AAB00000000000000000001A /* NeedsReplanLauncherSheet.swift */,
-				AAB00000000000000000001C /* NeedsReplanCardOverlay.swift */,
-				AAB00000000000000000001E /* NeedsReplanSummaryOverlay.swift */,
+				AAB000000000000000000018 /* LifeBoard/Presentation/Home/Replan/NeedsReplanTrayView.swift */,
+				AAB00000000000000000001A /* LifeBoard/Presentation/Home/Replan/NeedsReplanLauncherSheet.swift */,
+				AAB00000000000000000001C /* LifeBoard/Presentation/Home/Replan/NeedsReplanCardOverlay.swift */,
+				AAB00000000000000000001E /* LifeBoard/Presentation/Home/Replan/NeedsReplanSummaryOverlay.swift */,
 			);
 			path = Replan;
 			sourceTree = "<group>";
@@ -3735,7 +4208,7 @@
 		AAB000000000000000000022 /* Widgets */ = {
 			isa = PBXGroup;
 			children = (
-				AAB000000000000000000020 /* HomePrimaryWidgetRail.swift */,
+				AAB000000000000000000020 /* LifeBoard/Presentation/Home/Widgets/HomePrimaryWidgetRail.swift */,
 			);
 			path = Widgets;
 			sourceTree = "<group>";
@@ -3743,8 +4216,8 @@
 		AAB000000000000000000027 /* Timeline */ = {
 			isa = PBXGroup;
 			children = (
-				AAB00000000000000000002A /* HomeTimelineColumnLayout.swift */,
-				AAB000000000000000000028 /* HomeTimelineSnapshotRenderCache.swift */,
+				AAB00000000000000000002A /* LifeBoard/Presentation/Home/Timeline/HomeTimelineColumnLayout.swift */,
+				AAB000000000000000000028 /* LifeBoard/Presentation/Home/Timeline/HomeTimelineSnapshotRenderCache.swift */,
 				1144C788F612CB7B2BB7458B /* TimelinePreferenceKeys.swift */,
 				60A322E21AF97D46F076D5C8 /* TimelineTimeBlock.swift */,
 				A25F3E0B9D00FA850EE9E8A9 /* TimelinePhoneRenderModel.swift */,
@@ -3756,7 +4229,7 @@
 		AAB000000000000000000032 /* Search */ = {
 			isa = PBXGroup;
 			children = (
-				AAB000000000000000000030 /* HomeSearchState.swift */,
+				AAB000000000000000000030 /* LifeBoard/Presentation/Home/Search/HomeSearchState.swift */,
 			);
 			path = Search;
 			sourceTree = "<group>";
@@ -3765,6 +4238,7 @@
 			isa = PBXGroup;
 			children = (
 				B4D7E8213A4F5C6D7E8F9011 /* V3TestHarness.swift */,
+				B4D7E8213A4F5C6D7E8F9015 /* SharedColorTestHelpers.swift */,
 			);
 			path = TestSupport;
 			sourceTree = "<group>";
@@ -3773,7 +4247,7 @@
 			isa = PBXGroup;
 			children = (
 				017ECAA6FA89C9A7825A3E8A /* EnhancedDependencyContainer.swift */,
-				A1D100042F90000100AA2001 /* LifeBoardPersistentStoreBootstrapService.swift */,
+				A1D100042F90000100AA2001 /* LifeBoard/State/DI/LifeBoardPersistentStoreBootstrapService.swift */,
 			);
 			name = DI;
 			sourceTree = "<group>";
@@ -3796,9 +4270,9 @@
 		CF470A08F638B7A4505F5DD1 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
-				79E40B0ED12A11ACC6A161C8 /* AppGroupConstants.swift */,
-				A1D100032F90000100AA2001 /* ShortcutHandoffStore.swift */,
-				21637D8476DC186EA285FB33 /* WidgetSnapshot.swift */,
+				79E40B0ED12A11ACC6A161C8 /* Shared/AppGroupConstants.swift */,
+				A1D100032F90000100AA2001 /* Shared/ShortcutHandoffStore.swift */,
+				21637D8476DC186EA285FB33 /* Shared/WidgetSnapshot.swift */,
 			);
 			name = Shared;
 			sourceTree = "<group>";
@@ -3806,7 +4280,7 @@
 		D4F300000000000000000101 /* Weekly */ = {
 			isa = PBXGroup;
 			children = (
-				D4F100000000000000000108 /* WeeklyOperatingUseCases.swift */,
+				D4F100000000000000000108 /* LifeBoard/UseCases/Weekly/WeeklyOperatingUseCases.swift */,
 			);
 			path = Weekly;
 			sourceTree = "<group>";
@@ -3894,22 +4368,22 @@
 			children = (
 				8AD631E2A2245F830BA92FA5 /* CoreDataProjectRepository.swift */,
 				A365503F0A1EC71D5D159FC0 /* UserDefaultsSavedHomeViewRepository.swift */,
-				836DC307393EA1752081FFEE /* V2CoreDataRepositorySupport.swift */,
-				26D9ECAA7CAE990AACBF05E5 /* CoreDataLifeAreaRepository.swift */,
-				F0E3799E6AD3B71C2BCAA18D /* CoreDataSectionRepository.swift */,
-				9FD8DED9951762C1A0ACCBDD /* CoreDataTagRepository.swift */,
-				F4687654CCFC97DCFDA3E695 /* CoreDataTaskDefinitionRepository.swift */,
-				44CFBD9F581CA1A255A49A85 /* CoreDataHabitRepository.swift */,
-				C1A100000000000000000004 /* CoreDataHabitRuntimeReadRepository.swift */,
-				D6248E090BE231D70E41F08C /* CoreDataScheduleRepository.swift */,
-				A9E54F6F587FF89056E429DF /* CoreDataOccurrenceRepository.swift */,
-				10EE348FF84C5F729A416848 /* CoreDataReminderRepository.swift */,
-				1134D09887CAA3CD8F14E808 /* CoreDataGamificationRepository.swift */,
-				E6747A1FAF23571C7A3DA320 /* CoreDataAssistantActionRepository.swift */,
-				08CEBA82D3CB1ACE79D0E158 /* CoreDataExternalSyncRepository.swift */,
-				23A78189DAF93E5F5EA0C769 /* CoreDataTombstoneRepository.swift */,
-				A95FD785F6B6001D9106C2B8 /* CoreDataTaskReadModelRepository.swift */,
-				D4F100000000000000000107 /* CoreDataWeeklyRepositories.swift */,
+				836DC307393EA1752081FFEE /* LifeBoard/State/Repositories/V2CoreDataRepositorySupport.swift */,
+				26D9ECAA7CAE990AACBF05E5 /* LifeBoard/State/Repositories/CoreDataLifeAreaRepository.swift */,
+				F0E3799E6AD3B71C2BCAA18D /* LifeBoard/State/Repositories/CoreDataSectionRepository.swift */,
+				9FD8DED9951762C1A0ACCBDD /* LifeBoard/State/Repositories/CoreDataTagRepository.swift */,
+				F4687654CCFC97DCFDA3E695 /* LifeBoard/State/Repositories/CoreDataTaskDefinitionRepository.swift */,
+				44CFBD9F581CA1A255A49A85 /* LifeBoard/State/Repositories/CoreDataHabitRepository.swift */,
+				C1A100000000000000000004 /* LifeBoard/State/Repositories/CoreDataHabitRuntimeReadRepository.swift */,
+				D6248E090BE231D70E41F08C /* LifeBoard/State/Repositories/CoreDataScheduleRepository.swift */,
+				A9E54F6F587FF89056E429DF /* LifeBoard/State/Repositories/CoreDataOccurrenceRepository.swift */,
+				10EE348FF84C5F729A416848 /* LifeBoard/State/Repositories/CoreDataReminderRepository.swift */,
+				1134D09887CAA3CD8F14E808 /* LifeBoard/State/Repositories/CoreDataGamificationRepository.swift */,
+				E6747A1FAF23571C7A3DA320 /* LifeBoard/State/Repositories/CoreDataAssistantActionRepository.swift */,
+				08CEBA82D3CB1ACE79D0E158 /* LifeBoard/State/Repositories/CoreDataExternalSyncRepository.swift */,
+				23A78189DAF93E5F5EA0C769 /* LifeBoard/State/Repositories/CoreDataTombstoneRepository.swift */,
+				A95FD785F6B6001D9106C2B8 /* LifeBoard/State/Repositories/CoreDataTaskReadModelRepository.swift */,
+				D4F100000000000000000107 /* LifeBoard/State/Repositories/CoreDataWeeklyRepositories.swift */,
 			);
 			name = Repositories;
 			sourceTree = "<group>";
@@ -4212,9 +4686,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-LifeBoard-LifeBoardUITests/Pods-LifeBoard-LifeBoardUITests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-LifeBoard-LifeBoardUITests/Pods-LifeBoard-LifeBoardUITests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -4229,9 +4707,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-LifeBoard/Pods-LifeBoard-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-LifeBoard/Pods-LifeBoard-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -4268,8 +4750,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				944EF9DE463A08CF93BA48F0 /* LifeBoardWatchWidgetBundle.swift in Sources */,
-				A457B085A9BC111253AADA8E /* AppGroupConstants.swift in Sources */,
-				84BE48061CC9D9603E1C2CFE /* WidgetSnapshot.swift in Sources */,
+				A457B085A9BC111253AADA8E /* Shared/AppGroupConstants.swift in Sources */,
+				84BE48061CC9D9603E1C2CFE /* Shared/WidgetSnapshot.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4277,7 +4759,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DCC82F690B379131E60A69DA /* LifeBoardWidgetBundle.swift in Sources */,
+				DCC82F690B379131E60A69DA /* LifeBoardWidgets/LifeBoardWidgetBundle.swift in Sources */,
 				7AF141A3F67EC19A0961D749 /* LifeBoardTokens.swift in Sources */,
 				A8F1D2015E9C44A100112233 /* LifeBoardLayoutContext.swift in Sources */,
 				DE2C698360236D910D116D07 /* LifeBoardTheme.swift in Sources */,
@@ -4289,20 +4771,20 @@
 				8B3CA34519B5A28D8599A5B0 /* SwiftUI+TokenAdapters.swift in Sources */,
 				F1A2B3C4D5E6F7A8B9C0D1E3 /* LifeBoardTheme+SwiftUI.swift in Sources */,
 				F1A2B3C4D5E6F7A8B9C0D1E5 /* LifeBoardAnimations.swift in Sources */,
-				B1C2D3E42F90000100AA1001 /* TaskWidgetFoundation.swift in Sources */,
-				B1C2D3E52F90000100AA1001 /* TaskWidgetHomeViews.swift in Sources */,
-				B1C2D3E62F90000100AA1001 /* TaskWidgetAccessoryViews.swift in Sources */,
-				B1C2D3EA2F90000100AA1001 /* TaskWidgetDesignSystemCompat.swift in Sources */,
-				B1C2D3EC2F90000100AA1001 /* HomeCalendarWidgetView.swift in Sources */,
-				B1C2D3EF2F90000100AA1001 /* HomeTimelineWidgetView.swift in Sources */,
-				CD83FC6E516299A8FB19F781 /* TodayXPWidget.swift in Sources */,
-				7DDFA05C1E835A398268D1EF /* WeeklyScoreboardWidget.swift in Sources */,
-				481A6828453BE977412FD2EB /* NextMilestoneWidget.swift in Sources */,
-				5E49A6FCA0C096CB2B6EA054 /* StreakResilienceWidget.swift in Sources */,
-				8142FD6EB789DF1EED06EA7F /* FocusSeedWidget.swift in Sources */,
-				F1A2B3C4D5E6F708192A3B4C /* WidgetBrand.swift in Sources */,
-				4BB22BF593C5283CF8557AFE /* AppGroupConstants.swift in Sources */,
-				919FF9A13C8BB0FF98385DAA /* WidgetSnapshot.swift in Sources */,
+				B1C2D3E42F90000100AA1001 /* LifeBoardWidgets/TaskWidgetFoundation.swift in Sources */,
+				B1C2D3E52F90000100AA1001 /* LifeBoardWidgets/TaskWidgetHomeViews.swift in Sources */,
+				B1C2D3E62F90000100AA1001 /* LifeBoardWidgets/TaskWidgetAccessoryViews.swift in Sources */,
+				B1C2D3EA2F90000100AA1001 /* LifeBoardWidgets/TaskWidgetDesignSystemCompat.swift in Sources */,
+				B1C2D3EC2F90000100AA1001 /* LifeBoardWidgets/HomeCalendarWidgetView.swift in Sources */,
+				B1C2D3EF2F90000100AA1001 /* LifeBoardWidgets/HomeTimelineWidgetView.swift in Sources */,
+				CD83FC6E516299A8FB19F781 /* LifeBoardWidgets/TodayXPWidget.swift in Sources */,
+				7DDFA05C1E835A398268D1EF /* LifeBoardWidgets/WeeklyScoreboardWidget.swift in Sources */,
+				481A6828453BE977412FD2EB /* LifeBoardWidgets/NextMilestoneWidget.swift in Sources */,
+				5E49A6FCA0C096CB2B6EA054 /* LifeBoardWidgets/StreakResilienceWidget.swift in Sources */,
+				8142FD6EB789DF1EED06EA7F /* LifeBoardWidgets/FocusSeedWidget.swift in Sources */,
+				F1A2B3C4D5E6F708192A3B4C /* LifeBoardWidgets/WidgetBrand.swift in Sources */,
+				4BB22BF593C5283CF8557AFE /* Shared/AppGroupConstants.swift in Sources */,
+				919FF9A13C8BB0FF98385DAA /* Shared/WidgetSnapshot.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4312,8 +4794,8 @@
 			files = (
 				52623D942AC2922413277FF6 /* LifeBoardWatchApp.swift in Sources */,
 				AA8998042C8A124CBA384F20 /* WatchSnapshotReceiver.swift in Sources */,
-				6A59527C3E61ADE16A9C11AA /* AppGroupConstants.swift in Sources */,
-				0F7C061EF4DA8BEF5A8909BC /* WidgetSnapshot.swift in Sources */,
+				6A59527C3E61ADE16A9C11AA /* Shared/AppGroupConstants.swift in Sources */,
+				0F7C061EF4DA8BEF5A8909BC /* Shared/WidgetSnapshot.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4386,26 +4868,26 @@
 				75F0C70C2DE9E47C008F4460 /* ColoredPillBackgroundView.swift in Sources */,
 				7551DA09248832BE005CF826 /* ToDoTimeUtils.swift in Sources */,
 				753EFCA22445A24500A739E3 /* HomeViewController.swift in Sources */,
-				AAB000000000000000000002 /* HomeRenderState.swift in Sources */,
-				AAB000000000000000000004 /* HomeStores.swift in Sources */,
-				AAB000000000000000000009 /* HomeShellTypes.swift in Sources */,
-				AAB00000000000000000000D /* OnboardingTaskDetailDismissBridge.swift in Sources */,
-				AAB00000000000000000000F /* RescheduleViewController.swift in Sources */,
-				AAB000000000000000000011 /* HomeDailySummaryModalView.swift in Sources */,
-				AAB000000000000000000013 /* SunriseRecurringTaskDeleteConfirmationView.swift in Sources */,
-				AAB000000000000000000015 /* HomeUITestWorkspaceSeeder.swift in Sources */,
-				AAB000000000000000000019 /* NeedsReplanTrayView.swift in Sources */,
-				AAB00000000000000000001B /* NeedsReplanLauncherSheet.swift in Sources */,
-				AAB00000000000000000001D /* NeedsReplanCardOverlay.swift in Sources */,
-				AAB00000000000000000001F /* NeedsReplanSummaryOverlay.swift in Sources */,
-				AAB000000000000000000021 /* HomePrimaryWidgetRail.swift in Sources */,
-				AAB000000000000000000024 /* EvaOverdueRescueSheetV2.swift in Sources */,
-				AAB000000000000000000026 /* HomeiPadShell.swift in Sources */,
-				AAB000000000000000000029 /* HomeTimelineSnapshotRenderCache.swift in Sources */,
-				AAB00000000000000000002B /* HomeTimelineColumnLayout.swift in Sources */,
-				AAB00000000000000000002D /* HomeSunriseLayoutSupport.swift in Sources */,
-				AAB00000000000000000002F /* HomeDaySwipeResolver.swift in Sources */,
-				AAB000000000000000000031 /* HomeSearchState.swift in Sources */,
+				AAB000000000000000000002 /* LifeBoard/Presentation/Home/RenderState/HomeRenderState.swift in Sources */,
+				AAB000000000000000000004 /* LifeBoard/Presentation/Home/Stores/HomeStores.swift in Sources */,
+				AAB000000000000000000009 /* LifeBoard/Presentation/Home/Shell/HomeShellTypes.swift in Sources */,
+				AAB00000000000000000000D /* LifeBoard/Presentation/Home/Modals/OnboardingTaskDetailDismissBridge.swift in Sources */,
+				AAB00000000000000000000F /* LifeBoard/Presentation/Home/Modals/RescheduleViewController.swift in Sources */,
+				AAB000000000000000000011 /* LifeBoard/Presentation/Home/Modals/HomeDailySummaryModalView.swift in Sources */,
+				AAB000000000000000000013 /* LifeBoard/Presentation/Home/Modals/SunriseRecurringTaskDeleteConfirmationView.swift in Sources */,
+				AAB000000000000000000015 /* LifeBoard/TestingSupport/HomeUITestWorkspaceSeeder.swift in Sources */,
+				AAB000000000000000000019 /* LifeBoard/Presentation/Home/Replan/NeedsReplanTrayView.swift in Sources */,
+				AAB00000000000000000001B /* LifeBoard/Presentation/Home/Replan/NeedsReplanLauncherSheet.swift in Sources */,
+				AAB00000000000000000001D /* LifeBoard/Presentation/Home/Replan/NeedsReplanCardOverlay.swift in Sources */,
+				AAB00000000000000000001F /* LifeBoard/Presentation/Home/Replan/NeedsReplanSummaryOverlay.swift in Sources */,
+				AAB000000000000000000021 /* LifeBoard/Presentation/Home/Widgets/HomePrimaryWidgetRail.swift in Sources */,
+				AAB000000000000000000024 /* LifeBoard/Presentation/Home/Modals/EvaOverdueRescueSheetV2.swift in Sources */,
+				AAB000000000000000000026 /* LifeBoard/Presentation/Home/Shell/HomeiPadShell.swift in Sources */,
+				AAB000000000000000000029 /* LifeBoard/Presentation/Home/Timeline/HomeTimelineSnapshotRenderCache.swift in Sources */,
+				AAB00000000000000000002B /* LifeBoard/Presentation/Home/Timeline/HomeTimelineColumnLayout.swift in Sources */,
+				AAB00000000000000000002D /* LifeBoard/Presentation/Home/Shell/HomeSunriseLayoutSupport.swift in Sources */,
+				AAB00000000000000000002F /* LifeBoard/Presentation/Home/Shell/HomeDaySwipeResolver.swift in Sources */,
+				AAB000000000000000000031 /* LifeBoard/Presentation/Home/Search/HomeSearchState.swift in Sources */,
 				1F9B00012FBA700000000001 /* HomeNavigationCoordinator.swift in Sources */,
 				1F9B00032FBA700000000003 /* HomeReloadCoordinator.swift in Sources */,
 				1F9B00052FBA700000000005 /* HomeNavigationIntent.swift in Sources */,
@@ -4462,8 +4944,8 @@
 				75E929E32E8C782100207270 /* TaskRepeatPattern.swift in Sources */,
 				75D8274E2E8C8995000F04E1 /* UserRepositoryProtocol.swift in Sources */,
 				75D8274F2E8C8995000F04E1 /* NotificationServiceProtocol.swift in Sources */,
-				CA1A10000000000000000001 /* CalendarEventsProviderProtocol.swift in Sources */,
-				CA1A10000000000000000002 /* CalendarIntegrationModels.swift in Sources */,
+				CA1A10000000000000000001 /* LifeBoard/Domain/Interfaces/CalendarEventsProviderProtocol.swift in Sources */,
+				CA1A10000000000000000002 /* LifeBoard/Domain/Models/CalendarIntegrationModels.swift in Sources */,
 				750894CC2E8D3C390037FACE /* AnalyticsRepositoryProtocol.swift in Sources */,
 				75F89F782DFC57F1009EDD8F /* LLMSettingsView.swift in Sources */,
 				E0A100000000000000000008 /* EvaActivationModels.swift in Sources */,
@@ -4527,8 +5009,8 @@
 				4C1518DF4ED5BA6F4E6D9C81 /* InMemoryCacheService.swift in Sources */,
 				8CEB7AF8EA56D5550356778F /* CoreDataProjectRepository.swift in Sources */,
 				B426403E6996E2CE8BE66FB6 /* EnhancedDependencyContainer.swift in Sources */,
-				A1D100022F90000100AA2001 /* LifeBoardPersistentStoreBootstrapService.swift in Sources */,
-				C9F2A10C3D4E5F60718293AA /* WriteClosedRepositoryAdapters.swift in Sources */,
+				A1D100022F90000100AA2001 /* LifeBoard/State/DI/LifeBoardPersistentStoreBootstrapService.swift in Sources */,
+				C9F2A10C3D4E5F60718293AA /* LifeBoard/State/Sync/WriteClosedRepositoryAdapters.swift in Sources */,
 				75BFBC422F6F3EB000626F01 /* LifeBoardTokens.swift in Sources */,
 				75BFBC432F6F3EB000626F01 /* LifeBoardLayoutContext.swift in Sources */,
 				75BFBC442F6F3EB000626F01 /* LifeBoardTheme.swift in Sources */,
@@ -4543,7 +5025,7 @@
 				75BFBC4A2F6F3EB000626F01 /* SwiftUI+TokenAdapters.swift in Sources */,
 				75BFBC4B2F6F3EB000626F01 /* LifeBoardTheme+SwiftUI.swift in Sources */,
 				75BFBC4C2F6F3EB000626F01 /* LifeBoardAnimations.swift in Sources */,
-				B8E100032F70000100A0A001 /* LifeBoardCTABezel.metal in Sources */,
+				B8E100032F70000100A0A001 /* Effects/LifeBoardCTABezel.metal in Sources */,
 				B77B0891A4A5B4BF8D6162DC /* TaskDetailComponents.swift in Sources */,
 				F00D00000000000000001002 /* TaskDetailPresentationContracts.swift in Sources */,
 				C4D5E6F70891A2B3C4D5E702 /* SunriseTaskDetailScreen.swift in Sources */,
@@ -4564,19 +5046,19 @@
 				C2D804681AC165ADEAD7D906 /* SavedHomeView.swift in Sources */,
 				D6A192319732E9758B2D14B9 /* SavedHomeViewRepositoryProtocol.swift in Sources */,
 				50117460BC314EEA54344A9E /* GetHomeFilteredTasksUseCase.swift in Sources */,
-				B2E100000000000000000201 /* BuildHomeAgendaUseCase.swift in Sources */,
-				B2E10000000000000000020B /* BuildNeedsReplanCandidatesUseCase.swift in Sources */,
-				B2E10000000000000000020C /* HomeTimelineProjectionBuilder.swift in Sources */,
-				B2E100000000000000000202 /* HomeTodayRow.swift in Sources */,
-				B2E100000000000000000207 /* HomeTaskTintResolver.swift in Sources */,
-				B2E100000000000000000203 /* HomeHabitRow.swift in Sources */,
-				B2E100000000000000000206 /* HomeHabitLastCellInteraction.swift in Sources */,
-				B2E100000000000000000205 /* HomeSectionState.swift in Sources */,
-				D2A100000000000000000002 /* QuietTrackingComposerSnapshot.swift in Sources */,
-				B2E100000000000000000204 /* HomeHabitRowView.swift in Sources */,
-				C1B100000000000000000106 /* HabitBoardViews.swift in Sources */,
-				C1B100000000000000000104 /* HabitBoardViewModel.swift in Sources */,
-				C1B100000000000000000102 /* HabitBoardPresentationBuilder.swift in Sources */,
+				B2E100000000000000000201 /* LifeBoard/UseCases/Home/BuildHomeAgendaUseCase.swift in Sources */,
+				B2E10000000000000000020B /* LifeBoard/UseCases/Home/BuildNeedsReplanCandidatesUseCase.swift in Sources */,
+				B2E10000000000000000020C /* LifeBoard/UseCases/Home/HomeTimelineProjectionBuilder.swift in Sources */,
+				B2E100000000000000000202 /* LifeBoard/Presentation/Models/HomeTodayRow.swift in Sources */,
+				B2E100000000000000000207 /* LifeBoard/Presentation/Models/HomeTaskTintResolver.swift in Sources */,
+				B2E100000000000000000203 /* LifeBoard/Presentation/Models/HomeHabitRow.swift in Sources */,
+				B2E100000000000000000206 /* LifeBoard/Presentation/Models/HomeHabitLastCellInteraction.swift in Sources */,
+				B2E100000000000000000205 /* LifeBoard/Presentation/Models/HomeSectionState.swift in Sources */,
+				D2A100000000000000000002 /* LifeBoard/Presentation/Models/QuietTrackingComposerSnapshot.swift in Sources */,
+				B2E100000000000000000204 /* LifeBoard/View/HomeHabitRowView.swift in Sources */,
+				C1B100000000000000000106 /* LifeBoard/View/HabitBoardViews.swift in Sources */,
+				C1B100000000000000000104 /* LifeBoard/Presentation/ViewModels/HabitBoardViewModel.swift in Sources */,
+				C1B100000000000000000102 /* LifeBoard/Presentation/Habits/HabitBoardPresentationBuilder.swift in Sources */,
 				6BFABA2E6D0DFA253AEC67A9 /* UserDefaultsSavedHomeViewRepository.swift in Sources */,
 				A3A6DF9571AB7FEB410EB861 /* SunriseAdvancedFilterSheetView.swift in Sources */,
 				1B77769B1FFEBB2FA951419F /* AddTaskMetadataRow.swift in Sources */,
@@ -4598,12 +5080,12 @@
 				A11D5A110000000000000012 /* SunriseDaySwipeData.swift in Sources */,
 				A11D5A110000000000000013 /* SunriseDaySwipeWaveShape.swift in Sources */,
 				A11D5A110000000000000014 /* SunriseDaySwipeOverlay.swift in Sources */,
-				D4F400000000000000000201 /* SunriseTimelineSurface.swift in Sources */,
-				CA1A10000000000000000006 /* EventKitCalendarChooserSheet.swift in Sources */,
-				CA1A10000000000000000007 /* EventKitEventDetailView.swift in Sources */,
-				F00D00000000000000001006 /* CalendarSchedulePresentationContracts.swift in Sources */,
-				F00D00000000000000001008 /* CalendarTimelinePresentation.swift in Sources */,
-				D2A100000000000000000004 /* SunriseQuietTrackingComposerView.swift in Sources */,
+				D4F400000000000000000201 /* LifeBoard/View/SunriseTimelineSurface.swift in Sources */,
+				CA1A10000000000000000006 /* LifeBoard/View/Calendar/EventKitCalendarChooserSheet.swift in Sources */,
+				CA1A10000000000000000007 /* LifeBoard/View/Calendar/EventKitEventDetailView.swift in Sources */,
+				F00D00000000000000001006 /* LifeBoard/View/Calendar/CalendarSchedulePresentationContracts.swift in Sources */,
+				F00D00000000000000001008 /* LifeBoard/View/Calendar/CalendarTimelinePresentation.swift in Sources */,
+				D2A100000000000000000004 /* LifeBoard/View/SunriseQuietTrackingComposerView.swift in Sources */,
 				F2A1B2C3D4E5F60718293B50 /* HomeBottomBarItem.swift in Sources */,
 				F2A1B2C3D4E5F60718293B51 /* HomeBottomBarState.swift in Sources */,
 				AB12CD34EF5607891234ABCE /* CoverFlipTransition.swift in Sources */,
@@ -4635,7 +5117,7 @@
 				D6B2E31F4A5C7890BCDEF0AB /* AddTaskTitleField.swift in Sources */,
 				D6B2E31F4A5C7890BCDEF0BC /* AddTaskXPPreview.swift in Sources */,
 				ABCD00000000000000000011 /* AddHabitViewModel.swift in Sources */,
-				ABCD00000000000000000013 /* HabitIconCatalog.swift in Sources */,
+				ABCD00000000000000000013 /* LifeBoard/Presentation/Habits/HabitIconCatalog.swift in Sources */,
 				ABCD00000000000000000014 /* SunriseHabitLibraryView.swift in Sources */,
 				D6B2E31F4A5C7890BCDEF0CD /* Device+Notch.swift in Sources */,
 				A1B2C3D52F90000100AA1001 /* TaskEditorSectionCard.swift in Sources */,
@@ -4648,123 +5130,123 @@
 				18C32A093ADC765E90DBA71D /* AddTaskTagMultiSelect.swift in Sources */,
 				70260539B2410072EEE5DF2C /* AddTaskTaskPicker.swift in Sources */,
 				AB5F19766B9E8B7A003B9B1E /* LifeBoardSnackbar.swift in Sources */,
-				1325F41FAECBAE30E66C3E42 /* V2RepositoryProtocols.swift in Sources */,
-				C1A100000000000000000101 /* HabitRuntimeReadRepositoryProtocol.swift in Sources */,
-				453DD6D72ACCC238FEFE9ACB /* SchedulingEngineProtocol.swift in Sources */,
-				92A6F2B715C2C0A1687DACE9 /* LifeAreaRepositoryProtocol.swift in Sources */,
-				AFA64782BED04A879157E2A8 /* SectionRepositoryProtocol.swift in Sources */,
-				656AE33F845CFC0E1E317F5E /* TagRepositoryProtocol.swift in Sources */,
-				B93F762182E74294AC55C6CB /* TaskDefinitionRepositoryProtocol.swift in Sources */,
-				78824D15E7415EDE2EBA903C /* HabitRepositoryProtocol.swift in Sources */,
-				0D77AD04BFBCEC5DAB92B68D /* ScheduleRepositoryProtocol.swift in Sources */,
-				308A7EC3564F5C557224C776 /* OccurrenceRepositoryProtocol.swift in Sources */,
-				63F0A29CF92317D22F150D4B /* ReminderRepositoryProtocol.swift in Sources */,
-				4F8081C9186D3E09FC4A1D1E /* GamificationRepositoryProtocol.swift in Sources */,
-				5665C4C2C0BD133E3E4F59AA /* AssistantActionRepositoryProtocol.swift in Sources */,
-				A1E5C40F2F1A4B9D9C1E8A10 /* AppleRemindersProviderProtocol.swift in Sources */,
-				7F7D8255FC6F6CFC199943F2 /* LifeAreaMapper.swift in Sources */,
-				CEA4FD3F132804749E69A4B3 /* SectionMapper.swift in Sources */,
-				5AC278B44C8BDF3A50E94379 /* TagMapper.swift in Sources */,
-				37A2B8A6A25F06C72606019E /* TaskDefinitionMapper.swift in Sources */,
-				E06D2A329E5E510A206A8EC9 /* HabitDefinitionMapper.swift in Sources */,
-				FD5A8F04A6436C78DBBD43A4 /* TombstoneMapper.swift in Sources */,
-				B10B1C2D3E4F506172839401 /* StateLifeAreaMapper.swift in Sources */,
-				B10B1C2D3E4F506172839402 /* StateSectionMapper.swift in Sources */,
-				B10B1C2D3E4F506172839403 /* StateTagMapper.swift in Sources */,
-				B10B1C2D3E4F506172839404 /* StateTombstoneMapper.swift in Sources */,
-				B10B1C2D3E4F506172839405 /* StateHabitDefinitionMapper.swift in Sources */,
-				B10B1C2D3E4F506172839407 /* StateTaskDefinitionMapper.swift in Sources */,
-				B10B1C2D3E4F506172839408 /* StateProjectMapper.swift in Sources */,
-				AEF06D3B80CB5D968535DDE5 /* LifeArea.swift in Sources */,
-				D336A787C8DCE1322AB8ADAB /* Section.swift in Sources */,
+				1325F41FAECBAE30E66C3E42 /* LifeBoard/Domain/Interfaces/V2RepositoryProtocols.swift in Sources */,
+				C1A100000000000000000101 /* LifeBoard/Domain/Interfaces/HabitRuntimeReadRepositoryProtocol.swift in Sources */,
+				453DD6D72ACCC238FEFE9ACB /* LifeBoard/Domain/Interfaces/SchedulingEngineProtocol.swift in Sources */,
+				92A6F2B715C2C0A1687DACE9 /* LifeBoard/Domain/Interfaces/LifeAreaRepositoryProtocol.swift in Sources */,
+				AFA64782BED04A879157E2A8 /* LifeBoard/Domain/Interfaces/SectionRepositoryProtocol.swift in Sources */,
+				656AE33F845CFC0E1E317F5E /* LifeBoard/Domain/Interfaces/TagRepositoryProtocol.swift in Sources */,
+				B93F762182E74294AC55C6CB /* LifeBoard/Domain/Interfaces/TaskDefinitionRepositoryProtocol.swift in Sources */,
+				78824D15E7415EDE2EBA903C /* LifeBoard/Domain/Interfaces/HabitRepositoryProtocol.swift in Sources */,
+				0D77AD04BFBCEC5DAB92B68D /* LifeBoard/Domain/Interfaces/ScheduleRepositoryProtocol.swift in Sources */,
+				308A7EC3564F5C557224C776 /* LifeBoard/Domain/Interfaces/OccurrenceRepositoryProtocol.swift in Sources */,
+				63F0A29CF92317D22F150D4B /* LifeBoard/Domain/Interfaces/ReminderRepositoryProtocol.swift in Sources */,
+				4F8081C9186D3E09FC4A1D1E /* LifeBoard/Domain/Interfaces/GamificationRepositoryProtocol.swift in Sources */,
+				5665C4C2C0BD133E3E4F59AA /* LifeBoard/Domain/Interfaces/AssistantActionRepositoryProtocol.swift in Sources */,
+				A1E5C40F2F1A4B9D9C1E8A10 /* LifeBoard/Domain/Interfaces/AppleRemindersProviderProtocol.swift in Sources */,
+				7F7D8255FC6F6CFC199943F2 /* LifeBoard/Domain/Mappers/LifeAreaMapper.swift in Sources */,
+				CEA4FD3F132804749E69A4B3 /* LifeBoard/Domain/Mappers/SectionMapper.swift in Sources */,
+				5AC278B44C8BDF3A50E94379 /* LifeBoard/Domain/Mappers/TagMapper.swift in Sources */,
+				37A2B8A6A25F06C72606019E /* LifeBoard/Domain/Mappers/TaskDefinitionMapper.swift in Sources */,
+				E06D2A329E5E510A206A8EC9 /* LifeBoard/Domain/Mappers/HabitDefinitionMapper.swift in Sources */,
+				FD5A8F04A6436C78DBBD43A4 /* LifeBoard/Domain/Mappers/TombstoneMapper.swift in Sources */,
+				B10B1C2D3E4F506172839401 /* LifeBoard/State/Mappers/StateLifeAreaMapper.swift in Sources */,
+				B10B1C2D3E4F506172839402 /* LifeBoard/State/Mappers/StateSectionMapper.swift in Sources */,
+				B10B1C2D3E4F506172839403 /* LifeBoard/State/Mappers/StateTagMapper.swift in Sources */,
+				B10B1C2D3E4F506172839404 /* LifeBoard/State/Mappers/StateTombstoneMapper.swift in Sources */,
+				B10B1C2D3E4F506172839405 /* LifeBoard/State/Mappers/StateHabitDefinitionMapper.swift in Sources */,
+				B10B1C2D3E4F506172839407 /* LifeBoard/State/Mappers/StateTaskDefinitionMapper.swift in Sources */,
+				B10B1C2D3E4F506172839408 /* LifeBoard/State/Mappers/StateProjectMapper.swift in Sources */,
+				AEF06D3B80CB5D968535DDE5 /* LifeBoard/Domain/Models/LifeArea.swift in Sources */,
+				D336A787C8DCE1322AB8ADAB /* LifeBoard/Domain/Models/Section.swift in Sources */,
 				D4F200000000000000000101 /* TaskPlanningBucket.swift in Sources */,
-				147231A5B5EE1AFA9351EA13 /* TagDefinition.swift in Sources */,
-				C1A100000000000000000102 /* HabitTypes.swift in Sources */,
-				816AAF82986408293F48FA7C /* HabitDefinition.swift in Sources */,
-				807193C0B8E13112AFE45388 /* Tombstone.swift in Sources */,
-				A8595F3EF93E3431E8562A05 /* ScheduleTemplate.swift in Sources */,
-				EDD64897FAC96F1B85BDA5F7 /* Occurrence.swift in Sources */,
-				FA1924E817EE26D9DB798F93 /* ReminderDefinition.swift in Sources */,
-				4B7CFEBE8C7C67CCB5E4E73C /* GamificationProfile.swift in Sources */,
-				A4C2E9F12B7D4C5581AA0001 /* HomeTaskMutationPayload.swift in Sources */,
-				FF5BDB5653D5CB66DA106A16 /* XPEvent.swift in Sources */,
-				FAD4981C27F2BBC7898744CD /* Achievement.swift in Sources */,
-				6F02A28B57E02ED09779EC11 /* AssistantAction.swift in Sources */,
-				E15729081BE877C1AF53C8C8 /* ExternalSyncModels.swift in Sources */,
+				147231A5B5EE1AFA9351EA13 /* LifeBoard/Domain/Models/TagDefinition.swift in Sources */,
+				C1A100000000000000000102 /* LifeBoard/Domain/Models/HabitTypes.swift in Sources */,
+				816AAF82986408293F48FA7C /* LifeBoard/Domain/Models/HabitDefinition.swift in Sources */,
+				807193C0B8E13112AFE45388 /* LifeBoard/Domain/Models/Tombstone.swift in Sources */,
+				A8595F3EF93E3431E8562A05 /* LifeBoard/Domain/Models/ScheduleTemplate.swift in Sources */,
+				EDD64897FAC96F1B85BDA5F7 /* LifeBoard/Domain/Models/Occurrence.swift in Sources */,
+				FA1924E817EE26D9DB798F93 /* LifeBoard/Domain/Models/ReminderDefinition.swift in Sources */,
+				4B7CFEBE8C7C67CCB5E4E73C /* LifeBoard/Domain/Models/GamificationProfile.swift in Sources */,
+				A4C2E9F12B7D4C5581AA0001 /* LifeBoard/Domain/Models/HomeTaskMutationPayload.swift in Sources */,
+				FF5BDB5653D5CB66DA106A16 /* LifeBoard/Domain/Models/XPEvent.swift in Sources */,
+				FAD4981C27F2BBC7898744CD /* LifeBoard/Domain/Models/Achievement.swift in Sources */,
+				6F02A28B57E02ED09779EC11 /* LifeBoard/Domain/Models/AssistantAction.swift in Sources */,
+				E15729081BE877C1AF53C8C8 /* LifeBoard/Domain/Models/ExternalSyncModels.swift in Sources */,
 				D4F200000000000000000102 /* WeeklyPlan.swift in Sources */,
 				D4F200000000000000000103 /* WeeklyOutcome.swift in Sources */,
 				D4F200000000000000000104 /* WeeklyReview.swift in Sources */,
 				D4F200000000000000000105 /* ReflectionNote.swift in Sources */,
 				D4F200000000000000000106 /* WeeklyMomentumSummary.swift in Sources */,
-				68910C38BADF060D09F81CE3 /* V2CoreDataRepositorySupport.swift in Sources */,
-				A4E8C9D12F9A4C3600A1B2C3 /* LifeAreaIdentityRepair.swift in Sources */,
-				0F67D9989E8924F5B6E2B2EE /* CoreDataLifeAreaRepository.swift in Sources */,
-				166AB064CD81E7EAF6579B7E /* CoreDataSectionRepository.swift in Sources */,
-				4204230B763861761BB75AF3 /* CoreDataTagRepository.swift in Sources */,
-				83EFBFC4977B6ABACDEA352B /* CoreDataTaskDefinitionRepository.swift in Sources */,
-				877BB428E2F289B2E71A9989 /* CoreDataHabitRepository.swift in Sources */,
-				C1A100000000000000000104 /* CoreDataHabitRuntimeReadRepository.swift in Sources */,
-				1670AB6E54D82AC77EBC9B3D /* CoreDataScheduleRepository.swift in Sources */,
-				00E943E7872FB1B20D349D99 /* CoreDataOccurrenceRepository.swift in Sources */,
-				F7F1A376574BECAD5FD6A5E3 /* CoreDataReminderRepository.swift in Sources */,
-				863B6B92EB0A96ED4BAB5BA6 /* CoreDataGamificationRepository.swift in Sources */,
-				08CCE589CA3E83FE266289D1 /* CoreDataAssistantActionRepository.swift in Sources */,
-				3D26E03F6D3A9571E7204553 /* CoreDataExternalSyncRepository.swift in Sources */,
-				3367A12ABAB9C8FAB90843C2 /* CoreDataTombstoneRepository.swift in Sources */,
-				D4F200000000000000000107 /* CoreDataWeeklyRepositories.swift in Sources */,
-				30B49EE9EC93A901D247EA1F /* CoreSchedulingEngine.swift in Sources */,
-				A1E5C40F2F1A4B9D9C1E8A11 /* EventKitAppleRemindersProvider.swift in Sources */,
-				CA1A10000000000000000004 /* EventKitCalendarEventsProvider.swift in Sources */,
-				CA1A10000000000000000005 /* CalendarIntegrationService.swift in Sources */,
-				B07A5646DA7E6D9AC7739710 /* ManageLifeAreasUseCase.swift in Sources */,
-				599BA3DB81762830929CF142 /* ManageSectionsUseCase.swift in Sources */,
-				300E318A0AD9AB7F088C497E /* ManageTagsUseCase.swift in Sources */,
-				EE3E0D5AF58CB2AD95219EB6 /* CreateTaskDefinitionUseCase.swift in Sources */,
-				8DC9908CB24A163442B463FB /* CompleteTaskDefinitionUseCase.swift in Sources */,
-				E1C5A4B1D2E3F40123456789 /* UpdateTaskDefinitionUseCase.swift in Sources */,
-				E1C5A4B1D2E3F4012345678A /* DeleteTaskDefinitionUseCase.swift in Sources */,
-				E1C5A4B1D2E3F4012345678B /* RescheduleTaskDefinitionUseCase.swift in Sources */,
-				1E4C2C3AAF40D4455D5A2625 /* ManageHabitsUseCase.swift in Sources */,
-				C1A100000000000000000103 /* HabitRuntimeUseCases.swift in Sources */,
-				433493DCACF59AC715A519C4 /* GenerateOccurrencesUseCase.swift in Sources */,
-				A195295E32A95E537E16AF8A /* ResolveOccurrenceUseCase.swift in Sources */,
-				722536ED9234849F6B954FAF /* MaintainOccurrencesUseCase.swift in Sources */,
-				3EA2500F6FA7AE834A238C3A /* ScheduleReminderUseCase.swift in Sources */,
-				1D79C65FEB0FF79A7D4C349D /* RecordXPUseCase.swift in Sources */,
-				CA1A10000000000000000003 /* CalendarComputationUseCases.swift in Sources */,
-				D4F200000000000000000108 /* WeeklyOperatingUseCases.swift in Sources */,
-				C537950FC6FD78BB996E7CA5 /* HomeXPHeroView.swift in Sources */,
-				511B4F3A5B402E7BCB708321 /* XPEnums.swift in Sources */,
-				D1855A230115C554ADB92AEA /* DailyXPAggregateDefinition.swift in Sources */,
-				E9479027EA89BB78EAD282EF /* FocusSessionDefinition.swift in Sources */,
-				8FB82D17163DA0089635E128 /* XPCalculationEngine.swift in Sources */,
+				68910C38BADF060D09F81CE3 /* LifeBoard/State/Repositories/V2CoreDataRepositorySupport.swift in Sources */,
+				A4E8C9D12F9A4C3600A1B2C3 /* LifeBoard/State/Integrity/LifeAreaIdentityRepair.swift in Sources */,
+				0F67D9989E8924F5B6E2B2EE /* LifeBoard/State/Repositories/CoreDataLifeAreaRepository.swift in Sources */,
+				166AB064CD81E7EAF6579B7E /* LifeBoard/State/Repositories/CoreDataSectionRepository.swift in Sources */,
+				4204230B763861761BB75AF3 /* LifeBoard/State/Repositories/CoreDataTagRepository.swift in Sources */,
+				83EFBFC4977B6ABACDEA352B /* LifeBoard/State/Repositories/CoreDataTaskDefinitionRepository.swift in Sources */,
+				877BB428E2F289B2E71A9989 /* LifeBoard/State/Repositories/CoreDataHabitRepository.swift in Sources */,
+				C1A100000000000000000104 /* LifeBoard/State/Repositories/CoreDataHabitRuntimeReadRepository.swift in Sources */,
+				1670AB6E54D82AC77EBC9B3D /* LifeBoard/State/Repositories/CoreDataScheduleRepository.swift in Sources */,
+				00E943E7872FB1B20D349D99 /* LifeBoard/State/Repositories/CoreDataOccurrenceRepository.swift in Sources */,
+				F7F1A376574BECAD5FD6A5E3 /* LifeBoard/State/Repositories/CoreDataReminderRepository.swift in Sources */,
+				863B6B92EB0A96ED4BAB5BA6 /* LifeBoard/State/Repositories/CoreDataGamificationRepository.swift in Sources */,
+				08CCE589CA3E83FE266289D1 /* LifeBoard/State/Repositories/CoreDataAssistantActionRepository.swift in Sources */,
+				3D26E03F6D3A9571E7204553 /* LifeBoard/State/Repositories/CoreDataExternalSyncRepository.swift in Sources */,
+				3367A12ABAB9C8FAB90843C2 /* LifeBoard/State/Repositories/CoreDataTombstoneRepository.swift in Sources */,
+				D4F200000000000000000107 /* LifeBoard/State/Repositories/CoreDataWeeklyRepositories.swift in Sources */,
+				30B49EE9EC93A901D247EA1F /* LifeBoard/State/Services/CoreSchedulingEngine.swift in Sources */,
+				A1E5C40F2F1A4B9D9C1E8A11 /* LifeBoard/State/Services/EventKitAppleRemindersProvider.swift in Sources */,
+				CA1A10000000000000000004 /* LifeBoard/State/Services/EventKitCalendarEventsProvider.swift in Sources */,
+				CA1A10000000000000000005 /* LifeBoard/State/Services/CalendarIntegrationService.swift in Sources */,
+				B07A5646DA7E6D9AC7739710 /* LifeBoard/UseCases/LifeArea/ManageLifeAreasUseCase.swift in Sources */,
+				599BA3DB81762830929CF142 /* LifeBoard/UseCases/Section/ManageSectionsUseCase.swift in Sources */,
+				300E318A0AD9AB7F088C497E /* LifeBoard/UseCases/Tag/ManageTagsUseCase.swift in Sources */,
+				EE3E0D5AF58CB2AD95219EB6 /* LifeBoard/UseCases/Task/CreateTaskDefinitionUseCase.swift in Sources */,
+				8DC9908CB24A163442B463FB /* LifeBoard/UseCases/Task/CompleteTaskDefinitionUseCase.swift in Sources */,
+				E1C5A4B1D2E3F40123456789 /* LifeBoard/UseCases/Task/UpdateTaskDefinitionUseCase.swift in Sources */,
+				E1C5A4B1D2E3F4012345678A /* LifeBoard/UseCases/Task/DeleteTaskDefinitionUseCase.swift in Sources */,
+				E1C5A4B1D2E3F4012345678B /* LifeBoard/UseCases/Task/RescheduleTaskDefinitionUseCase.swift in Sources */,
+				1E4C2C3AAF40D4455D5A2625 /* LifeBoard/UseCases/Habit/ManageHabitsUseCase.swift in Sources */,
+				C1A100000000000000000103 /* LifeBoard/UseCases/Habit/HabitRuntimeUseCases.swift in Sources */,
+				433493DCACF59AC715A519C4 /* LifeBoard/UseCases/Schedule/GenerateOccurrencesUseCase.swift in Sources */,
+				A195295E32A95E537E16AF8A /* LifeBoard/UseCases/Schedule/ResolveOccurrenceUseCase.swift in Sources */,
+				722536ED9234849F6B954FAF /* LifeBoard/UseCases/Schedule/MaintainOccurrencesUseCase.swift in Sources */,
+				3EA2500F6FA7AE834A238C3A /* LifeBoard/UseCases/Reminder/ScheduleReminderUseCase.swift in Sources */,
+				1D79C65FEB0FF79A7D4C349D /* LifeBoard/UseCases/Gamification/RecordXPUseCase.swift in Sources */,
+				CA1A10000000000000000003 /* LifeBoard/UseCases/Calendar/CalendarComputationUseCases.swift in Sources */,
+				D4F200000000000000000108 /* LifeBoard/UseCases/Weekly/WeeklyOperatingUseCases.swift in Sources */,
+				C537950FC6FD78BB996E7CA5 /* LifeBoard/View/HomeXPHeroView.swift in Sources */,
+				511B4F3A5B402E7BCB708321 /* LifeBoard/Domain/Models/XPEnums.swift in Sources */,
+				D1855A230115C554ADB92AEA /* LifeBoard/Domain/Models/DailyXPAggregateDefinition.swift in Sources */,
+				E9479027EA89BB78EAD282EF /* LifeBoard/Domain/Models/FocusSessionDefinition.swift in Sources */,
+				8FB82D17163DA0089635E128 /* LifeBoard/Domain/Models/XPCalculationEngine.swift in Sources */,
 				A6D5E0EA942DF95EA0C175B8 /* GamificationTokens.swift in Sources */,
-				76CEBFD41A570542EB212A69 /* GamificationEngine.swift in Sources */,
-				858A4B4BBFF2BD3553D36F21 /* AssistantActionPipelineUseCase.swift in Sources */,
-				2C3429C2681D310EA9197AE3 /* LinkExternalRemindersUseCase.swift in Sources */,
-				DFF1C01087EA0CE41AF85876 /* ReconcileExternalRemindersUseCase.swift in Sources */,
-				AE2B20F87AC525CF7E27B3C0 /* LLMContextProjectionService.swift in Sources */,
-				BEB8BC780A4A962C58A77BC4 /* V2FeatureFlags.swift in Sources */,
-				59E0A865A7529C69B04F684A /* LocalNotificationService.swift in Sources */,
-				7F1B2C3D4E5F60718293A4B5 /* GamificationRemoteKillSwitchService.swift in Sources */,
-				7F1B2C3D4E5F60718293A4B7 /* LiquidMetalCTARemoteConfigService.swift in Sources */,
+				76CEBFD41A570542EB212A69 /* LifeBoard/UseCases/Gamification/GamificationEngine.swift in Sources */,
+				858A4B4BBFF2BD3553D36F21 /* LifeBoard/UseCases/LLM/AssistantActionPipelineUseCase.swift in Sources */,
+				2C3429C2681D310EA9197AE3 /* LifeBoard/UseCases/Sync/LinkExternalRemindersUseCase.swift in Sources */,
+				DFF1C01087EA0CE41AF85876 /* LifeBoard/UseCases/Sync/ReconcileExternalRemindersUseCase.swift in Sources */,
+				AE2B20F87AC525CF7E27B3C0 /* LifeBoard/LLM/Models/LLMContextProjectionService.swift in Sources */,
+				BEB8BC780A4A962C58A77BC4 /* LifeBoard/Services/V2FeatureFlags.swift in Sources */,
+				59E0A865A7529C69B04F684A /* LifeBoard/Services/LocalNotificationService.swift in Sources */,
+				7F1B2C3D4E5F60718293A4B5 /* LifeBoard/Services/GamificationRemoteKillSwitchService.swift in Sources */,
+				7F1B2C3D4E5F60718293A4B7 /* LifeBoard/Services/LiquidMetalCTARemoteConfigService.swift in Sources */,
 				C03666F6116B077DFA194278 /* SyncMergeState.swift in Sources */,
-				47EE4E9B0C3B5EC21C43BED8 /* ReminderMergeEngine.swift in Sources */,
-				6A4B1EB5E3E85FE74AD7AEDC /* AssistantCommandExecutor.swift in Sources */,
+				47EE4E9B0C3B5EC21C43BED8 /* LifeBoard/UseCases/Sync/ReminderMergeEngine.swift in Sources */,
+				6A4B1EB5E3E85FE74AD7AEDC /* LifeBoard/UseCases/LLM/AssistantCommandExecutor.swift in Sources */,
 				6211D7BD7037AA1D03E6F90B /* TaskReadModelRepositoryProtocol.swift in Sources */,
 				ACE5DE19204D2D1CDBF3A053 /* TaskReadQueries.swift in Sources */,
-				8CF22C53A483ED3E88E74656 /* CoreDataTaskReadModelRepository.swift in Sources */,
-				C4B2E3D5F6A70819 /* AchievementCatalog.swift in Sources */,
-				C4B2E3D5F6A7081A /* BadgeGalleryView.swift in Sources */,
-				C4B2E3D5F6A7081B /* LevelUpCelebrationView.swift in Sources */,
-				C4B2E3D5F6A7081C /* MilestoneCelebrationView.swift in Sources */,
-				C4B2E3D5F6A7081D /* BadgeDetailSheet.swift in Sources */,
-				36235D01BFCF2D2001A39CCE /* FocusSessionUseCase.swift in Sources */,
-				D4F300000000000000000130 /* DailyReflectionLoadCoordinator.swift in Sources */,
-				A2181FC3974A81C3FB7BEDFF /* MarkDailyReflectionCompleteUseCase.swift in Sources */,
-				3A549BEBEF3902410F96971A /* SunriseFocusTimerView.swift in Sources */,
-				A912CB15A1588398C547FCE3 /* SunriseFocusSessionSummaryView.swift in Sources */,
-				BA046E8ED5086F9E39ACB225 /* SunriseDailyReflectionView.swift in Sources */,
+				8CF22C53A483ED3E88E74656 /* LifeBoard/State/Repositories/CoreDataTaskReadModelRepository.swift in Sources */,
+				C4B2E3D5F6A70819 /* LifeBoard/Domain/Models/AchievementCatalog.swift in Sources */,
+				C4B2E3D5F6A7081A /* LifeBoard/View/BadgeGalleryView.swift in Sources */,
+				C4B2E3D5F6A7081B /* LifeBoard/View/LevelUpCelebrationView.swift in Sources */,
+				C4B2E3D5F6A7081C /* LifeBoard/View/MilestoneCelebrationView.swift in Sources */,
+				C4B2E3D5F6A7081D /* LifeBoard/View/BadgeDetailSheet.swift in Sources */,
+				36235D01BFCF2D2001A39CCE /* LifeBoard/UseCases/Gamification/FocusSessionUseCase.swift in Sources */,
+				D4F300000000000000000130 /* LifeBoard/UseCases/Gamification/DailyReflectionLoadCoordinator.swift in Sources */,
+				A2181FC3974A81C3FB7BEDFF /* LifeBoard/UseCases/Gamification/MarkDailyReflectionCompleteUseCase.swift in Sources */,
+				3A549BEBEF3902410F96971A /* LifeBoard/View/SunriseFocusTimerView.swift in Sources */,
+				A912CB15A1588398C547FCE3 /* LifeBoard/View/SunriseFocusSessionSummaryView.swift in Sources */,
+				BA046E8ED5086F9E39ACB225 /* LifeBoard/View/SunriseDailyReflectionView.swift in Sources */,
 				D5A200000000000000000001 /* ReflectPlanStyle.swift in Sources */,
 				D5A200000000000000000002 /* SunriseReflectPlanScreen.swift in Sources */,
 				D5A200000000000000000003 /* ReflectPlanHeader.swift in Sources */,
@@ -4783,10 +5265,10 @@
 				D5A200000000000000000010 /* SwapTaskPicker.swift in Sources */,
 				D4F200000000000000000109 /* WeeklyPlannerViewModel.swift in Sources */,
 				D4F20000000000000000010A /* WeeklyReviewViewModel.swift in Sources */,
-				FFCF1FC469B2AE9FC88CF3D1 /* InsightsViewModel.swift in Sources */,
-				D9A0B1C2D3E4F506172839AD /* InsightsModuleVisibilityPlanner.swift in Sources */,
-				A25DA7AE7D00020D26A9EBC7 /* InsightsTabView.swift in Sources */,
-				5E7A10000000000000000001 /* SunriseInsightsView.swift in Sources */,
+				FFCF1FC469B2AE9FC88CF3D1 /* LifeBoard/Presentation/ViewModels/InsightsViewModel.swift in Sources */,
+				D9A0B1C2D3E4F506172839AD /* LifeBoard/Presentation/Models/InsightsModuleVisibilityPlanner.swift in Sources */,
+				A25DA7AE7D00020D26A9EBC7 /* LifeBoard/View/Insights/InsightsTabView.swift in Sources */,
+				5E7A10000000000000000001 /* LifeBoard/View/Insights/SunriseInsightsView.swift in Sources */,
 				5E7A20000000000000000001 /* SunriseInsightsHeaderView.swift in Sources */,
 				5E7A20000000000000000003 /* SunriseInsightsHeroCard.swift in Sources */,
 				D4F20000000000000000010B /* HomeWeeklySummaryCard.swift in Sources */,
@@ -4800,9 +5282,9 @@
 				7551F0000000000000000002 /* SunriseDestinationScaffold.swift in Sources */,
 				7551F0000000000000000003 /* SunriseSegmentedControl.swift in Sources */,
 				7551F0000000000000000004 /* SunriseSearchFaceView.swift in Sources */,
-				4D31E9106C4721F38F1B2394 /* AppGroupConstants.swift in Sources */,
-				A1D100012F90000100AA2001 /* ShortcutHandoffStore.swift in Sources */,
-				3D5A1FDECBC53839EF1F4953 /* WidgetSnapshot.swift in Sources */,
+				4D31E9106C4721F38F1B2394 /* Shared/AppGroupConstants.swift in Sources */,
+				A1D100012F90000100AA2001 /* Shared/ShortcutHandoffStore.swift in Sources */,
+				3D5A1FDECBC53839EF1F4953 /* Shared/WidgetSnapshot.swift in Sources */,
 				BD300CBF97B95F0D2A2CA092 /* WatchWidgetSnapshotSync.swift in Sources */,
 				C7A200000000000000000005 /* LockedResultAccumulator.swift in Sources */,
 				02548417398F2FC3E57621F1 /* HomeArchitectureProtocols.swift in Sources */,
@@ -4826,477 +5308,477 @@
 				E19F74D16FD5238F2C77D32A /* TimelineTimeBlock.swift in Sources */,
 				84F03ABBF9605F10AF9BB212 /* TimelinePhoneRenderModel.swift in Sources */,
 				200250316B998CD442EAD960 /* TimelineRendererModels.swift in Sources */,
-				E7DE591D7ACDB8FF504008CA /* OnboardingNotificationNameExtension.swift in Sources */,
-				8D8A8C8983C91CD1372CA1EB /* AppOnboardingAccessibilityID.swift in Sources */,
-				44E3EB20B7DF2407719E6B2F /* OnboardingCopy.swift in Sources */,
-				4F19404CD237ADA1ADE1F528 /* OnboardingProgress.swift in Sources */,
-				D4E0D80A4976DADBFEC9F159 /* onboardingLogLine.swift in Sources */,
-				17EF835E3AB7BCA161FBFB5C /* logOnboardingInfo.swift in Sources */,
-				8FE784A4B9FCFA802CE95542 /* logOnboardingError.swift in Sources */,
-				4A52BB8E16EAECC2A970E287 /* OnboardingOutcome.swift in Sources */,
-				8790268063CEA1C833D51C7A /* OnboardingStep.swift in Sources */,
-				83CBA72051A1B8A5580FB888 /* OnboardingPrimaryGoal.swift in Sources */,
-				04AD0E929FAB37FD57D8BCB8 /* OnboardingPainPoint.swift in Sources */,
-				70A9068D6C68CC20C0201150 /* OnboardingStarterHabitPreference.swift in Sources */,
-				E428ECADD6A89C0B1D7F174B /* OnboardingEvaPreparationPhase.swift in Sources */,
-				48756A3EF4DA7E57686EA3BF /* OnboardingEvaPreparationState.swift in Sources */,
-				C158FF33EA33FDAD9E137F25 /* OnboardingNetworkClass.swift in Sources */,
-				0ACC594D16D9F9D83D812052 /* OnboardingFrictionProfile.swift in Sources */,
-				D86B5C7DF619A7A577D4874F /* OnboardingMode.swift in Sources */,
-				AD8804130CE2160E653414FD /* OnboardingEntryContext.swift in Sources */,
-				125D26BDB072E9A8F3E515D7 /* OnboardingTaskTemplateState.swift in Sources */,
-				20F7A92A6373992D5B74E817 /* OnboardingHabitTemplateState.swift in Sources */,
-				EE1B64C0721BCF43D9599B65 /* OnboardingReminderPromptState.swift in Sources */,
-				E9974C1A3AC57A1E1E5B60CA /* WelcomeIntroPhase.swift in Sources */,
-				0B2EA9B1BC50C6D572DBDA14 /* OnboardingWorkspaceSnapshot.swift in Sources */,
-				5E62A1F6764E8C4158AE395D /* OnboardingEligibility.swift in Sources */,
-				01D3E1ADABC2FB7D419F301E /* AppOnboardingSummary.swift in Sources */,
-				D6988674F7729285A707C98C /* CodingKeys.swift in Sources */,
-				539FB9E50686C14B24DADEC8 /* OnboardingBreakdownStep.swift in Sources */,
-				0FF401A34059E3AECC2B14B1 /* OnboardingProjectDraft.swift in Sources */,
-				54E3898C156FECCEE5A57CE5 /* ResolvedLifeAreaSelection.swift in Sources */,
-				C017F11E0720B026D1DC1692 /* ResolvedProjectSelection.swift in Sources */,
-				66FBAD17B454FE9E6A36D30F /* OnboardingJourneySnapshot.swift in Sources */,
-				9B5D983BDED5F3B292E2920D /* CodingKeys2.swift in Sources */,
-				3BFDC99E090DF4551C917CE6 /* AppOnboardingState.swift in Sources */,
-				CE101A5DFCA6C30A72A5CE61 /* PendingOnboardingPresentation.swift in Sources */,
-				262A9D38982EE6BE9E44E616 /* OnboardingPresentationQueue.swift in Sources */,
-				CA588F0C88CA2D9300D59E10 /* AppOnboardingStateStore.swift in Sources */,
-				193F65F5AD20237F0366DCF8 /* StarterTaskTemplate.swift in Sources */,
-				13AFF7E41F28B08AD43AA900 /* StarterHabitTemplate.swift in Sources */,
-				E2B058A2C6F1249FA0248124 /* StarterProjectTemplate.swift in Sources */,
-				EAB76D638082DDE00237973C /* StarterLifeAreaTemplate.swift in Sources */,
-				F825BC32A2F154EF1E81504E /* StarterWorkspaceCatalog.swift in Sources */,
-				9BF910D455817C716D94F9D8 /* OnboardingEligibilityService.swift in Sources */,
-				036E9881C0F7EC40685393B7 /* HomeOnboardingGuidanceModel.swift in Sources */,
-				7FC722F1C850B171F2A2713E /* OnboardingFeedbackController.swift in Sources */,
-				AF82520CAEE921B7BE04E017 /* OnboardingFlowModel.swift in Sources */,
-				0512B30196300E86AE6ABE53 /* OnboardingFlowModel+CatalogPresentation.swift in Sources */,
-				FCC23D047188986E5F29D1EF /* OnboardingFlowModel+LifeAreaHabitTaskSetup.swift in Sources */,
-				4FDA467939746A454749A279 /* OnboardingFlowModel+EvaPreferencesAndDemo.swift in Sources */,
-				C3D50B7B0090C88C8F837DA5 /* OnboardingFlowModel+NavigationPersistence.swift in Sources */,
-				582890EBB89DC028C4FA8F9D /* OnboardingFlowModel+EvaActivationPreparation.swift in Sources */,
-				A88F93F1E4769FB8D7640E3E /* AppOnboardingHostAdapter.swift in Sources */,
-				F0A15BDE3E582D2E951E98F4 /* HomeViewControllerExtension.swift in Sources */,
-				D38314D027D0FAD3E8DBD55A /* AppOnboardingCoordinator.swift in Sources */,
-				A516ABAD2F7D26235B44C3A1 /* AppOnboardingCoordinator+Presentation.swift in Sources */,
-				07F9DF04416807600DA792AA /* OnboardingInputField.swift in Sources */,
-				8689D743382AFB9679125174 /* AppOnboardingJourneyView.swift in Sources */,
-				7CBC9FB5197011346A405CEA /* AppOnboardingJourneyView+LayoutWelcomeAndGoal.swift in Sources */,
-				E36C6117443BE8E4989A930C /* AppOnboardingJourneyView+SetupSteps.swift in Sources */,
-				910A98F48562792C6651F69A /* AppOnboardingJourneyView+DemoPermissionsAndDock.swift in Sources */,
-				4DD16D458439FF0B85BA9CF7 /* AppOnboardingJourneyView+OutcomeDraftsAndActions.swift in Sources */,
-				8792E823650E54CA4E14AA8E /* AppOnboardingPromptSheetView.swift in Sources */,
-				14CDB6B6887E83C9AF1E8412 /* OnboardingPromptBackground.swift in Sources */,
-				28F2FC0F85DA578FDDEC4C32 /* OnboardingPromptChecklistCard.swift in Sources */,
-				C2FD7479882454D6E58D05D5 /* OnboardingPromptTheme.swift in Sources */,
-				DC1DB2042D99A4C779FADDCA /* OnboardingPromptValueCard.swift in Sources */,
-				11E1CAF9151542D119B4883B /* OnboardingPromptPrimaryCTAButtonStyle.swift in Sources */,
-				0ACC457D0516F36AB25D3367 /* OnboardingPromptGlassPanelModifier.swift in Sources */,
-				09CD9170481BB868874A059E /* OnboardingPromptFooterMaterialModifier.swift in Sources */,
-				86E90FFDD209E7304B7D5BBE /* HomeOnboardingGuidanceBanner.swift in Sources */,
-				90C6619892CA88CDC07F0618 /* OnboardingTheme.swift in Sources */,
-				BFE43C633C4F5FD1C5ED3D91 /* OnboardingPastelPalette.swift in Sources */,
-				2F9410224630703F3E950DDD /* OnboardingStepVisualTheme.swift in Sources */,
-				B696207D77139D62369E4954 /* OnboardingConcentricColorField.swift in Sources */,
-				98327A7BB4DC3205D53A6D32 /* OnboardingConcentricTransitionLayer.swift in Sources */,
-				6A791794B107ED921F62EF41 /* OnboardingFloatingNextAction.swift in Sources */,
-				4C1EDC5A08CA68696B5EADD9 /* OnboardingFloatingNextButton.swift in Sources */,
-				13E26BA7B62EB8B9BACF274E /* AppOnboardingBackground.swift in Sources */,
-				AF46E4534CA58DD946E8AF43 /* OnboardingSectionHeader.swift in Sources */,
-				89F6DD86DEF66E5F787909B1 /* OnboardingEyebrowLabel.swift in Sources */,
-				38B214F1E69681E0A58C8665 /* OnboardingTrustRow.swift in Sources */,
-				CB80F340473A31AFE8CF162A /* OnboardingHeroMediaAsset.swift in Sources */,
-				980E67E8DC345CD40457C5BD /* OnboardingCinematicBackdrop.swift in Sources */,
-				CAE86C460FCB7CB9FA6C9AE2 /* OnboardingAccessibilityMarker.swift in Sources */,
-				8C023F1274CF5FC1D02A717C /* OnboardingAccessibilityMarkerView.swift in Sources */,
-				7069388CBB2CDAEB362DA386 /* OnboardingWelcomeCinematicOverlay.swift in Sources */,
-				D65596F60D499A8BB32EFBD4 /* OnboardingWelcomeIntroLine.swift in Sources */,
-				F3C1E701D90B17B69DA1D98C /* OnboardingHeroVideoView.swift in Sources */,
-				937B562AC1B7C19DC318F1B1 /* OnboardingLoopingPlayerView.swift in Sources */,
-				0C2ECCAB66276D4F1B630EBE /* OnboardingFrictionSelector.swift in Sources */,
-				B15275C8511EAB14F4112515 /* OnboardingFrictionSelectorLayout.swift in Sources */,
-				80AECAD4D9127F42BFAA8304 /* OnboardingFrictionSelectorWidthPreferenceKey.swift in Sources */,
-				00E2B96FE676ECE56D1C1587 /* OnboardingSelectionSummaryCard.swift in Sources */,
-				CDFF51674BB1F653FF14260A /* OnboardingMascotCarousel.swift in Sources */,
-				BF2F6F85EA92C566A31BB5D4 /* OnboardingCustomEntryRow.swift in Sources */,
-				C2421458D3A338445B13FBE6 /* OnboardingInlineActionRow.swift in Sources */,
-				3F64B79D565266A18289D9CC /* OnboardingDownloadStatusStrip.swift in Sources */,
-				1274375D849BBF28D4DF1408 /* OnboardingDownloadStatusPill.swift in Sources */,
-				32FB0E5EB16490C5930975F4 /* OnboardingPermissionHeroIcon.swift in Sources */,
-				982DF7E1D0152A8257DDFCF5 /* OnboardingHomeDemoSnapshotFactory.swift in Sources */,
-				BE3795CCDFC49D30531F1016 /* OnboardingHomeDemoPreview.swift in Sources */,
-				0122C4D3D195380D2CDCBED5 /* OnboardingChecklistCard.swift in Sources */,
-				6D6E90ED524D19DBBBC00FD2 /* OnboardingChecklistRow.swift in Sources */,
-				63D15C0A35A7BF3479A69D30 /* OnboardingSelectableDetailCard.swift in Sources */,
-				1842D1AB7AB9D66E5A024CEE /* OnboardingFilterChip.swift in Sources */,
-				18BC4EA3F8C23BB362367B1B /* OnboardingHabitStreakPreviewCard.swift in Sources */,
-				DA81A406247E701A8EE98417 /* OnboardingMiniMetric.swift in Sources */,
-				10BDA207EE601292AB9E1231 /* OnboardingTaskPreviewCard.swift in Sources */,
-				CB0E20CDE17573CE6A56AEFF /* OnboardingCompactHabitRail.swift in Sources */,
-				B430108C7AE1B927B9B1FB58 /* OnboardingEvaStatusCard.swift in Sources */,
-				C6D12F2061A8EBCCFD6346DA /* OnboardingFrictionOptionCard.swift in Sources */,
-				DA50FEA644495EB466054A2B /* OnboardingSelectableCard.swift in Sources */,
-				5ABA1E0B75C50F023148D89F /* OnboardingHabitRecommendationCard.swift in Sources */,
-				9A7AA6C367FAD2093F16DB77 /* OnboardingTaskRecommendationCard.swift in Sources */,
-				59FE36E7A9A47274A3D610FC /* OnboardingPressScaleButtonStyle.swift in Sources */,
-				62DA1F2B6CF478CD9F07E040 /* OnboardingPrimaryCTAButtonStyle.swift in Sources */,
-				EB9FD2ECFB4D4AD697D091F3 /* OnboardingInlineBadge.swift in Sources */,
-				0B3ACC1A28B21B661E547518 /* OnboardingFocusHeroCard.swift in Sources */,
-				6EDF2C884AFF7BC3644F93F7 /* OnboardingFocusTimer.swift in Sources */,
-				C3B88D39DA52634C915E96AE /* OnboardingSuccessHero.swift in Sources */,
-				2E5BDB7E8B94F068AE98C73B /* OnboardingSuccessSummaryCard.swift in Sources */,
-				7445A553C6B57662C98F3C2C /* OnboardingSuccessSummaryRow.swift in Sources */,
-				974FDA7040049B93F737E5B9 /* onboardingNaturalLanguageList.swift in Sources */,
-				390DB347BE033669B7CF9A28 /* ViewExtension.swift in Sources */,
-				02828F570030008E7C1B441C /* LifeAreaRepositoryProtocolExtension.swift in Sources */,
-				25FC3C1A435E0F8199ADBCD5 /* ProjectRepositoryProtocolExtension.swift in Sources */,
-				B3002EA7B07545C684BF2B16 /* HabitRepositoryProtocolExtension.swift in Sources */,
-				ABB8A81FC820F8057D7D0BB1 /* TaskDefinitionRepositoryProtocolExtension.swift in Sources */,
-				35EE69887A851F70BD73AB93 /* ManageLifeAreasUseCaseExtension.swift in Sources */,
-				56DF97BE6987C2AFF6929D47 /* ManageProjectsUseCaseExtension.swift in Sources */,
-				90D12F41EEB78A45B410CCDA /* CreateTaskDefinitionUseCaseExtension.swift in Sources */,
-				9B356B21E02F7FF4F6D8A6E2 /* CreateHabitUseCaseExtension.swift in Sources */,
-				971C0B6E09B4E9AA9B0F3939 /* ManageHabitsUseCaseExtension.swift in Sources */,
-				396F9CD34E10195B8C5FE0F7 /* CompleteTaskDefinitionUseCaseExtension.swift in Sources */,
-				094363D420BA00C23B9DC952 /* ResolveHabitOccurrenceUseCaseExtension.swift in Sources */,
-				69170C2AAEAA052519F64E78 /* CalendarIntegrationServiceExtension.swift in Sources */,
-				7FD844573284EB98B015104F /* NotificationServiceProtocolExtension.swift in Sources */,
-				A6E41D973B02F8BBF91E0666 /* LifeBoardCancellableDispatchWorkItem.swift in Sources */,
-				21D645FE5F1A842122F06A51 /* HomeTaskDetailMetadataState.swift in Sources */,
-				E3553D65476C93716D966319 /* HomeTaskDetailRelationshipMetadataState.swift in Sources */,
-				C3AC86F4BE2832B4E90C8467 /* HomeDueTodayAgendaLoadState.swift in Sources */,
-				32004AA08DF5D7FE9587C767 /* HomeCanonicalHabitMutationLoadState.swift in Sources */,
-				4835621B71E16E83CE9A39F5 /* HomeHabitWidgetRowsState.swift in Sources */,
-				54F4A36D13378251013B4956 /* DailySummaryLoadState.swift in Sources */,
-				6BE216860D602F917606397C /* HomeTaskMutationEvent.swift in Sources */,
-				D2D43D1D68EDFA8B61A9D766 /* HomeReloadScope.swift in Sources */,
-				F425DA7463D1A09323AFE4DE /* HomeDateNavigationSource.swift in Sources */,
-				82FB6DE938FB3650E891FC88 /* HomeDayNavigationDirection.swift in Sources */,
-				6CA88A6A8612FD806A55CEC5 /* HomeDataRevision.swift in Sources */,
-				424A813126216FCDBB3BB9D3 /* HomeRenderInvalidation.swift in Sources */,
-				DB20D31BAB145922299137A0 /* HomeTimelineWorkspacePreferencesSignature.swift in Sources */,
-				23D6A9438FB6BD00F6A8483A /* HomeTimelineEventSignature.swift in Sources */,
-				0D84D0166C11E5E8015ACA82 /* HomeTimelineSnapshotCacheKey.swift in Sources */,
-				86A93997F7D4FD6F2D0E4D4F /* HomeTimelineCalendarSignature.swift in Sources */,
-				EC45E6BBD381E86DD65D5EDF /* HomeTimelineReplanCandidateSignature.swift in Sources */,
-				E322491389C9B239A6D3BA57 /* HomeTimelineReplanPhaseSignature.swift in Sources */,
-				1A469FF8CAAD8B2B7D9A2FEF /* HomeTimelineReplanStateSignature.swift in Sources */,
-				6F8AE9CBE66BD30649B53BF2 /* HomeReplanResolutionKind.swift in Sources */,
-				19B603FD5B8EFE10233D20EE /* HomeReplanUndoEntry.swift in Sources */,
-				9EAAFEDF8331B11C56CDDA0F /* HabitRecoveryReflectionPrompt.swift in Sources */,
-				B5A18D04B79585D76C0CE5D9 /* HomeHabitMutationFeedbackHaptic.swift in Sources */,
-				41C931CFD888EF92197B0D24 /* HomeHabitMutationFeedback.swift in Sources */,
-				56E4DCAE5C1E65F706523538 /* HomeReloadBatchTracker.swift in Sources */,
-				1189D09985E33267B5E56A34 /* NSLockExtension.swift in Sources */,
-				16FDAE94A8B5B7D16F330DF2 /* HomeHabitMutationRequest.swift in Sources */,
-				1D443F47BB19EE9B20BFC4EE /* HomeHabitMutationKey.swift in Sources */,
-				263B577D54B198C0599992DE /* HomeHabitMutationSnapshot.swift in Sources */,
-				C97CA61FED91A0C2BE4E3AB1 /* HomeDerivedTaskRowsCache.swift in Sources */,
-				6CBA9A1192D4C0870A538CB6 /* HomeDerivedHabitRowsCache.swift in Sources */,
-				49BE8D232D0B830AC1D787AA /* HomeHabitMutationSectionPatch.swift in Sources */,
-				328B171396378ED1B150C54A /* HomeHabitRowPlacementBucket.swift in Sources */,
-				C280C01585D08BFD8692758E /* HomeHabitRowPlacement.swift in Sources */,
-				973C96958E583C28BB9194A3 /* HomeTaskReloadNotificationEvent.swift in Sources */,
-				58361669F430895FBF2918C5 /* FocusPinResult.swift in Sources */,
-				7F4CC1257A958D8992586922 /* FocusPromotionResult.swift in Sources */,
-				689BD052F12F388961F9C63C /* HomeNotificationNameExtension.swift in Sources */,
-				F260B975BFD99463197CD6A0 /* CelebrationKind.swift in Sources */,
-				F64C9A3B63E962670DB86280 /* CelebrationEvent.swift in Sources */,
-				B7B914D911EA894F24D58E27 /* CelebrationPresentation.swift in Sources */,
-				CEBD06B0323F598F2C11A5DC /* CelebrationRouter.swift in Sources */,
-				539F4B713CA94D564337B279 /* DefaultCelebrationRouter.swift in Sources */,
-				C68012797DEDCF3D065BBA45 /* InsightsLaunchRequest.swift in Sources */,
-				160F368EB1102A7D052D2220 /* HomeOverdueRescueLauncherState.swift in Sources */,
-				0EC49C3CF56F9FF0863151BD /* HomeViewModelRoot.swift in Sources */,
-				181CC936773A7F7700000000 /* HomeViewModel+Bindings.swift in Sources */,
-				050AE50E81D4703777D6F0C1 /* HomeViewModel+RenderTransaction.swift in Sources */,
-				5EA366582815849801B3F3F2 /* HomeViewModel+AnalyticsRefresh.swift in Sources */,
-				0F97D0D0CB26167BF4F3E1DD /* HomeViewModel+DailyReflectionPreview.swift in Sources */,
-				220B2D5DF3B84749D8AABC99 /* HomeViewModel+DailySummaryModal.swift in Sources */,
-				DC94FAFADB950991425D291B /* HomeViewModel+DateNavigation.swift in Sources */,
-				16E09E0E5A4633E33062DF74 /* HomeViewModel+DueTodayAgenda.swift in Sources */,
-				9E5BA6BF68993D536CEA3AC5 /* HomeViewModel+EvaRescueActions.swift in Sources */,
-				170D294E77D3B8898DFD0D85 /* HomeViewModel+FocusPins.swift in Sources */,
-				9092BD6AC3FACD1123284752 /* HomeViewModel+FocusSessions.swift in Sources */,
-				F3240A09F43701C96CE99815 /* HomeViewModel+FocusWhyCandidates.swift in Sources */,
-				DF610ABA86EAF98C49C6278A /* HomeViewModel+HabitActionShortcuts.swift in Sources */,
-				BDAFA3BFCD791B15C8DB9A9D /* HomeViewModel+HabitReconciliation.swift in Sources */,
-				E7CF89A56979F3789A7ED0E0 /* HomeViewModel+InitialLoading.swift in Sources */,
-				43672EBCA0F500EAA29B3088 /* HomeViewModel+InsightsLaunch.swift in Sources */,
-				67A73E4B61D4A82E1336EA51 /* HomeViewModel+ProjectionInvalidation.swift in Sources */,
-				CD7AADFB07AFA97B5C0D6452 /* HomeViewModel+RecurringTopUp.swift in Sources */,
-				78DE25A4719C53B4CB4EA8E0 /* HomeViewModel+ReferenceDataLoading.swift in Sources */,
-				20E905AEA02392CC5482222E /* HomeViewModel+RescueEligibility.swift in Sources */,
-				60077665EB3D3BDC56741ED6 /* HomeViewModel+TaskDetailMetadata.swift in Sources */,
-				E39BA7BC60FB71563853AE5F /* HomeViewModel+RefreshEntryPoints.swift in Sources */,
-				041BEC95EB82F86644971605 /* HomeViewModel+TaskActions.swift in Sources */,
-				6868D7DE1D836622DADA12CD /* HomeViewModel+TaskCreationDependencies.swift in Sources */,
-				44E3D8F1869822A9B8AFE2F9 /* HomeViewModel+FiltersAndSavedViews.swift in Sources */,
-				429BC3BC461278EFC2DCE53B /* HomeViewModel+EvaFocus.swift in Sources */,
-				8B4908D385E24901840412E6 /* HomeViewModel+RescueUndo.swift in Sources */,
-				6C55EB9AB6FB62999A3A710D /* HomeViewModel+DailyAnalytics.swift in Sources */,
-				3273E07D3C81B8301BCC6111 /* HomeViewModel+HabitMutations.swift in Sources */,
-				BD46BE503829CCD15E61E839 /* HomeViewModel+HabitMutationPatching.swift in Sources */,
-				8C6F6176F05C02D99369AB30 /* HomeViewModel+ReloadPipeline.swift in Sources */,
-				7C4E89225AA28D69904278A9 /* HomeViewModel+SectionProjection.swift in Sources */,
-				E01C6D15AED947A29929589A /* HomeViewModel+FocusRankingAndWidgetSnapshot.swift in Sources */,
-				446C1ECFEE836138F6A2FC04 /* HomeViewModel+ReloadBatchingAndReplanLauncher.swift in Sources */,
-				8968A51E3DD681D2B360D98C /* HomeViewModel+NeedsReplanStateAndPlacement.swift in Sources */,
-				61C740CCAEA2AAD70648F5FB /* HomeViewModel+CompletionProjection.swift in Sources */,
-				8D7BDD59803F690867AC75C8 /* HomeViewModel+StateUtilities.swift in Sources */,
-				E74EA3C46BB64BDD2E97F053 /* TimelineStreamInfluenceKind.swift in Sources */,
-				5F143687250957A73D400A49 /* TimelineStreamInfluence.swift in Sources */,
-				821E0BCBE223961EAB4DC4BD /* TimelineStreamInfluenceExtension.swift in Sources */,
-				21F6DC4C03DB207B0F93B967 /* TimelineStreamDirection.swift in Sources */,
-				7051BB581E31CCD8EC76429E /* TimelineStreamAnchor.swift in Sources */,
-				C6763538C5D158A7E8967D88 /* TimelineStreamSegment.swift in Sources */,
-				3832EF761CF5E6940EC8391C /* TimelineStreamSample.swift in Sources */,
-				F3C3DA3A987F1E361784B3C3 /* TimelineStreamGeometry.swift in Sources */,
-				58DE2299787427B905EC9D9E /* TimelineStreamGeometry+LaneLayoutAndPaths.swift in Sources */,
-				F078AE75786C51F7F4F78ABA /* TimelineStreamGeometry+MassClustering.swift in Sources */,
-				C3FB1D92DD198DC445CB8DB7 /* TimelineStreamLayerSpec.swift in Sources */,
-				653F0562A00EC4FD085B2436 /* TimelineNowBeadPresentation.swift in Sources */,
-				8ECE25D7C3266F62DF4D3888 /* TimelineCanvasLayoutPlan.swift in Sources */,
-				C4BB75857943B70FDC94219A /* TimelineCanvasLayoutPlan+VisualTimeMapping.swift in Sources */,
-				4B6D91346B20578BE27DD080 /* TimelineCanvasLayoutPlan+Positioning.swift in Sources */,
-				2CBC973505B2E0B6424541FB /* TimelineCompactLayoutPlan.swift in Sources */,
-				1E7D50D956C53289A4DC9691 /* TimelineFormatting.swift in Sources */,
-				7208997F226E7C45527E0F1D /* TimelineItemVisuals.swift in Sources */,
-				9399E0A93BBEBA504BB0526D /* TimelineDayRelation.swift in Sources */,
-				F7B0AB4286AC80DE2918E298 /* TimelineDayStablePresentation.swift in Sources */,
-				E776248C1D58F4223BE929E3 /* TimelineDayCurrentState.swift in Sources */,
-				B344A818A99590F452C10FC9 /* TimelineDayPresentation.swift in Sources */,
-				23D6911A2603575D6C3B32B4 /* TimelineVisualTokens.swift in Sources */,
-				4F71CEC7E0020E4BDABEB6A7 /* TimelineSurfaceMetrics.swift in Sources */,
-				13B527B121DA29E15716552A /* TimelineRailMetrics.swift in Sources */,
-				2EAFE882376B87E7901A885D /* TimelineSpineMounting.swift in Sources */,
-				7211B3D09FA27E8048BAF208 /* TimelineRailLabelKind.swift in Sources */,
-				84F7B021F3EAE4E07C455703 /* TimelineRailTypography.swift in Sources */,
-				3B95A6809B4D22F1D58A51E2 /* TimelineRailTimeFormatter.swift in Sources */,
-				F4CE8A08BB795C67615BDCB1 /* TimelineRoutineTextFormatter.swift in Sources */,
-				3BF5A228B4CE3008B8672DA1 /* TimelineBottomProtectionBudget.swift in Sources */,
-				A68140FD4222813E17094331 /* timelineDisplayedNow.swift in Sources */,
-				0CE03D5DE6944FB2FE2FBA3F /* timelineSuggestedAddDate.swift in Sources */,
-				7527F27DE6CAFC928FF07E85 /* timelineMetaText.swift in Sources */,
-				8C6F80184376D9187D2B39B9 /* timelineMetaColor.swift in Sources */,
-				0C972AF626F688F063459503 /* timelineTitleColor.swift in Sources */,
-				926138681C7DEC596E8C4F5D /* timelineRingColor.swift in Sources */,
-				7DBF73B54FC410E442F25A41 /* timelineAccessibilityLabel.swift in Sources */,
-				05017EDD38C8DCBBD917220C /* timelineAccessibilityIdentifier.swift in Sources */,
-				4455C821CEE50484216FDFC3 /* timelineRailText.swift in Sources */,
-				7241D3EE88E0D3355DDECF0D /* timelineStemColor.swift in Sources */,
-				DA083B470E02C697ADD728B8 /* timelineGapPromptText.swift in Sources */,
-				6958B671C35CEBA029BF084D /* gapPromptTint.swift in Sources */,
-				5063FF3626FB43ED4C7032FF /* timelineCapsuleHeight.swift in Sources */,
-				97503DD4CD8A6F7E1E6894B8 /* TimelineUtilityItemExtension.swift in Sources */,
-				55A4869DF1D5E4DD89557A1D /* TimelineRailPresentationSpec.swift in Sources */,
-				2D8D1185CFE2993F5861CAC2 /* SunriseTimelineSurfaceRoot.swift in Sources */,
-				09C4C3472A904F2E9C0E819A /* SunriseTimelineSurface+PlacementHelpers.swift in Sources */,
-				52CB4508EA7C96B9940B6799 /* TimelinePlacementPrompt.swift in Sources */,
-				FA2867EC44B15B0F834583B7 /* TimelinePlacementDock.swift in Sources */,
-				2DAC4DF99D4D0356E58AC4C2 /* TimelinePalette.swift in Sources */,
-				E4EE09FF5DA5E3D7530F0D94 /* SunriseTimelineBar.swift in Sources */,
-				7E4A49A2CC73B3C46AB49388 /* TimelinePlanningShelf.swift in Sources */,
-				DF7287CB7D22A27B0D68A9AD /* TimelineShelfItemCard.swift in Sources */,
-				EA9B4B976075D91EAB6902EB /* TimelineInboxPlanningCard.swift in Sources */,
-				6372B9063E39D08CCAF5A8C9 /* TimelineCurrentTimeRule.swift in Sources */,
-				4F4C0C5EE35B10B8DE2B66B8 /* TimelineCurrentTimeMarker.swift in Sources */,
-				6F0B5225F22BF0C2D1AEDFB5 /* TimelineRailLabel.swift in Sources */,
-				75F707F2E6238335515F2AAE /* TimelineSpineEndView.swift in Sources */,
-				03C55431D0F00584B024BACF /* TimelineStreamPalette.swift in Sources */,
-				A7CA2FCA1F9D09173330EAA2 /* TimelineStreamGlintPresentation.swift in Sources */,
-				1138787A92BD5440BF7B4D2D /* CurvingDayStreamView.swift in Sources */,
-				8E7D7A391577BD986A03B7A9 /* TimelineNowBeadView.swift in Sources */,
-				1E448F0CF8BEEFF9349F0F7E /* TimelineLongGapIndicator.swift in Sources */,
-				032A6D4BF36C354B8064310D /* TimelineEndAddMarker.swift in Sources */,
-				10F906589FFC0DE720F5FEB2 /* TimelineEmptyStateCard.swift in Sources */,
-				6A2E1305DB4B80D3BE0925F4 /* TimelineEmptyStateActionTone.swift in Sources */,
-				FE8EC07F1D05E4B12382FEA9 /* TimelineDenseTitleFormatter.swift in Sources */,
-				F6BF00E2BC75CA6D7EA0D449 /* TimelineNormalItemCard.swift in Sources */,
-				A72AC20CB4A49927EC98D3C6 /* TimelineTaskMarkerLayout.swift in Sources */,
-				94105F04150FE16142615C03 /* TimelineTaskMarkerRow.swift in Sources */,
-				319DAA1BD9A0076B2E78F2C7 /* TimelineFlockBlock.swift in Sources */,
-				94BE392CBEE903C8468E2899 /* TimelineFlockRowView.swift in Sources */,
-				96DB3A4F8D7B4B6FDF37EED5 /* TimelineOverlapClusterCard.swift in Sources */,
-				2721FCB8D7ABE25DBC7508B1 /* TimelineOverlapItemCard.swift in Sources */,
-				03EE1F33BC0AB56FA78CCCBE /* TimelineTimeBlockCard.swift in Sources */,
-				60756010B1F282A96E52851C /* TimelineTaskBlockRow.swift in Sources */,
-				91FD9F166D26C453EBA6BF67 /* TimelineMeetingBlockRow.swift in Sources */,
-				8C9CDC17702E6AC04114BAE5 /* DailyTimelineCanvas.swift in Sources */,
-				57F03D79758CC9FB3B892D91 /* DailyTimelineCanvas+RailAndCanvas.swift in Sources */,
-				320E8E819E057D02D689989F /* DailyTimelineCanvas+ItemRendering.swift in Sources */,
-				4B65F890786EE2C3F5A39C2C /* DailyTimelineCompactView.swift in Sources */,
-				D4ABAC9936B71C3DEB673B49 /* TimelineCompactAnchorRow.swift in Sources */,
-				CABA353295DF444EC908D3CC /* TimelineCompactItemRow.swift in Sources */,
-				7A41D73D8C289095E3560DB5 /* TimelineCompactGapRow.swift in Sources */,
-				D705016D0D6D308050273D76 /* TimelineCompactConnector.swift in Sources */,
-				032EBA2A2DF996C1E0110D70 /* DailyTimelineAgendaView.swift in Sources */,
-				A647A4ACDED4835C9EA6C0D6 /* TimelineAgendaAnchorRow.swift in Sources */,
-				7AB21ECF758F38938E8A5EE7 /* TimelineAgendaItemRow.swift in Sources */,
-				A97A6E7A7869366C7EF25D0E /* TimelineStemSegments.swift in Sources */,
-				108EDCB9266B21C80D773BBC /* TimelineUtilityRow.swift in Sources */,
-				1225D0DCBDEB90ACA96B6B5F /* TimelineCapsule.swift in Sources */,
-				61EAA0A5C594CBB9F626A7C1 /* TimelineCompletionRing.swift in Sources */,
-				F40B68EBDD554016F132F4E0 /* TimelineGapPrompt.swift in Sources */,
-				2E47612416B8D316F93760D1 /* TimelineGapExtension.swift in Sources */,
-				D57A320DF8A2202069F711FB /* TimelineBackdropWeekView.swift in Sources */,
-				BE57DA6C896F7EF32A6C3D87 /* TimelineWeekDayCell.swift in Sources */,
-				91FD6A303660EEF5294F7902 /* HomeTimeIntervalExtension.swift in Sources */,
-				EF8AD806AA6D1C9D47FA2BDE /* HomePerformanceSignposts.swift in Sources */,
-				CE266F5395572A3FFC2150D1 /* HomeHabitSectionCardHost.swift in Sources */,
-				0DDCFBDB474413795EC30643 /* HomeCalendarEventDetailSelection.swift in Sources */,
-				8B28B02DAA779156218510BB /* HomeCalendarEventDetailSheet.swift in Sources */,
-				DC9F1811662585E9D53AA8FA /* SunriseHomeDatePickerPopover.swift in Sources */,
-				5B7BAB6078EBCDB6CC9F7B7E /* SunriseAppShellViewRoot.swift in Sources */,
-				5C336D92A4C8046FB4291347 /* SunriseAppShellView+DerivedState.swift in Sources */,
-				6C361AE75951A20D4AA68C5B /* SunriseAppShellView+RescueOverlays.swift in Sources */,
-				F14217E9721A35DF328C2F66 /* SunriseAppShellView+HomeScreenComposition.swift in Sources */,
-				6BDDCD87B9F9CF4256048C93 /* SunriseAppShellView+ObserversSearchAndBackdrop.swift in Sources */,
-				ACF0BB7B85C9268CD15869B1 /* SunriseAppShellView+FacesAndSearchChat.swift in Sources */,
-				DC90B81FA56C3F8715AD26A1 /* SunriseAppShellView+SearchSurface.swift in Sources */,
-				DF8962905A29B85F26BDA46D /* SunriseAppShellView+TaskListAndDaySwipe.swift in Sources */,
-				E86FFAEB786065858AD5DFD4 /* SunriseAppShellView+TimelineSurface.swift in Sources */,
-				79A0BA40A86AF0524E6A1802 /* SunriseAppShellView+CalendarFooterAndTrackingRail.swift in Sources */,
-				4EFCDE37C57E117EA5041D85 /* SunriseAppShellView+HabitsAgendaAndFocusStrip.swift in Sources */,
-				55A68085778A4B9EA4FAC65D /* SunriseAppShellView+FocusInsightsAndRouting.swift in Sources */,
-				D697AD981C87D4D7D84A6EF0 /* SunriseAppShellView+FocusTimersAndReflection.swift in Sources */,
-				3E939305B64D29F91B6C188B /* CalendarCardChromeModifier.swift in Sources */,
-				AF5A65D3A0CB556B850BFC01 /* InsightsActionIntentExtension.swift in Sources */,
-				6FB7164807B1BD76EEF6B571 /* HomeStaggerModifier.swift in Sources */,
-				117D70E33461D260AF2A46C1 /* HomeDenseSurfaceModifier.swift in Sources */,
-				C01EF007CBD4512099E412AF /* QuietTrackingRailStreakWidget.swift in Sources */,
-				A48DB3A40E4B91F10D54B6B3 /* OverdueRescueLauncherOverlayView.swift in Sources */,
-				C27DED3B1AE919A68A5FA783 /* OverdueRescueDeckState.swift in Sources */,
-				0EC4FE8730866512296A0674 /* OverdueRescueDecisionSource.swift in Sources */,
-				0A2C5397D36D0D8C6B082AE8 /* OverdueRescueDecisionAction.swift in Sources */,
-				0AA9543F5B27EAE43ABA8843 /* RecurrenceInstanceSnapshot.swift in Sources */,
-				082C004A39ABC9840802B32C /* OverdueRescueUndoRecord.swift in Sources */,
-				ECF7EF4565293CE7F54AD9E8 /* OverdueRescueSummary.swift in Sources */,
-				DF045C31DEEDEEFC1A5F26EA /* OverdueRescueSessionScope.swift in Sources */,
-				8D7E0FDB18955B5CE76F16C6 /* OverdueRescueSessionState.swift in Sources */,
-				BA1DA60A9EB08E7E655CD957 /* OverdueRescueSessionStore.swift in Sources */,
-				514DDD3FB2EC2CD49EC01B12 /* UserDefaultsOverdueRescueSessionStore.swift in Sources */,
-				5986289E16E72070D526991E /* OverdueRescueStateMachine.swift in Sources */,
-				ED47AF6B2834E824484A40C5 /* OverdueRescueDeckLayoutMetrics.swift in Sources */,
-				7B986AAE5765AADF671B17D9 /* OverdueRescueDeckCopy.swift in Sources */,
-				546344BD2EA4D1FE47598FBB /* OverdueRescuePalette.swift in Sources */,
-				FC7A4DCCA6C83872D730A8BF /* OverdueRescueVisualSpec.swift in Sources */,
-				86A6A4A15FEE67AF21983B22 /* OverdueRescueSwipeRevealKind.swift in Sources */,
-				A2A1CBE7757AA1C9B5EA668E /* OverdueRescueDragResolution.swift in Sources */,
-				525C6689F6C181E296086096 /* OverdueRescueDragResolver.swift in Sources */,
-				3726D051C70DA7D059BBC8F4 /* OverdueRescueCardModel.swift in Sources */,
-				6EEA323B3C94CC3D3875A12A /* OverdueRescueMoveLaterResolver.swift in Sources */,
-				92ED5FEA6361F15C79382539 /* OverdueRescueEligibilityService.swift in Sources */,
-				81EB32FF0E69DB807E839151 /* OverdueRescueViewModel.swift in Sources */,
-				BF85F977D5CE48A00E45CB52 /* OverdueRescueViewModel+CardActions.swift in Sources */,
-				182AF6ED0E5475309A58CDF0 /* OverdueRescueViewModel+SessionPersistence.swift in Sources */,
-				0C1F3166AD2FCCA3FF3814DC /* OverdueRescueEditDraft.swift in Sources */,
-				2C4A24B77FA545940760F514 /* EvaOverdueRescueSheetV2Root.swift in Sources */,
-				9FCA8998FEF6F2B292163FB1 /* OverdueRescueDeckView.swift in Sources */,
-				2C9423200947462BB96E027D /* OverdueRescueBackCards.swift in Sources */,
-				223050CBCB2512809C97BFE4 /* OverdueRescueTaskCard.swift in Sources */,
-				A523362EF6446433532CC824 /* OverdueRescueRevealPanel.swift in Sources */,
-				21828AB3835916ECE946A73F /* OverdueRescueDeleteOverlay.swift in Sources */,
-				F71A150EACB33EB7B19F1E24 /* OverdueRescueSwipeHint.swift in Sources */,
-				FB8B2B57A23CA5361BE9C535 /* OverdueRescueActionGrid.swift in Sources */,
-				2E5FB69076ABDE23D77BDCF4 /* OverdueRescueQuickEditSheet.swift in Sources */,
-				8693C29C9C7147AC903DA772 /* OverdueRescueSafeFixesView.swift in Sources */,
-				E7526D26F32780AEE900BAFA /* OverdueRescuePauseView.swift in Sources */,
-				92B41286923165E8B772C985 /* OverdueRescueCompletionView.swift in Sources */,
-				5B0A4FDD9721341E85EF7093 /* OverdueRescueLargeStackView.swift in Sources */,
-				E47B01A4B384D82C914661A4 /* OverdueRescueErrorView.swift in Sources */,
-				13654561D6AE1564FAA82441 /* OverdueRescueBackground.swift in Sources */,
-				19062C6842CD068931CB3D63 /* OverdueRescuePlant.swift in Sources */,
-				96E8DB75698F710B91E6C77D /* OverdueRescueCupHero.swift in Sources */,
-				7EFC7582344FA582791827CA /* OverdueRescueShieldHero.swift in Sources */,
-				60200C66D978383E5757D92D /* OverdueRescueSunriseHero.swift in Sources */,
-				E4DF33BE9BD8B06FF928DA81 /* LifeBoardProgressBar.swift in Sources */,
-				1D8B3A4014113650D7298CA5 /* LifeManagementComposerRoute.swift in Sources */,
-				87A099A8CE32334354449960 /* LifeManagementTreeInteractionMode.swift in Sources */,
-				64978B8A3598BEE330C5F52D /* LifeManagementViewRoot.swift in Sources */,
-				563FA0843C94B94146D0A715 /* LifeManagementView+BrowserAndTree.swift in Sources */,
-				78A4D4DB20E3D0A3034A5E57 /* LifeManagementView+DetailsComposerAndOverlays.swift in Sources */,
-				1AC6BA7B2FA7EB7216540681 /* LifeManagementMenuLabel.swift in Sources */,
-				314809E17C3C294340F2DA1E /* LifeManagementAppearanceLine.swift in Sources */,
-				096DC7AAFD7B5580A3DABEC3 /* lifeManagementHabitStatusText.swift in Sources */,
-				98394DA04DCC1FB307F8FA6C /* lifeManagementAreaAccentHex.swift in Sources */,
-				B2621FA8D6DFC6D96F027AA1 /* lifeManagementHabitCadenceLabel.swift in Sources */,
-				51459E137A715214E7CD7481 /* AreaListRow.swift in Sources */,
-				7F6F5E34FE261604F7D6BFD0 /* AreaSummaryRow.swift in Sources */,
-				144C7E3E26AF1D97BC310AFF /* ProjectListRow.swift in Sources */,
-				686BD3F9EE58F613BD29E6C8 /* ProjectSummaryRow.swift in Sources */,
-				C5F044673340D4322E0821B9 /* HabitListRow.swift in Sources */,
-				F00D8D326BF77E4E42597083 /* HabitSummaryRow.swift in Sources */,
-				F85EBA97A802F4DC015E332F /* HabitArchiveRow.swift in Sources */,
-				EACA938DF5FA7C9EDE59A3E9 /* AccentIconBadge.swift in Sources */,
-				671162B95889EABEC8DB6123 /* InlineToneBadge.swift in Sources */,
-				E27B1B656A0E3808DD252E18 /* LifeManagementAreaDetailView.swift in Sources */,
-				014575655AA3DBD8B1BD4C5F /* LifeManagementProjectDetailView.swift in Sources */,
-				3447A60285674490A2726759 /* LifeManagementAreaComposerView.swift in Sources */,
-				9251E3DBECB09B6DBC3F5E6A /* LifeManagementProjectComposerView.swift in Sources */,
-				0A469058A907DD61A98AAF4C /* LifeManagementComposerPreviewMetric.swift in Sources */,
-				1E8F023F70606AF2879DEFBE /* LifeManagementAreaPaletteOption.swift in Sources */,
-				40E1706994A23C948306E25F /* LifeManagementComposerPreviewCard.swift in Sources */,
-				DB875C16F1B99BF79F3B4D6C /* LifeManagementComposerMetricTile.swift in Sources */,
-				876568AD4ACD09548D5F3199 /* LifeManagementComposerSectionCard.swift in Sources */,
-				1D91EF2A13A06697AF7AB056 /* LifeManagementComposerFieldLabel.swift in Sources */,
-				62E3C0A2BCA96C7A1DB01932 /* LifeManagementComposerInlineMessage.swift in Sources */,
-				F1BBC7AE7656181142FE5487 /* LifeManagementAreaSwatchPicker.swift in Sources */,
-				71A922288848416DA81F7339 /* LifeManagementProjectColorPicker.swift in Sources */,
-				F5C55F69B9C3BEDDF1C2FD8F /* LifeManagementColorSwatchButton.swift in Sources */,
-				FFE402DD68D4595A5B90EC4B /* LifeManagementAreaIconPicker.swift in Sources */,
-				78D78EA96C40AD8462A19EC9 /* LifeManagementProjectIconPicker.swift in Sources */,
-				7F217D39FE1F01D4E8731F64 /* LifeManagementIconTile.swift in Sources */,
-				4C116CACC08E51B35A4EA8B4 /* lifeManagementAreaPaletteOptions.swift in Sources */,
-				703E14D9DE8D191C47A5150F /* lifeManagementAreaPaletteMatch.swift in Sources */,
-				1C0ACEFFC26353A9CA10873F /* lifeManagementResolvedColor.swift in Sources */,
-				E7F919BAE9F8CABAE8F00BE6 /* lifeManagementResolvedHex.swift in Sources */,
-				EE9035C0B9F8F991433E9826 /* lifeManagementNormalizedHex.swift in Sources */,
-				E7E382F8167672FCEB4D0B60 /* lifeManagementAreaIconLabel.swift in Sources */,
-				7669746360890A5F6BFF15B0 /* ProjectMoveSheet.swift in Sources */,
-				3CA024512D42A38C712034E0 /* DeleteAreaSheet.swift in Sources */,
-				04821EE8B574D3BAF98E7B76 /* DeleteProjectSheet.swift in Sources */,
-				29AAA780F791C00A198F8FA7 /* StringExtension.swift in Sources */,
-				49E7E5624BF18A470B23059C /* ChatTimeIntervalExtension.swift in Sources */,
-				ED97E21547C8335D58370530 /* TypingIndicator.swift in Sources */,
-				1F2D5D429CB73C24348EE788 /* EvaWorkingStatusLibrary.swift in Sources */,
-				B0045AC9A4CD19C619A2E2F1 /* EvaLiveWorkingStatusView.swift in Sources */,
-				B8A0777F2A0301936C76BAE4 /* EvaDayTaskOverlayState.swift in Sources */,
-				EBEBD8815DECEEB6E6A67CAC /* EvaDayHabitOverlayState.swift in Sources */,
-				DB6DB22472BF68C888913F37 /* EvaDayStatusChipsView.swift in Sources */,
-				B07988E6375D66CC8CDB8D47 /* EvaDaySunriseTaskRowView.swift in Sources */,
-				DB95AC7DC5F9BE77042C3290 /* EvaDayHabitRowView.swift in Sources */,
-				A5857BBC75940D4FC8CFF13E /* EvaDayTaskHeaderView.swift in Sources */,
-				B901CF64B494992760AE96FB /* EvaDayTaskMetadataView.swift in Sources */,
-				8455171FE035DD36178C82A1 /* EvaDayTaskActionsView.swift in Sources */,
-				F008F091A6B8DB39893BDF07 /* EvaDayTaskActionButtonView.swift in Sources */,
-				39B8F09956E3FFEF16B72812 /* EvaDayHabitHeaderView.swift in Sources */,
-				3BFD0F4FDBF2CF845F1ED1BA /* EvaDayHabitMetadataView.swift in Sources */,
-				C7E4C6E991D23697752D8D6C /* EvaDayHabitActionsView.swift in Sources */,
-				552B5C25F6D738A5BA9CD095 /* EvaDayHabitActionButtonView.swift in Sources */,
-				FA06177C5FE545D4DB799E31 /* MessageView.swift in Sources */,
-				63578F35F6200B19F85FE9F0 /* MessageView+AssistantAndUserBubble.swift in Sources */,
-				88F9D9D24093FC098261F935 /* MessageView+EvaProposalAndDayOverview.swift in Sources */,
-				6AD96644B6458794736BA46D /* MessageView+DayOverviewAndProposalActions.swift in Sources */,
-				F4FF0FD29ACA5B7B4CF12827 /* MessageView+CommandResultsAndUndo.swift in Sources */,
-				F0D4A5D3F940D3BD0B515BEF /* ConversationViewRoot.swift in Sources */,
-				D92AC2EBBC4D507DE7D45C8F /* ConversationView+LiveOutput.swift in Sources */,
-				7477D906A0AC312F3C4B3912 /* EvaChatNavigationChromeState.swift in Sources */,
-				CB2585384EDD36506A08BC39 /* EvaChatSunriseGlass.swift in Sources */,
-				0EDFDE262FBEB052B1E2BDFE /* EvaChatSunriseBackground.swift in Sources */,
-				E83889CA9BD741CA471800E8 /* ChatHeaderView.swift in Sources */,
-				30CF71E853B4D59EBDBDA4AE /* ChatEmptyStateView.swift in Sources */,
-				9529034A5040C4E7C31DC102 /* EvaChiefOfStaffGuideSection.swift in Sources */,
-				4E816E3A12F0DFB4283D9FCF /* EvaHomePromptChip.swift in Sources */,
-				2330C3F5294BC6FE822B80D0 /* EvaChiefOfStaffGuideContent.swift in Sources */,
-				F5BD3FA4315CD2E0D8E33730 /* EvaChiefOfStaffGuideView.swift in Sources */,
-				FD83FBA515FA99D90DE5465C /* FlowPromptChipsView.swift in Sources */,
-				7C907B3AC77B5CAD3A68E7C1 /* ChatComposerView.swift in Sources */,
-				48B55AA334E364D314DCE8CB /* ChatComposerView+StructuredComposer.swift in Sources */,
-				73860C05746CA1B37767FA58 /* ChatStorageDegradedBanner.swift in Sources */,
-				5D45628FA820FA3BEB7A97D3 /* ChatScaffoldView.swift in Sources */,
-				63D0ECF6FEB314DC1FD1AFAD /* ChatScaffoldView+NavigationChrome.swift in Sources */,
+				E7DE591D7ACDB8FF504008CA /* LifeBoard/Onboarding/Models/OnboardingNotificationNameExtension.swift in Sources */,
+				8D8A8C8983C91CD1372CA1EB /* LifeBoard/Onboarding/Models/AppOnboardingAccessibilityID.swift in Sources */,
+				44E3EB20B7DF2407719E6B2F /* LifeBoard/Onboarding/Models/OnboardingCopy.swift in Sources */,
+				4F19404CD237ADA1ADE1F528 /* LifeBoard/Onboarding/Models/OnboardingProgress.swift in Sources */,
+				D4E0D80A4976DADBFEC9F159 /* LifeBoard/Onboarding/Models/onboardingLogLine.swift in Sources */,
+				17EF835E3AB7BCA161FBFB5C /* LifeBoard/Onboarding/Models/logOnboardingInfo.swift in Sources */,
+				8FE784A4B9FCFA802CE95542 /* LifeBoard/Onboarding/Models/logOnboardingError.swift in Sources */,
+				4A52BB8E16EAECC2A970E287 /* LifeBoard/Onboarding/Models/OnboardingOutcome.swift in Sources */,
+				8790268063CEA1C833D51C7A /* LifeBoard/Onboarding/Models/OnboardingStep.swift in Sources */,
+				83CBA72051A1B8A5580FB888 /* LifeBoard/Onboarding/Models/OnboardingPrimaryGoal.swift in Sources */,
+				04AD0E929FAB37FD57D8BCB8 /* LifeBoard/Onboarding/Models/OnboardingPainPoint.swift in Sources */,
+				70A9068D6C68CC20C0201150 /* LifeBoard/Onboarding/Models/OnboardingStarterHabitPreference.swift in Sources */,
+				E428ECADD6A89C0B1D7F174B /* LifeBoard/Onboarding/Models/OnboardingEvaPreparationPhase.swift in Sources */,
+				48756A3EF4DA7E57686EA3BF /* LifeBoard/Onboarding/Models/OnboardingEvaPreparationState.swift in Sources */,
+				C158FF33EA33FDAD9E137F25 /* LifeBoard/Onboarding/Models/OnboardingNetworkClass.swift in Sources */,
+				0ACC594D16D9F9D83D812052 /* LifeBoard/Onboarding/Models/OnboardingFrictionProfile.swift in Sources */,
+				D86B5C7DF619A7A577D4874F /* LifeBoard/Onboarding/Models/OnboardingMode.swift in Sources */,
+				AD8804130CE2160E653414FD /* LifeBoard/Onboarding/Models/OnboardingEntryContext.swift in Sources */,
+				125D26BDB072E9A8F3E515D7 /* LifeBoard/Onboarding/Models/OnboardingTaskTemplateState.swift in Sources */,
+				20F7A92A6373992D5B74E817 /* LifeBoard/Onboarding/Models/OnboardingHabitTemplateState.swift in Sources */,
+				EE1B64C0721BCF43D9599B65 /* LifeBoard/Onboarding/Models/OnboardingReminderPromptState.swift in Sources */,
+				E9974C1A3AC57A1E1E5B60CA /* LifeBoard/Onboarding/Models/WelcomeIntroPhase.swift in Sources */,
+				0B2EA9B1BC50C6D572DBDA14 /* LifeBoard/Onboarding/Models/OnboardingWorkspaceSnapshot.swift in Sources */,
+				5E62A1F6764E8C4158AE395D /* LifeBoard/Onboarding/Models/OnboardingEligibility.swift in Sources */,
+				01D3E1ADABC2FB7D419F301E /* LifeBoard/Onboarding/Models/AppOnboardingSummary.swift in Sources */,
+				D6988674F7729285A707C98C /* LifeBoard/Onboarding/Models/CodingKeys.swift in Sources */,
+				539FB9E50686C14B24DADEC8 /* LifeBoard/Onboarding/Models/OnboardingBreakdownStep.swift in Sources */,
+				0FF401A34059E3AECC2B14B1 /* LifeBoard/Onboarding/Models/OnboardingProjectDraft.swift in Sources */,
+				54E3898C156FECCEE5A57CE5 /* LifeBoard/Onboarding/Models/ResolvedLifeAreaSelection.swift in Sources */,
+				C017F11E0720B026D1DC1692 /* LifeBoard/Onboarding/Models/ResolvedProjectSelection.swift in Sources */,
+				66FBAD17B454FE9E6A36D30F /* LifeBoard/Onboarding/Models/OnboardingJourneySnapshot.swift in Sources */,
+				9B5D983BDED5F3B292E2920D /* LifeBoard/Onboarding/Models/CodingKeys2.swift in Sources */,
+				3BFDC99E090DF4551C917CE6 /* LifeBoard/Onboarding/Models/AppOnboardingState.swift in Sources */,
+				CE101A5DFCA6C30A72A5CE61 /* LifeBoard/Onboarding/Models/PendingOnboardingPresentation.swift in Sources */,
+				262A9D38982EE6BE9E44E616 /* LifeBoard/Onboarding/Models/OnboardingPresentationQueue.swift in Sources */,
+				CA588F0C88CA2D9300D59E10 /* LifeBoard/Onboarding/Services/AppOnboardingStateStore.swift in Sources */,
+				193F65F5AD20237F0366DCF8 /* LifeBoard/Onboarding/Models/StarterTaskTemplate.swift in Sources */,
+				13AFF7E41F28B08AD43AA900 /* LifeBoard/Onboarding/Models/StarterHabitTemplate.swift in Sources */,
+				E2B058A2C6F1249FA0248124 /* LifeBoard/Onboarding/Models/StarterProjectTemplate.swift in Sources */,
+				EAB76D638082DDE00237973C /* LifeBoard/Onboarding/Models/StarterLifeAreaTemplate.swift in Sources */,
+				F825BC32A2F154EF1E81504E /* LifeBoard/Onboarding/Models/StarterWorkspaceCatalog.swift in Sources */,
+				9BF910D455817C716D94F9D8 /* LifeBoard/Onboarding/Services/OnboardingEligibilityService.swift in Sources */,
+				036E9881C0F7EC40685393B7 /* LifeBoard/Onboarding/Services/HomeOnboardingGuidanceModel.swift in Sources */,
+				7FC722F1C850B171F2A2713E /* LifeBoard/Onboarding/Services/OnboardingFeedbackController.swift in Sources */,
+				AF82520CAEE921B7BE04E017 /* LifeBoard/Onboarding/Services/OnboardingFlowModel.swift in Sources */,
+				0512B30196300E86AE6ABE53 /* LifeBoard/Onboarding/Services/OnboardingFlowModel+CatalogPresentation.swift in Sources */,
+				FCC23D047188986E5F29D1EF /* LifeBoard/Onboarding/Services/OnboardingFlowModel+LifeAreaHabitTaskSetup.swift in Sources */,
+				4FDA467939746A454749A279 /* LifeBoard/Onboarding/Services/OnboardingFlowModel+EvaPreferencesAndDemo.swift in Sources */,
+				C3D50B7B0090C88C8F837DA5 /* LifeBoard/Onboarding/Services/OnboardingFlowModel+NavigationPersistence.swift in Sources */,
+				582890EBB89DC028C4FA8F9D /* LifeBoard/Onboarding/Services/OnboardingFlowModel+EvaActivationPreparation.swift in Sources */,
+				A88F93F1E4769FB8D7640E3E /* LifeBoard/Onboarding/Coordinator/AppOnboardingHostAdapter.swift in Sources */,
+				F0A15BDE3E582D2E951E98F4 /* LifeBoard/Onboarding/Components/HomeViewControllerExtension.swift in Sources */,
+				D38314D027D0FAD3E8DBD55A /* LifeBoard/Onboarding/Coordinator/AppOnboardingCoordinator.swift in Sources */,
+				A516ABAD2F7D26235B44C3A1 /* LifeBoard/Onboarding/Coordinator/AppOnboardingCoordinator+Presentation.swift in Sources */,
+				07F9DF04416807600DA792AA /* LifeBoard/Onboarding/Models/OnboardingInputField.swift in Sources */,
+				8689D743382AFB9679125174 /* LifeBoard/Onboarding/Views/AppOnboardingJourneyView.swift in Sources */,
+				7CBC9FB5197011346A405CEA /* LifeBoard/Onboarding/Views/AppOnboardingJourneyView+LayoutWelcomeAndGoal.swift in Sources */,
+				E36C6117443BE8E4989A930C /* LifeBoard/Onboarding/Views/AppOnboardingJourneyView+SetupSteps.swift in Sources */,
+				910A98F48562792C6651F69A /* LifeBoard/Onboarding/Views/AppOnboardingJourneyView+DemoPermissionsAndDock.swift in Sources */,
+				4DD16D458439FF0B85BA9CF7 /* LifeBoard/Onboarding/Views/AppOnboardingJourneyView+OutcomeDraftsAndActions.swift in Sources */,
+				8792E823650E54CA4E14AA8E /* LifeBoard/Onboarding/Views/AppOnboardingPromptSheetView.swift in Sources */,
+				14CDB6B6887E83C9AF1E8412 /* LifeBoard/Onboarding/Components/OnboardingPromptBackground.swift in Sources */,
+				28F2FC0F85DA578FDDEC4C32 /* LifeBoard/Onboarding/Components/OnboardingPromptChecklistCard.swift in Sources */,
+				C2FD7479882454D6E58D05D5 /* LifeBoard/Onboarding/Models/OnboardingPromptTheme.swift in Sources */,
+				DC1DB2042D99A4C779FADDCA /* LifeBoard/Onboarding/Components/OnboardingPromptValueCard.swift in Sources */,
+				11E1CAF9151542D119B4883B /* LifeBoard/Onboarding/Components/OnboardingPromptPrimaryCTAButtonStyle.swift in Sources */,
+				0ACC457D0516F36AB25D3367 /* LifeBoard/Onboarding/Models/OnboardingPromptGlassPanelModifier.swift in Sources */,
+				09CD9170481BB868874A059E /* LifeBoard/Onboarding/Models/OnboardingPromptFooterMaterialModifier.swift in Sources */,
+				86E90FFDD209E7304B7D5BBE /* LifeBoard/Onboarding/Components/HomeOnboardingGuidanceBanner.swift in Sources */,
+				90C6619892CA88CDC07F0618 /* LifeBoard/Onboarding/Models/OnboardingTheme.swift in Sources */,
+				BFE43C633C4F5FD1C5ED3D91 /* LifeBoard/Onboarding/Models/OnboardingPastelPalette.swift in Sources */,
+				2F9410224630703F3E950DDD /* LifeBoard/Onboarding/Models/OnboardingStepVisualTheme.swift in Sources */,
+				B696207D77139D62369E4954 /* LifeBoard/Onboarding/Models/OnboardingConcentricColorField.swift in Sources */,
+				98327A7BB4DC3205D53A6D32 /* LifeBoard/Onboarding/Models/OnboardingConcentricTransitionLayer.swift in Sources */,
+				6A791794B107ED921F62EF41 /* LifeBoard/Onboarding/Models/OnboardingFloatingNextAction.swift in Sources */,
+				4C1EDC5A08CA68696B5EADD9 /* LifeBoard/Onboarding/Components/OnboardingFloatingNextButton.swift in Sources */,
+				13E26BA7B62EB8B9BACF274E /* LifeBoard/Onboarding/Views/AppOnboardingBackground.swift in Sources */,
+				AF46E4534CA58DD946E8AF43 /* LifeBoard/Onboarding/Models/OnboardingSectionHeader.swift in Sources */,
+				89F6DD86DEF66E5F787909B1 /* LifeBoard/Onboarding/Models/OnboardingEyebrowLabel.swift in Sources */,
+				38B214F1E69681E0A58C8665 /* LifeBoard/Onboarding/Components/OnboardingTrustRow.swift in Sources */,
+				CB80F340473A31AFE8CF162A /* LifeBoard/Onboarding/Components/OnboardingHeroMediaAsset.swift in Sources */,
+				980E67E8DC345CD40457C5BD /* LifeBoard/Onboarding/Components/OnboardingCinematicBackdrop.swift in Sources */,
+				CAE86C460FCB7CB9FA6C9AE2 /* LifeBoard/Onboarding/Models/OnboardingAccessibilityMarker.swift in Sources */,
+				8C023F1274CF5FC1D02A717C /* LifeBoard/Onboarding/Views/OnboardingAccessibilityMarkerView.swift in Sources */,
+				7069388CBB2CDAEB362DA386 /* LifeBoard/Onboarding/Models/OnboardingWelcomeCinematicOverlay.swift in Sources */,
+				D65596F60D499A8BB32EFBD4 /* LifeBoard/Onboarding/Models/OnboardingWelcomeIntroLine.swift in Sources */,
+				F3C1E701D90B17B69DA1D98C /* LifeBoard/Onboarding/Views/OnboardingHeroVideoView.swift in Sources */,
+				937B562AC1B7C19DC318F1B1 /* LifeBoard/Onboarding/Views/OnboardingLoopingPlayerView.swift in Sources */,
+				0C2ECCAB66276D4F1B630EBE /* LifeBoard/Onboarding/Components/OnboardingFrictionSelector.swift in Sources */,
+				B15275C8511EAB14F4112515 /* LifeBoard/Onboarding/Components/OnboardingFrictionSelectorLayout.swift in Sources */,
+				80AECAD4D9127F42BFAA8304 /* LifeBoard/Onboarding/Components/OnboardingFrictionSelectorWidthPreferenceKey.swift in Sources */,
+				00E2B96FE676ECE56D1C1587 /* LifeBoard/Onboarding/Components/OnboardingSelectionSummaryCard.swift in Sources */,
+				CDFF51674BB1F653FF14260A /* LifeBoard/Onboarding/Models/OnboardingMascotCarousel.swift in Sources */,
+				BF2F6F85EA92C566A31BB5D4 /* LifeBoard/Onboarding/Components/OnboardingCustomEntryRow.swift in Sources */,
+				C2421458D3A338445B13FBE6 /* LifeBoard/Onboarding/Components/OnboardingInlineActionRow.swift in Sources */,
+				3F64B79D565266A18289D9CC /* LifeBoard/Onboarding/Models/OnboardingDownloadStatusStrip.swift in Sources */,
+				1274375D849BBF28D4DF1408 /* LifeBoard/Onboarding/Models/OnboardingDownloadStatusPill.swift in Sources */,
+				32FB0E5EB16490C5930975F4 /* LifeBoard/Onboarding/Components/OnboardingPermissionHeroIcon.swift in Sources */,
+				982DF7E1D0152A8257DDFCF5 /* LifeBoard/Onboarding/Models/OnboardingHomeDemoSnapshotFactory.swift in Sources */,
+				BE3795CCDFC49D30531F1016 /* LifeBoard/Onboarding/Components/OnboardingHomeDemoPreview.swift in Sources */,
+				0122C4D3D195380D2CDCBED5 /* LifeBoard/Onboarding/Components/OnboardingChecklistCard.swift in Sources */,
+				6D6E90ED524D19DBBBC00FD2 /* LifeBoard/Onboarding/Components/OnboardingChecklistRow.swift in Sources */,
+				63D15C0A35A7BF3479A69D30 /* LifeBoard/Onboarding/Components/OnboardingSelectableDetailCard.swift in Sources */,
+				1842D1AB7AB9D66E5A024CEE /* LifeBoard/Onboarding/Components/OnboardingFilterChip.swift in Sources */,
+				18BC4EA3F8C23BB362367B1B /* LifeBoard/Onboarding/Components/OnboardingHabitStreakPreviewCard.swift in Sources */,
+				DA81A406247E701A8EE98417 /* LifeBoard/Onboarding/Models/OnboardingMiniMetric.swift in Sources */,
+				10BDA207EE601292AB9E1231 /* LifeBoard/Onboarding/Components/OnboardingTaskPreviewCard.swift in Sources */,
+				CB0E20CDE17573CE6A56AEFF /* LifeBoard/Onboarding/Models/OnboardingCompactHabitRail.swift in Sources */,
+				B430108C7AE1B927B9B1FB58 /* LifeBoard/Onboarding/Components/OnboardingEvaStatusCard.swift in Sources */,
+				C6D12F2061A8EBCCFD6346DA /* LifeBoard/Onboarding/Components/OnboardingFrictionOptionCard.swift in Sources */,
+				DA50FEA644495EB466054A2B /* LifeBoard/Onboarding/Components/OnboardingSelectableCard.swift in Sources */,
+				5ABA1E0B75C50F023148D89F /* LifeBoard/Onboarding/Components/OnboardingHabitRecommendationCard.swift in Sources */,
+				9A7AA6C367FAD2093F16DB77 /* LifeBoard/Onboarding/Components/OnboardingTaskRecommendationCard.swift in Sources */,
+				59FE36E7A9A47274A3D610FC /* LifeBoard/Onboarding/Components/OnboardingPressScaleButtonStyle.swift in Sources */,
+				62DA1F2B6CF478CD9F07E040 /* LifeBoard/Onboarding/Components/OnboardingPrimaryCTAButtonStyle.swift in Sources */,
+				EB9FD2ECFB4D4AD697D091F3 /* LifeBoard/Onboarding/Models/OnboardingInlineBadge.swift in Sources */,
+				0B3ACC1A28B21B661E547518 /* LifeBoard/Onboarding/Components/OnboardingFocusHeroCard.swift in Sources */,
+				6EDF2C884AFF7BC3644F93F7 /* LifeBoard/Onboarding/Models/OnboardingFocusTimer.swift in Sources */,
+				C3B88D39DA52634C915E96AE /* LifeBoard/Onboarding/Components/OnboardingSuccessHero.swift in Sources */,
+				2E5BDB7E8B94F068AE98C73B /* LifeBoard/Onboarding/Components/OnboardingSuccessSummaryCard.swift in Sources */,
+				7445A553C6B57662C98F3C2C /* LifeBoard/Onboarding/Components/OnboardingSuccessSummaryRow.swift in Sources */,
+				974FDA7040049B93F737E5B9 /* LifeBoard/Onboarding/Models/onboardingNaturalLanguageList.swift in Sources */,
+				390DB347BE033669B7CF9A28 /* LifeBoard/Onboarding/Components/ViewExtension.swift in Sources */,
+				02828F570030008E7C1B441C /* LifeBoard/Onboarding/Models/LifeAreaRepositoryProtocolExtension.swift in Sources */,
+				25FC3C1A435E0F8199ADBCD5 /* LifeBoard/Onboarding/Models/ProjectRepositoryProtocolExtension.swift in Sources */,
+				B3002EA7B07545C684BF2B16 /* LifeBoard/Onboarding/Models/HabitRepositoryProtocolExtension.swift in Sources */,
+				ABB8A81FC820F8057D7D0BB1 /* LifeBoard/Onboarding/Models/TaskDefinitionRepositoryProtocolExtension.swift in Sources */,
+				35EE69887A851F70BD73AB93 /* LifeBoard/Onboarding/Models/ManageLifeAreasUseCaseExtension.swift in Sources */,
+				56DF97BE6987C2AFF6929D47 /* LifeBoard/Onboarding/Models/ManageProjectsUseCaseExtension.swift in Sources */,
+				90D12F41EEB78A45B410CCDA /* LifeBoard/Onboarding/Models/CreateTaskDefinitionUseCaseExtension.swift in Sources */,
+				9B356B21E02F7FF4F6D8A6E2 /* LifeBoard/Onboarding/Models/CreateHabitUseCaseExtension.swift in Sources */,
+				971C0B6E09B4E9AA9B0F3939 /* LifeBoard/Onboarding/Models/ManageHabitsUseCaseExtension.swift in Sources */,
+				396F9CD34E10195B8C5FE0F7 /* LifeBoard/Onboarding/Models/CompleteTaskDefinitionUseCaseExtension.swift in Sources */,
+				094363D420BA00C23B9DC952 /* LifeBoard/Onboarding/Models/ResolveHabitOccurrenceUseCaseExtension.swift in Sources */,
+				69170C2AAEAA052519F64E78 /* LifeBoard/Onboarding/Services/CalendarIntegrationServiceExtension.swift in Sources */,
+				7FD844573284EB98B015104F /* LifeBoard/Onboarding/Services/NotificationServiceProtocolExtension.swift in Sources */,
+				A6E41D973B02F8BBF91E0666 /* LifeBoard/Presentation/ViewModels/Home/LifeBoardCancellableDispatchWorkItem.swift in Sources */,
+				21D645FE5F1A842122F06A51 /* LifeBoard/Presentation/ViewModels/Home/HomeTaskDetailMetadataState.swift in Sources */,
+				E3553D65476C93716D966319 /* LifeBoard/Presentation/ViewModels/Home/HomeTaskDetailRelationshipMetadataState.swift in Sources */,
+				C3AC86F4BE2832B4E90C8467 /* LifeBoard/Presentation/ViewModels/Home/HomeDueTodayAgendaLoadState.swift in Sources */,
+				32004AA08DF5D7FE9587C767 /* LifeBoard/Presentation/ViewModels/Home/HomeCanonicalHabitMutationLoadState.swift in Sources */,
+				4835621B71E16E83CE9A39F5 /* LifeBoard/Presentation/ViewModels/Home/HomeHabitWidgetRowsState.swift in Sources */,
+				54F4A36D13378251013B4956 /* LifeBoard/Presentation/ViewModels/Home/DailySummaryLoadState.swift in Sources */,
+				6BE216860D602F917606397C /* LifeBoard/Presentation/ViewModels/Home/HomeTaskMutationEvent.swift in Sources */,
+				D2D43D1D68EDFA8B61A9D766 /* LifeBoard/Presentation/ViewModels/Home/HomeReloadScope.swift in Sources */,
+				F425DA7463D1A09323AFE4DE /* LifeBoard/Presentation/ViewModels/Home/HomeDateNavigationSource.swift in Sources */,
+				82FB6DE938FB3650E891FC88 /* LifeBoard/Presentation/ViewModels/Home/HomeDayNavigationDirection.swift in Sources */,
+				6CA88A6A8612FD806A55CEC5 /* LifeBoard/Presentation/ViewModels/Home/HomeDataRevision.swift in Sources */,
+				424A813126216FCDBB3BB9D3 /* LifeBoard/Presentation/ViewModels/Home/HomeRenderInvalidation.swift in Sources */,
+				DB20D31BAB145922299137A0 /* LifeBoard/Presentation/ViewModels/Home/HomeTimelineWorkspacePreferencesSignature.swift in Sources */,
+				23D6A9438FB6BD00F6A8483A /* LifeBoard/Presentation/ViewModels/Home/HomeTimelineEventSignature.swift in Sources */,
+				0D84D0166C11E5E8015ACA82 /* LifeBoard/Presentation/ViewModels/Home/HomeTimelineSnapshotCacheKey.swift in Sources */,
+				86A93997F7D4FD6F2D0E4D4F /* LifeBoard/Presentation/ViewModels/Home/HomeTimelineCalendarSignature.swift in Sources */,
+				EC45E6BBD381E86DD65D5EDF /* LifeBoard/Presentation/ViewModels/Home/HomeTimelineReplanCandidateSignature.swift in Sources */,
+				E322491389C9B239A6D3BA57 /* LifeBoard/Presentation/ViewModels/Home/HomeTimelineReplanPhaseSignature.swift in Sources */,
+				1A469FF8CAAD8B2B7D9A2FEF /* LifeBoard/Presentation/ViewModels/Home/HomeTimelineReplanStateSignature.swift in Sources */,
+				6F8AE9CBE66BD30649B53BF2 /* LifeBoard/Presentation/ViewModels/Home/HomeReplanResolutionKind.swift in Sources */,
+				19B603FD5B8EFE10233D20EE /* LifeBoard/Presentation/ViewModels/Home/HomeReplanUndoEntry.swift in Sources */,
+				9EAAFEDF8331B11C56CDDA0F /* LifeBoard/Presentation/ViewModels/Home/HabitRecoveryReflectionPrompt.swift in Sources */,
+				B5A18D04B79585D76C0CE5D9 /* LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationFeedbackHaptic.swift in Sources */,
+				41C931CFD888EF92197B0D24 /* LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationFeedback.swift in Sources */,
+				56E4DCAE5C1E65F706523538 /* LifeBoard/Presentation/ViewModels/Home/HomeReloadBatchTracker.swift in Sources */,
+				1189D09985E33267B5E56A34 /* LifeBoard/Presentation/ViewModels/Home/NSLockExtension.swift in Sources */,
+				16FDAE94A8B5B7D16F330DF2 /* LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationRequest.swift in Sources */,
+				1D443F47BB19EE9B20BFC4EE /* LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationKey.swift in Sources */,
+				263B577D54B198C0599992DE /* LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationSnapshot.swift in Sources */,
+				C97CA61FED91A0C2BE4E3AB1 /* LifeBoard/Presentation/ViewModels/Home/HomeDerivedTaskRowsCache.swift in Sources */,
+				6CBA9A1192D4C0870A538CB6 /* LifeBoard/Presentation/ViewModels/Home/HomeDerivedHabitRowsCache.swift in Sources */,
+				49BE8D232D0B830AC1D787AA /* LifeBoard/Presentation/ViewModels/Home/HomeHabitMutationSectionPatch.swift in Sources */,
+				328B171396378ED1B150C54A /* LifeBoard/Presentation/ViewModels/Home/HomeHabitRowPlacementBucket.swift in Sources */,
+				C280C01585D08BFD8692758E /* LifeBoard/Presentation/ViewModels/Home/HomeHabitRowPlacement.swift in Sources */,
+				973C96958E583C28BB9194A3 /* LifeBoard/Presentation/ViewModels/Home/HomeTaskReloadNotificationEvent.swift in Sources */,
+				58361669F430895FBF2918C5 /* LifeBoard/Presentation/ViewModels/Home/FocusPinResult.swift in Sources */,
+				7F4CC1257A958D8992586922 /* LifeBoard/Presentation/ViewModels/Home/FocusPromotionResult.swift in Sources */,
+				689BD052F12F388961F9C63C /* LifeBoard/Presentation/ViewModels/Home/HomeNotificationNameExtension.swift in Sources */,
+				F260B975BFD99463197CD6A0 /* LifeBoard/Presentation/ViewModels/Home/CelebrationKind.swift in Sources */,
+				F64C9A3B63E962670DB86280 /* LifeBoard/Presentation/ViewModels/Home/CelebrationEvent.swift in Sources */,
+				B7B914D911EA894F24D58E27 /* LifeBoard/Presentation/ViewModels/Home/CelebrationPresentation.swift in Sources */,
+				CEBD06B0323F598F2C11A5DC /* LifeBoard/Presentation/ViewModels/Home/CelebrationRouter.swift in Sources */,
+				539F4B713CA94D564337B279 /* LifeBoard/Presentation/ViewModels/Home/DefaultCelebrationRouter.swift in Sources */,
+				C68012797DEDCF3D065BBA45 /* LifeBoard/Presentation/ViewModels/Home/InsightsLaunchRequest.swift in Sources */,
+				160F368EB1102A7D052D2220 /* LifeBoard/Presentation/ViewModels/Home/HomeOverdueRescueLauncherState.swift in Sources */,
+				0EC49C3CF56F9FF0863151BD /* LifeBoard/Presentation/ViewModels/Home/HomeViewModelRoot.swift in Sources */,
+				181CC936773A7F7700000000 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+Bindings.swift in Sources */,
+				050AE50E81D4703777D6F0C1 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+RenderTransaction.swift in Sources */,
+				5EA366582815849801B3F3F2 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+AnalyticsRefresh.swift in Sources */,
+				0F97D0D0CB26167BF4F3E1DD /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+DailyReflectionPreview.swift in Sources */,
+				220B2D5DF3B84749D8AABC99 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+DailySummaryModal.swift in Sources */,
+				DC94FAFADB950991425D291B /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+DateNavigation.swift in Sources */,
+				16E09E0E5A4633E33062DF74 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+DueTodayAgenda.swift in Sources */,
+				9E5BA6BF68993D536CEA3AC5 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+EvaRescueActions.swift in Sources */,
+				170D294E77D3B8898DFD0D85 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+FocusPins.swift in Sources */,
+				9092BD6AC3FACD1123284752 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+FocusSessions.swift in Sources */,
+				F3240A09F43701C96CE99815 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+FocusWhyCandidates.swift in Sources */,
+				DF610ABA86EAF98C49C6278A /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+HabitActionShortcuts.swift in Sources */,
+				BDAFA3BFCD791B15C8DB9A9D /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+HabitReconciliation.swift in Sources */,
+				E7CF89A56979F3789A7ED0E0 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+InitialLoading.swift in Sources */,
+				43672EBCA0F500EAA29B3088 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+InsightsLaunch.swift in Sources */,
+				67A73E4B61D4A82E1336EA51 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+ProjectionInvalidation.swift in Sources */,
+				CD7AADFB07AFA97B5C0D6452 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+RecurringTopUp.swift in Sources */,
+				78DE25A4719C53B4CB4EA8E0 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+ReferenceDataLoading.swift in Sources */,
+				20E905AEA02392CC5482222E /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+RescueEligibility.swift in Sources */,
+				60077665EB3D3BDC56741ED6 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+TaskDetailMetadata.swift in Sources */,
+				E39BA7BC60FB71563853AE5F /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+RefreshEntryPoints.swift in Sources */,
+				041BEC95EB82F86644971605 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+TaskActions.swift in Sources */,
+				6868D7DE1D836622DADA12CD /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+TaskCreationDependencies.swift in Sources */,
+				44E3D8F1869822A9B8AFE2F9 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+FiltersAndSavedViews.swift in Sources */,
+				429BC3BC461278EFC2DCE53B /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+EvaFocus.swift in Sources */,
+				8B4908D385E24901840412E6 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+RescueUndo.swift in Sources */,
+				6C55EB9AB6FB62999A3A710D /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+DailyAnalytics.swift in Sources */,
+				3273E07D3C81B8301BCC6111 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+HabitMutations.swift in Sources */,
+				BD46BE503829CCD15E61E839 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+HabitMutationPatching.swift in Sources */,
+				8C6F6176F05C02D99369AB30 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+ReloadPipeline.swift in Sources */,
+				7C4E89225AA28D69904278A9 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+SectionProjection.swift in Sources */,
+				E01C6D15AED947A29929589A /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+FocusRankingAndWidgetSnapshot.swift in Sources */,
+				446C1ECFEE836138F6A2FC04 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+ReloadBatchingAndReplanLauncher.swift in Sources */,
+				8968A51E3DD681D2B360D98C /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+NeedsReplanStateAndPlacement.swift in Sources */,
+				61C740CCAEA2AAD70648F5FB /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+CompletionProjection.swift in Sources */,
+				8D7BDD59803F690867AC75C8 /* LifeBoard/Presentation/ViewModels/Home/HomeViewModel+StateUtilities.swift in Sources */,
+				E74EA3C46BB64BDD2E97F053 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamInfluenceKind.swift in Sources */,
+				5F143687250957A73D400A49 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamInfluence.swift in Sources */,
+				821E0BCBE223961EAB4DC4BD /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamInfluenceExtension.swift in Sources */,
+				21F6DC4C03DB207B0F93B967 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamDirection.swift in Sources */,
+				7051BB581E31CCD8EC76429E /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamAnchor.swift in Sources */,
+				C6763538C5D158A7E8967D88 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamSegment.swift in Sources */,
+				3832EF761CF5E6940EC8391C /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamSample.swift in Sources */,
+				F3C3DA3A987F1E361784B3C3 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamGeometry.swift in Sources */,
+				58DE2299787427B905EC9D9E /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamGeometry+LaneLayoutAndPaths.swift in Sources */,
+				F078AE75786C51F7F4F78ABA /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamGeometry+MassClustering.swift in Sources */,
+				C3FB1D92DD198DC445CB8DB7 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamLayerSpec.swift in Sources */,
+				653F0562A00EC4FD085B2436 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineNowBeadPresentation.swift in Sources */,
+				8ECE25D7C3266F62DF4D3888 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCanvasLayoutPlan.swift in Sources */,
+				C4BB75857943B70FDC94219A /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCanvasLayoutPlan+VisualTimeMapping.swift in Sources */,
+				4B6D91346B20578BE27DD080 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCanvasLayoutPlan+Positioning.swift in Sources */,
+				2CBC973505B2E0B6424541FB /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompactLayoutPlan.swift in Sources */,
+				1E7D50D956C53289A4DC9691 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineFormatting.swift in Sources */,
+				7208997F226E7C45527E0F1D /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineItemVisuals.swift in Sources */,
+				9399E0A93BBEBA504BB0526D /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineDayRelation.swift in Sources */,
+				F7B0AB4286AC80DE2918E298 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineDayStablePresentation.swift in Sources */,
+				E776248C1D58F4223BE929E3 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineDayCurrentState.swift in Sources */,
+				B344A818A99590F452C10FC9 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineDayPresentation.swift in Sources */,
+				23D6911A2603575D6C3B32B4 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineVisualTokens.swift in Sources */,
+				4F71CEC7E0020E4BDABEB6A7 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineSurfaceMetrics.swift in Sources */,
+				13B527B121DA29E15716552A /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailMetrics.swift in Sources */,
+				2EAFE882376B87E7901A885D /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineSpineMounting.swift in Sources */,
+				7211B3D09FA27E8048BAF208 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailLabelKind.swift in Sources */,
+				84F7B021F3EAE4E07C455703 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailTypography.swift in Sources */,
+				3B95A6809B4D22F1D58A51E2 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailTimeFormatter.swift in Sources */,
+				F4CE8A08BB795C67615BDCB1 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineRoutineTextFormatter.swift in Sources */,
+				3BF5A228B4CE3008B8672DA1 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineBottomProtectionBudget.swift in Sources */,
+				A68140FD4222813E17094331 /* LifeBoard/Presentation/Home/Timeline/Surface/timelineDisplayedNow.swift in Sources */,
+				0CE03D5DE6944FB2FE2FBA3F /* LifeBoard/Presentation/Home/Timeline/Surface/timelineSuggestedAddDate.swift in Sources */,
+				7527F27DE6CAFC928FF07E85 /* LifeBoard/Presentation/Home/Timeline/Surface/timelineMetaText.swift in Sources */,
+				8C6F80184376D9187D2B39B9 /* LifeBoard/Presentation/Home/Timeline/Surface/timelineMetaColor.swift in Sources */,
+				0C972AF626F688F063459503 /* LifeBoard/Presentation/Home/Timeline/Surface/timelineTitleColor.swift in Sources */,
+				926138681C7DEC596E8C4F5D /* LifeBoard/Presentation/Home/Timeline/Surface/timelineRingColor.swift in Sources */,
+				7DBF73B54FC410E442F25A41 /* LifeBoard/Presentation/Home/Timeline/Surface/timelineAccessibilityLabel.swift in Sources */,
+				05017EDD38C8DCBBD917220C /* LifeBoard/Presentation/Home/Timeline/Surface/timelineAccessibilityIdentifier.swift in Sources */,
+				4455C821CEE50484216FDFC3 /* LifeBoard/Presentation/Home/Timeline/Surface/timelineRailText.swift in Sources */,
+				7241D3EE88E0D3355DDECF0D /* LifeBoard/Presentation/Home/Timeline/Surface/timelineStemColor.swift in Sources */,
+				DA083B470E02C697ADD728B8 /* LifeBoard/Presentation/Home/Timeline/Surface/timelineGapPromptText.swift in Sources */,
+				6958B671C35CEBA029BF084D /* LifeBoard/Presentation/Home/Timeline/Surface/gapPromptTint.swift in Sources */,
+				5063FF3626FB43ED4C7032FF /* LifeBoard/Presentation/Home/Timeline/Surface/timelineCapsuleHeight.swift in Sources */,
+				97503DD4CD8A6F7E1E6894B8 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineUtilityItemExtension.swift in Sources */,
+				55A4869DF1D5E4DD89557A1D /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailPresentationSpec.swift in Sources */,
+				2D8D1185CFE2993F5861CAC2 /* LifeBoard/Presentation/Home/Timeline/Surface/SunriseTimelineSurfaceRoot.swift in Sources */,
+				09C4C3472A904F2E9C0E819A /* LifeBoard/Presentation/Home/Timeline/Surface/SunriseTimelineSurface+PlacementHelpers.swift in Sources */,
+				52CB4508EA7C96B9940B6799 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelinePlacementPrompt.swift in Sources */,
+				FA2867EC44B15B0F834583B7 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelinePlacementDock.swift in Sources */,
+				2DAC4DF99D4D0356E58AC4C2 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelinePalette.swift in Sources */,
+				E4EE09FF5DA5E3D7530F0D94 /* LifeBoard/Presentation/Home/Timeline/Surface/SunriseTimelineBar.swift in Sources */,
+				7E4A49A2CC73B3C46AB49388 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelinePlanningShelf.swift in Sources */,
+				DF7287CB7D22A27B0D68A9AD /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineShelfItemCard.swift in Sources */,
+				EA9B4B976075D91EAB6902EB /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineInboxPlanningCard.swift in Sources */,
+				6372B9063E39D08CCAF5A8C9 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCurrentTimeRule.swift in Sources */,
+				4F4C0C5EE35B10B8DE2B66B8 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCurrentTimeMarker.swift in Sources */,
+				6F0B5225F22BF0C2D1AEDFB5 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineRailLabel.swift in Sources */,
+				75F707F2E6238335515F2AAE /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineSpineEndView.swift in Sources */,
+				03C55431D0F00584B024BACF /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamPalette.swift in Sources */,
+				A7CA2FCA1F9D09173330EAA2 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStreamGlintPresentation.swift in Sources */,
+				1138787A92BD5440BF7B4D2D /* LifeBoard/Presentation/Home/Timeline/Surface/CurvingDayStreamView.swift in Sources */,
+				8E7D7A391577BD986A03B7A9 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineNowBeadView.swift in Sources */,
+				1E448F0CF8BEEFF9349F0F7E /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineLongGapIndicator.swift in Sources */,
+				032A6D4BF36C354B8064310D /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineEndAddMarker.swift in Sources */,
+				10F906589FFC0DE720F5FEB2 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineEmptyStateCard.swift in Sources */,
+				6A2E1305DB4B80D3BE0925F4 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineEmptyStateActionTone.swift in Sources */,
+				FE8EC07F1D05E4B12382FEA9 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineDenseTitleFormatter.swift in Sources */,
+				F6BF00E2BC75CA6D7EA0D449 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineNormalItemCard.swift in Sources */,
+				A72AC20CB4A49927EC98D3C6 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineTaskMarkerLayout.swift in Sources */,
+				94105F04150FE16142615C03 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineTaskMarkerRow.swift in Sources */,
+				319DAA1BD9A0076B2E78F2C7 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineFlockBlock.swift in Sources */,
+				94BE392CBEE903C8468E2899 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineFlockRowView.swift in Sources */,
+				96DB3A4F8D7B4B6FDF37EED5 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineOverlapClusterCard.swift in Sources */,
+				2721FCB8D7ABE25DBC7508B1 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineOverlapItemCard.swift in Sources */,
+				03EE1F33BC0AB56FA78CCCBE /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineTimeBlockCard.swift in Sources */,
+				60756010B1F282A96E52851C /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineTaskBlockRow.swift in Sources */,
+				91FD9F166D26C453EBA6BF67 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineMeetingBlockRow.swift in Sources */,
+				8C9CDC17702E6AC04114BAE5 /* LifeBoard/Presentation/Home/Timeline/Surface/DailyTimelineCanvas.swift in Sources */,
+				57F03D79758CC9FB3B892D91 /* LifeBoard/Presentation/Home/Timeline/Surface/DailyTimelineCanvas+RailAndCanvas.swift in Sources */,
+				320E8E819E057D02D689989F /* LifeBoard/Presentation/Home/Timeline/Surface/DailyTimelineCanvas+ItemRendering.swift in Sources */,
+				4B65F890786EE2C3F5A39C2C /* LifeBoard/Presentation/Home/Timeline/Surface/DailyTimelineCompactView.swift in Sources */,
+				D4ABAC9936B71C3DEB673B49 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompactAnchorRow.swift in Sources */,
+				CABA353295DF444EC908D3CC /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompactItemRow.swift in Sources */,
+				7A41D73D8C289095E3560DB5 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompactGapRow.swift in Sources */,
+				D705016D0D6D308050273D76 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompactConnector.swift in Sources */,
+				032EBA2A2DF996C1E0110D70 /* LifeBoard/Presentation/Home/Timeline/Surface/DailyTimelineAgendaView.swift in Sources */,
+				A647A4ACDED4835C9EA6C0D6 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineAgendaAnchorRow.swift in Sources */,
+				7AB21ECF758F38938E8A5EE7 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineAgendaItemRow.swift in Sources */,
+				A97A6E7A7869366C7EF25D0E /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineStemSegments.swift in Sources */,
+				108EDCB9266B21C80D773BBC /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineUtilityRow.swift in Sources */,
+				1225D0DCBDEB90ACA96B6B5F /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCapsule.swift in Sources */,
+				61EAA0A5C594CBB9F626A7C1 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineCompletionRing.swift in Sources */,
+				F40B68EBDD554016F132F4E0 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineGapPrompt.swift in Sources */,
+				2E47612416B8D316F93760D1 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineGapExtension.swift in Sources */,
+				D57A320DF8A2202069F711FB /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineBackdropWeekView.swift in Sources */,
+				BE57DA6C896F7EF32A6C3D87 /* LifeBoard/Presentation/Home/Timeline/Surface/TimelineWeekDayCell.swift in Sources */,
+				91FD6A303660EEF5294F7902 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeTimeIntervalExtension.swift in Sources */,
+				EF8AD806AA6D1C9D47FA2BDE /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomePerformanceSignposts.swift in Sources */,
+				CE266F5395572A3FFC2150D1 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeHabitSectionCardHost.swift in Sources */,
+				0DDCFBDB474413795EC30643 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeCalendarEventDetailSelection.swift in Sources */,
+				8B28B02DAA779156218510BB /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeCalendarEventDetailSheet.swift in Sources */,
+				DC9F1811662585E9D53AA8FA /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseHomeDatePickerPopover.swift in Sources */,
+				5B7BAB6078EBCDB6CC9F7B7E /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellViewRoot.swift in Sources */,
+				5C336D92A4C8046FB4291347 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+DerivedState.swift in Sources */,
+				6C361AE75951A20D4AA68C5B /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+RescueOverlays.swift in Sources */,
+				F14217E9721A35DF328C2F66 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+HomeScreenComposition.swift in Sources */,
+				6BDDCD87B9F9CF4256048C93 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+ObserversSearchAndBackdrop.swift in Sources */,
+				ACF0BB7B85C9268CD15869B1 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+FacesAndSearchChat.swift in Sources */,
+				DC90B81FA56C3F8715AD26A1 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+SearchSurface.swift in Sources */,
+				DF8962905A29B85F26BDA46D /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+TaskListAndDaySwipe.swift in Sources */,
+				E86FFAEB786065858AD5DFD4 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+TimelineSurface.swift in Sources */,
+				79A0BA40A86AF0524E6A1802 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+CalendarFooterAndTrackingRail.swift in Sources */,
+				4EFCDE37C57E117EA5041D85 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+HabitsAgendaAndFocusStrip.swift in Sources */,
+				55A68085778A4B9EA4FAC65D /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+FocusInsightsAndRouting.swift in Sources */,
+				D697AD981C87D4D7D84A6EF0 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/SunriseAppShellView+FocusTimersAndReflection.swift in Sources */,
+				3E939305B64D29F91B6C188B /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/CalendarCardChromeModifier.swift in Sources */,
+				AF5A65D3A0CB556B850BFC01 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/InsightsActionIntentExtension.swift in Sources */,
+				6FB7164807B1BD76EEF6B571 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeStaggerModifier.swift in Sources */,
+				117D70E33461D260AF2A46C1 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/HomeDenseSurfaceModifier.swift in Sources */,
+				C01EF007CBD4512099E412AF /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/QuietTrackingRailStreakWidget.swift in Sources */,
+				A48DB3A40E4B91F10D54B6B3 /* LifeBoard/Presentation/Home/Shell/SunriseAppShell/OverdueRescueLauncherOverlayView.swift in Sources */,
+				C27DED3B1AE919A68A5FA783 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDeckState.swift in Sources */,
+				0EC4FE8730866512296A0674 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDecisionSource.swift in Sources */,
+				0A2C5397D36D0D8C6B082AE8 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDecisionAction.swift in Sources */,
+				0AA9543F5B27EAE43ABA8843 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/RecurrenceInstanceSnapshot.swift in Sources */,
+				082C004A39ABC9840802B32C /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueUndoRecord.swift in Sources */,
+				ECF7EF4565293CE7F54AD9E8 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSummary.swift in Sources */,
+				DF045C31DEEDEEFC1A5F26EA /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSessionScope.swift in Sources */,
+				8D7E0FDB18955B5CE76F16C6 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSessionState.swift in Sources */,
+				BA1DA60A9EB08E7E655CD957 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSessionStore.swift in Sources */,
+				514DDD3FB2EC2CD49EC01B12 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/UserDefaultsOverdueRescueSessionStore.swift in Sources */,
+				5986289E16E72070D526991E /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueStateMachine.swift in Sources */,
+				ED47AF6B2834E824484A40C5 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDeckLayoutMetrics.swift in Sources */,
+				7B986AAE5765AADF671B17D9 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDeckCopy.swift in Sources */,
+				546344BD2EA4D1FE47598FBB /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescuePalette.swift in Sources */,
+				FC7A4DCCA6C83872D730A8BF /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueVisualSpec.swift in Sources */,
+				86A6A4A15FEE67AF21983B22 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSwipeRevealKind.swift in Sources */,
+				A2A1CBE7757AA1C9B5EA668E /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDragResolution.swift in Sources */,
+				525C6689F6C181E296086096 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDragResolver.swift in Sources */,
+				3726D051C70DA7D059BBC8F4 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueCardModel.swift in Sources */,
+				6EEA323B3C94CC3D3875A12A /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueMoveLaterResolver.swift in Sources */,
+				92ED5FEA6361F15C79382539 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueEligibilityService.swift in Sources */,
+				81EB32FF0E69DB807E839151 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueViewModel.swift in Sources */,
+				BF85F977D5CE48A00E45CB52 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueViewModel+CardActions.swift in Sources */,
+				182AF6ED0E5475309A58CDF0 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueViewModel+SessionPersistence.swift in Sources */,
+				0C1F3166AD2FCCA3FF3814DC /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueEditDraft.swift in Sources */,
+				2C4A24B77FA545940760F514 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/EvaOverdueRescueSheetV2Root.swift in Sources */,
+				9FCA8998FEF6F2B292163FB1 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDeckView.swift in Sources */,
+				2C9423200947462BB96E027D /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueBackCards.swift in Sources */,
+				223050CBCB2512809C97BFE4 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueTaskCard.swift in Sources */,
+				A523362EF6446433532CC824 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueRevealPanel.swift in Sources */,
+				21828AB3835916ECE946A73F /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueDeleteOverlay.swift in Sources */,
+				F71A150EACB33EB7B19F1E24 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSwipeHint.swift in Sources */,
+				FB8B2B57A23CA5361BE9C535 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueActionGrid.swift in Sources */,
+				2E5FB69076ABDE23D77BDCF4 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueQuickEditSheet.swift in Sources */,
+				8693C29C9C7147AC903DA772 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSafeFixesView.swift in Sources */,
+				E7526D26F32780AEE900BAFA /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescuePauseView.swift in Sources */,
+				92B41286923165E8B772C985 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueCompletionView.swift in Sources */,
+				5B0A4FDD9721341E85EF7093 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueLargeStackView.swift in Sources */,
+				E47B01A4B384D82C914661A4 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueErrorView.swift in Sources */,
+				13654561D6AE1564FAA82441 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueBackground.swift in Sources */,
+				19062C6842CD068931CB3D63 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescuePlant.swift in Sources */,
+				96E8DB75698F710B91E6C77D /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueCupHero.swift in Sources */,
+				7EFC7582344FA582791827CA /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueShieldHero.swift in Sources */,
+				60200C66D978383E5757D92D /* LifeBoard/Presentation/Home/Modals/OverdueRescue/OverdueRescueSunriseHero.swift in Sources */,
+				E4DF33BE9BD8B06FF928DA81 /* LifeBoard/Presentation/Home/Modals/OverdueRescue/LifeBoardProgressBar.swift in Sources */,
+				1D8B3A4014113650D7298CA5 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerRoute.swift in Sources */,
+				87A099A8CE32334354449960 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementTreeInteractionMode.swift in Sources */,
+				64978B8A3598BEE330C5F52D /* LifeBoard/Views/Settings/LifeManagement/LifeManagementViewRoot.swift in Sources */,
+				563FA0843C94B94146D0A715 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementView+BrowserAndTree.swift in Sources */,
+				78A4D4DB20E3D0A3034A5E57 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementView+DetailsComposerAndOverlays.swift in Sources */,
+				1AC6BA7B2FA7EB7216540681 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementMenuLabel.swift in Sources */,
+				314809E17C3C294340F2DA1E /* LifeBoard/Views/Settings/LifeManagement/LifeManagementAppearanceLine.swift in Sources */,
+				096DC7AAFD7B5580A3DABEC3 /* LifeBoard/Views/Settings/LifeManagement/lifeManagementHabitStatusText.swift in Sources */,
+				98394DA04DCC1FB307F8FA6C /* LifeBoard/Views/Settings/LifeManagement/lifeManagementAreaAccentHex.swift in Sources */,
+				B2621FA8D6DFC6D96F027AA1 /* LifeBoard/Views/Settings/LifeManagement/lifeManagementHabitCadenceLabel.swift in Sources */,
+				51459E137A715214E7CD7481 /* LifeBoard/Views/Settings/LifeManagement/AreaListRow.swift in Sources */,
+				7F6F5E34FE261604F7D6BFD0 /* LifeBoard/Views/Settings/LifeManagement/AreaSummaryRow.swift in Sources */,
+				144C7E3E26AF1D97BC310AFF /* LifeBoard/Views/Settings/LifeManagement/ProjectListRow.swift in Sources */,
+				686BD3F9EE58F613BD29E6C8 /* LifeBoard/Views/Settings/LifeManagement/ProjectSummaryRow.swift in Sources */,
+				C5F044673340D4322E0821B9 /* LifeBoard/Views/Settings/LifeManagement/HabitListRow.swift in Sources */,
+				F00D8D326BF77E4E42597083 /* LifeBoard/Views/Settings/LifeManagement/HabitSummaryRow.swift in Sources */,
+				F85EBA97A802F4DC015E332F /* LifeBoard/Views/Settings/LifeManagement/HabitArchiveRow.swift in Sources */,
+				EACA938DF5FA7C9EDE59A3E9 /* LifeBoard/Views/Settings/LifeManagement/AccentIconBadge.swift in Sources */,
+				671162B95889EABEC8DB6123 /* LifeBoard/Views/Settings/LifeManagement/InlineToneBadge.swift in Sources */,
+				E27B1B656A0E3808DD252E18 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementAreaDetailView.swift in Sources */,
+				014575655AA3DBD8B1BD4C5F /* LifeBoard/Views/Settings/LifeManagement/LifeManagementProjectDetailView.swift in Sources */,
+				3447A60285674490A2726759 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementAreaComposerView.swift in Sources */,
+				9251E3DBECB09B6DBC3F5E6A /* LifeBoard/Views/Settings/LifeManagement/LifeManagementProjectComposerView.swift in Sources */,
+				0A469058A907DD61A98AAF4C /* LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerPreviewMetric.swift in Sources */,
+				1E8F023F70606AF2879DEFBE /* LifeBoard/Views/Settings/LifeManagement/LifeManagementAreaPaletteOption.swift in Sources */,
+				40E1706994A23C948306E25F /* LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerPreviewCard.swift in Sources */,
+				DB875C16F1B99BF79F3B4D6C /* LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerMetricTile.swift in Sources */,
+				876568AD4ACD09548D5F3199 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerSectionCard.swift in Sources */,
+				1D91EF2A13A06697AF7AB056 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerFieldLabel.swift in Sources */,
+				62E3C0A2BCA96C7A1DB01932 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementComposerInlineMessage.swift in Sources */,
+				F1BBC7AE7656181142FE5487 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementAreaSwatchPicker.swift in Sources */,
+				71A922288848416DA81F7339 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementProjectColorPicker.swift in Sources */,
+				F5C55F69B9C3BEDDF1C2FD8F /* LifeBoard/Views/Settings/LifeManagement/LifeManagementColorSwatchButton.swift in Sources */,
+				FFE402DD68D4595A5B90EC4B /* LifeBoard/Views/Settings/LifeManagement/LifeManagementAreaIconPicker.swift in Sources */,
+				78D78EA96C40AD8462A19EC9 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementProjectIconPicker.swift in Sources */,
+				7F217D39FE1F01D4E8731F64 /* LifeBoard/Views/Settings/LifeManagement/LifeManagementIconTile.swift in Sources */,
+				4C116CACC08E51B35A4EA8B4 /* LifeBoard/Views/Settings/LifeManagement/lifeManagementAreaPaletteOptions.swift in Sources */,
+				703E14D9DE8D191C47A5150F /* LifeBoard/Views/Settings/LifeManagement/lifeManagementAreaPaletteMatch.swift in Sources */,
+				1C0ACEFFC26353A9CA10873F /* LifeBoard/Views/Settings/LifeManagement/lifeManagementResolvedColor.swift in Sources */,
+				E7F919BAE9F8CABAE8F00BE6 /* LifeBoard/Views/Settings/LifeManagement/lifeManagementResolvedHex.swift in Sources */,
+				EE9035C0B9F8F991433E9826 /* LifeBoard/Views/Settings/LifeManagement/lifeManagementNormalizedHex.swift in Sources */,
+				E7E382F8167672FCEB4D0B60 /* LifeBoard/Views/Settings/LifeManagement/lifeManagementAreaIconLabel.swift in Sources */,
+				7669746360890A5F6BFF15B0 /* LifeBoard/Views/Settings/LifeManagement/ProjectMoveSheet.swift in Sources */,
+				3CA024512D42A38C712034E0 /* LifeBoard/Views/Settings/LifeManagement/DeleteAreaSheet.swift in Sources */,
+				04821EE8B574D3BAF98E7B76 /* LifeBoard/Views/Settings/LifeManagement/DeleteProjectSheet.swift in Sources */,
+				29AAA780F791C00A198F8FA7 /* LifeBoard/Views/Settings/LifeManagement/StringExtension.swift in Sources */,
+				49E7E5624BF18A470B23059C /* LifeBoard/LLM/Views/Chat/Conversation/ChatTimeIntervalExtension.swift in Sources */,
+				ED97E21547C8335D58370530 /* LifeBoard/LLM/Views/Chat/Conversation/TypingIndicator.swift in Sources */,
+				1F2D5D429CB73C24348EE788 /* LifeBoard/LLM/Views/Chat/Conversation/EvaWorkingStatusLibrary.swift in Sources */,
+				B0045AC9A4CD19C619A2E2F1 /* LifeBoard/LLM/Views/Chat/Conversation/EvaLiveWorkingStatusView.swift in Sources */,
+				B8A0777F2A0301936C76BAE4 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayTaskOverlayState.swift in Sources */,
+				EBEBD8815DECEEB6E6A67CAC /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitOverlayState.swift in Sources */,
+				DB6DB22472BF68C888913F37 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayStatusChipsView.swift in Sources */,
+				B07988E6375D66CC8CDB8D47 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDaySunriseTaskRowView.swift in Sources */,
+				DB95AC7DC5F9BE77042C3290 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitRowView.swift in Sources */,
+				A5857BBC75940D4FC8CFF13E /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayTaskHeaderView.swift in Sources */,
+				B901CF64B494992760AE96FB /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayTaskMetadataView.swift in Sources */,
+				8455171FE035DD36178C82A1 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayTaskActionsView.swift in Sources */,
+				F008F091A6B8DB39893BDF07 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayTaskActionButtonView.swift in Sources */,
+				39B8F09956E3FFEF16B72812 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitHeaderView.swift in Sources */,
+				3BFD0F4FDBF2CF845F1ED1BA /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitMetadataView.swift in Sources */,
+				C7E4C6E991D23697752D8D6C /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitActionsView.swift in Sources */,
+				552B5C25F6D738A5BA9CD095 /* LifeBoard/LLM/Views/Chat/Conversation/EvaDayHabitActionButtonView.swift in Sources */,
+				FA06177C5FE545D4DB799E31 /* LifeBoard/LLM/Views/Chat/Conversation/MessageView.swift in Sources */,
+				63578F35F6200B19F85FE9F0 /* LifeBoard/LLM/Views/Chat/Conversation/MessageView+AssistantAndUserBubble.swift in Sources */,
+				88F9D9D24093FC098261F935 /* LifeBoard/LLM/Views/Chat/Conversation/MessageView+EvaProposalAndDayOverview.swift in Sources */,
+				6AD96644B6458794736BA46D /* LifeBoard/LLM/Views/Chat/Conversation/MessageView+DayOverviewAndProposalActions.swift in Sources */,
+				F4FF0FD29ACA5B7B4CF12827 /* LifeBoard/LLM/Views/Chat/Conversation/MessageView+CommandResultsAndUndo.swift in Sources */,
+				F0D4A5D3F940D3BD0B515BEF /* LifeBoard/LLM/Views/Chat/Conversation/ConversationViewRoot.swift in Sources */,
+				D92AC2EBBC4D507DE7D45C8F /* LifeBoard/LLM/Views/Chat/Conversation/ConversationView+LiveOutput.swift in Sources */,
+				7477D906A0AC312F3C4B3912 /* LifeBoard/LLM/Views/Chat/Chrome/EvaChatNavigationChromeState.swift in Sources */,
+				CB2585384EDD36506A08BC39 /* LifeBoard/LLM/Views/Chat/Chrome/EvaChatSunriseGlass.swift in Sources */,
+				0EDFDE262FBEB052B1E2BDFE /* LifeBoard/LLM/Views/Chat/Chrome/EvaChatSunriseBackground.swift in Sources */,
+				E83889CA9BD741CA471800E8 /* LifeBoard/LLM/Views/Chat/Chrome/ChatHeaderView.swift in Sources */,
+				30CF71E853B4D59EBDBDA4AE /* LifeBoard/LLM/Views/Chat/Chrome/ChatEmptyStateView.swift in Sources */,
+				9529034A5040C4E7C31DC102 /* LifeBoard/LLM/Views/Chat/Chrome/EvaChiefOfStaffGuideSection.swift in Sources */,
+				4E816E3A12F0DFB4283D9FCF /* LifeBoard/LLM/Views/Chat/Chrome/EvaHomePromptChip.swift in Sources */,
+				2330C3F5294BC6FE822B80D0 /* LifeBoard/LLM/Views/Chat/Chrome/EvaChiefOfStaffGuideContent.swift in Sources */,
+				F5BD3FA4315CD2E0D8E33730 /* LifeBoard/LLM/Views/Chat/Chrome/EvaChiefOfStaffGuideView.swift in Sources */,
+				FD83FBA515FA99D90DE5465C /* LifeBoard/LLM/Views/Chat/Chrome/FlowPromptChipsView.swift in Sources */,
+				7C907B3AC77B5CAD3A68E7C1 /* LifeBoard/LLM/Views/Chat/Chrome/ChatComposerView.swift in Sources */,
+				48B55AA334E364D314DCE8CB /* LifeBoard/LLM/Views/Chat/Chrome/ChatComposerView+StructuredComposer.swift in Sources */,
+				73860C05746CA1B37767FA58 /* LifeBoard/LLM/Views/Chat/Chrome/ChatStorageDegradedBanner.swift in Sources */,
+				5D45628FA820FA3BEB7A97D3 /* LifeBoard/LLM/Views/Chat/Chrome/ChatScaffoldView.swift in Sources */,
+				63D0ECF6FEB314DC1FD1AFAD /* LifeBoard/LLM/Views/Chat/Chrome/ChatScaffoldView+NavigationChrome.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5357,6 +5839,7 @@
 				B8E100052F70000100A0A001 /* LifeBoardCTABezelResolverTests.swift in Sources */,
 				B8F9A0B1C2D3E4F506172839 /* LLMPersonalMemoryStoreTests.swift in Sources */,
 				B4D7E8213A4F5C6D7E8F9012 /* V3TestHarness.swift in Sources */,
+				B4D7E8213A4F5C6D7E8F9014 /* SharedColorTestHelpers.swift in Sources */,
 				C2D3E4F5061728394A5B6C7D /* DeleteTaskDefinitionUseCaseTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -5690,7 +6173,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = LifeBoard.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = CJ43UNM3AR;
 				INFOPLIST_FILE = LifeBoard/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = LifeBoard;
@@ -5700,7 +6183,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.9.8;
+				MARKETING_VERSION = 1.9.9;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-Wl,-no_warn_duplicate_libraries",
@@ -5723,7 +6206,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = LifeBoard.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = CJ43UNM3AR;
 				INFOPLIST_FILE = LifeBoard/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = LifeBoard;
@@ -5733,7 +6216,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.9.8;
+				MARKETING_VERSION = 1.9.9;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-Wl,-no_warn_duplicate_libraries",

--- a/LifeBoard/LifeBoardDesign/Components/LBAssistantPromptCard.swift
+++ b/LifeBoard/LifeBoardDesign/Components/LBAssistantPromptCard.swift
@@ -15,9 +15,6 @@ struct LBAssistantPromptCard: View {
                 usesMaterialBackground: false
             ) {
                 HStack(spacing: LBSpacingTokens.md) {
-                    Image(systemName: "sparkles")
-                        .font(.system(size: 22, weight: .semibold))
-                        .foregroundStyle(LBColorTokens.violet)
                     VStack(alignment: .leading, spacing: 2) {
                         Text(title)
                             .font(LBTypographyTokens.bodyStrong)

--- a/LifeBoard/LifeBoardDesign/Components/LBAssistantPromptCard.swift
+++ b/LifeBoard/LifeBoardDesign/Components/LBAssistantPromptCard.swift
@@ -32,5 +32,7 @@ struct LBAssistantPromptCard: View {
             }
         }
         .buttonStyle(.plain)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Assistant prompt, \(title), \(subtitle)")
     }
 }

--- a/LifeBoard/LifeBoardDesign/Components/LBMeetingFlockCard.swift
+++ b/LifeBoard/LifeBoardDesign/Components/LBMeetingFlockCard.swift
@@ -46,7 +46,6 @@ struct LBMeetingFlockCard: View {
                         onTapMeeting(meeting)
                     } label: {
                         HStack(spacing: LBSpacingTokens.sm) {
-                            LBIconBadge(systemName: "calendar", role: .meeting, size: 36)
                             VStack(alignment: .leading, spacing: 2) {
                                 Text(meeting.title)
                                     .font(LBTypographyTokens.bodyStrong)

--- a/LifeBoard/LifeBoardDesign/Components/LBMeetingFlockCard.swift
+++ b/LifeBoard/LifeBoardDesign/Components/LBMeetingFlockCard.swift
@@ -62,6 +62,8 @@ struct LBMeetingFlockCard: View {
                         .background(LBColorTokens.glassStrong.opacity(meeting.isNow ? 0.70 : 0.54), in: RoundedRectangle(cornerRadius: 15, style: .continuous))
                     }
                     .buttonStyle(.plain)
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel("Meeting, \(meeting.title), \(meeting.isNow ? "Now" : meeting.timeText)")
                 }
             }
             .padding(LBSpacingTokens.md)

--- a/LifeBoard/LifeBoardDesign/Components/LBTimelineCard.swift
+++ b/LifeBoard/LifeBoardDesign/Components/LBTimelineCard.swift
@@ -20,18 +20,15 @@ struct LBTimelineCard: View, Equatable {
         let timeText: String
         let role: LBRole
         let kind: Kind
-        let systemImage: String
         let tintHex: String?
         let accessoryText: String?
         let temporalState: LBTimelineTemporalState
         let isCompleted: Bool
-        let isToggleable: Bool
         let isCurrent: Bool
     }
 
     let model: Model
     let onTap: () -> Void
-    var onToggleComplete: (() -> Void)?
 
     nonisolated static func == (lhs: LBTimelineCard, rhs: LBTimelineCard) -> Bool {
         lhs.model == rhs.model
@@ -86,6 +83,8 @@ struct LBTimelineCard: View, Equatable {
             }
             .buttonStyle(.plain)
             .accessibilityElement(children: .combine)
+            .accessibilityLabel(accessibilityLabel)
+            .accessibilityValue(accessibilityValue)
             .accessibilityIdentifier(accessibilityIdentifier)
         }
     }
@@ -107,6 +106,28 @@ struct LBTimelineCard: View, Equatable {
             return "home.timeline.task.\(String(model.id.dropFirst("task:".count)))"
         }
         return "home.timeline.\(model.kind.rawValue).\(model.id)"
+    }
+
+    private var accessibilityLabel: String {
+        [
+            accessibilityKind,
+            model.title,
+            model.subtitle.isEmpty ? model.timeText : "\(model.timeText), \(model.subtitle)"
+        ]
+        .filter { $0.isEmpty == false }
+        .joined(separator: ", ")
+    }
+
+    private var accessibilityKind: String {
+        switch model.kind {
+        case .anchor: return "Routine"
+        case .calendar: return "Meeting"
+        case .task: return "Task"
+        }
+    }
+
+    private var accessibilityValue: String {
+        model.kind == .task ? (model.isCompleted ? "Completed" : "Not completed") : ""
     }
 
     private var cornerRadius: CGFloat {

--- a/LifeBoard/LifeBoardDesign/Components/LBTimelineCard.swift
+++ b/LifeBoard/LifeBoardDesign/Components/LBTimelineCard.swift
@@ -58,8 +58,6 @@ struct LBTimelineCard: View, Equatable {
                     usesMaterialBackground: false
                 ) {
                     HStack(spacing: LBSpacingTokens.sm) {
-                        leadingControl(style: style)
-
                         VStack(alignment: .leading, spacing: 4) {
                             Text(model.title)
                                 .font(LBTypographyTokens.cardTitle)
@@ -109,33 +107,6 @@ struct LBTimelineCard: View, Equatable {
             return "home.timeline.task.\(String(model.id.dropFirst("task:".count)))"
         }
         return "home.timeline.\(model.kind.rawValue).\(model.id)"
-    }
-
-    @ViewBuilder
-    private func leadingControl(style: LBRoleStyle) -> some View {
-        if model.kind == .task {
-            let accentColor = taskAccentColor(fallback: style.base)
-            Button(action: { onToggleComplete?() }) {
-                ZStack {
-                    RoundedRectangle(cornerRadius: 8, style: .continuous)
-                        .fill(model.isCompleted ? accentColor : LBColorTokens.glassStrong.opacity(model.temporalState == .past ? 0.58 : 0.94))
-                        .frame(width: 34, height: 34)
-                        .overlay {
-                            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                                .stroke(model.isCompleted ? accentColor : accentColor.opacity(model.temporalState == .past ? 0.42 : 0.85), lineWidth: 2)
-                        }
-                    Image(systemName: model.isCompleted ? "checkmark" : "checkmark")
-                        .font(.system(size: 15, weight: .bold))
-                        .foregroundStyle(model.isCompleted ? Color.white : accentColor.opacity(0.0))
-                }
-            }
-            .buttonStyle(.plain)
-            .disabled(!model.isToggleable)
-            .accessibilityLabel(model.isCompleted ? "Reopen task" : "Complete task")
-        } else {
-            LBIconBadge(systemName: model.systemImage, role: model.role)
-                .opacity(model.temporalState == .past ? 0.62 : 1)
-        }
     }
 
     private var cornerRadius: CGFloat {

--- a/LifeBoard/LifeBoardDesign/Components/LBTimelineItem.swift
+++ b/LifeBoard/LifeBoardDesign/Components/LBTimelineItem.swift
@@ -7,6 +7,7 @@ struct LBTimelineItem<Content: View>: View {
     var temporalState: LBTimelineTemporalState = .future
     var spineIconSystemName: String?
     var spineIconAccessibilityLabel: String?
+    var spineIconAccessibilityValue: String?
     var spineIconAction: (() -> Void)?
     @ViewBuilder let content: Content
 
@@ -17,6 +18,7 @@ struct LBTimelineItem<Content: View>: View {
         temporalState: LBTimelineTemporalState = .future,
         spineIconSystemName: String? = nil,
         spineIconAccessibilityLabel: String? = nil,
+        spineIconAccessibilityValue: String? = nil,
         spineIconAction: (() -> Void)? = nil,
         @ViewBuilder content: () -> Content
     ) {
@@ -26,6 +28,7 @@ struct LBTimelineItem<Content: View>: View {
         self.temporalState = temporalState
         self.spineIconSystemName = spineIconSystemName
         self.spineIconAccessibilityLabel = spineIconAccessibilityLabel
+        self.spineIconAccessibilityValue = spineIconAccessibilityValue
         self.spineIconAction = spineIconAction
         self.content = content()
     }
@@ -57,6 +60,7 @@ struct LBTimelineItem<Content: View>: View {
             temporalState: temporalState,
             iconSystemName: spineIconSystemName,
             iconAccessibilityLabel: spineIconAccessibilityLabel,
+            iconAccessibilityValue: spineIconAccessibilityValue,
             iconAction: spineIconAction
         )
     }

--- a/LifeBoard/LifeBoardDesign/Components/LBTimelineItem.swift
+++ b/LifeBoard/LifeBoardDesign/Components/LBTimelineItem.swift
@@ -5,7 +5,30 @@ struct LBTimelineItem<Content: View>: View {
     let role: LBRole
     var tintHex: String?
     var temporalState: LBTimelineTemporalState = .future
+    var spineIconSystemName: String?
+    var spineIconAccessibilityLabel: String?
+    var spineIconAction: (() -> Void)?
     @ViewBuilder let content: Content
+
+    init(
+        timeText: String,
+        role: LBRole,
+        tintHex: String? = nil,
+        temporalState: LBTimelineTemporalState = .future,
+        spineIconSystemName: String? = nil,
+        spineIconAccessibilityLabel: String? = nil,
+        spineIconAction: (() -> Void)? = nil,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.timeText = timeText
+        self.role = role
+        self.tintHex = tintHex
+        self.temporalState = temporalState
+        self.spineIconSystemName = spineIconSystemName
+        self.spineIconAccessibilityLabel = spineIconAccessibilityLabel
+        self.spineIconAction = spineIconAction
+        self.content = content()
+    }
 
     var body: some View {
         HStack(alignment: .top, spacing: LBSpacingTokens.timelineCardGap) {
@@ -18,12 +41,24 @@ struct LBTimelineItem<Content: View>: View {
                 .frame(width: LBSpacingTokens.timelineTimeColumnWidth, alignment: .trailing)
                 .padding(.top, LBSpacingTokens.sm)
 
-            LBTimelineSpine(role: role, tintHex: tintHex, temporalState: temporalState)
+            spine
                 .frame(width: LBSpacingTokens.timelineRailWidth)
 
             content
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
+    }
+
+    @ViewBuilder
+    private var spine: some View {
+        LBTimelineSpine(
+            role: role,
+            tintHex: tintHex,
+            temporalState: temporalState,
+            iconSystemName: spineIconSystemName,
+            iconAccessibilityLabel: spineIconAccessibilityLabel,
+            iconAction: spineIconAction
+        )
     }
 
     private var timeColor: Color {

--- a/LifeBoard/LifeBoardDesign/Components/LBTimelineSpine.swift
+++ b/LifeBoard/LifeBoardDesign/Components/LBTimelineSpine.swift
@@ -6,6 +6,7 @@ struct LBTimelineSpine: View {
     var temporalState: LBTimelineTemporalState = .future
     var iconSystemName: String?
     var iconAccessibilityLabel: String?
+    var iconAccessibilityValue: String?
     var iconAction: (() -> Void)?
 
     var body: some View {
@@ -32,6 +33,7 @@ struct LBTimelineSpine: View {
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel(iconAccessibilityLabel ?? "Timeline action")
+                .accessibilityValue(iconAccessibilityValue ?? "")
             } else {
                 iconMarker(systemName: iconSystemName, baseColor: baseColor)
                     .accessibilityHidden(true)

--- a/LifeBoard/LifeBoardDesign/Components/LBTimelineSpine.swift
+++ b/LifeBoard/LifeBoardDesign/Components/LBTimelineSpine.swift
@@ -4,6 +4,9 @@ struct LBTimelineSpine: View {
     let role: LBRole
     var tintHex: String?
     var temporalState: LBTimelineTemporalState = .future
+    var iconSystemName: String?
+    var iconAccessibilityLabel: String?
+    var iconAction: (() -> Void)?
 
     var body: some View {
         let style = LBColorTokens.role(role)
@@ -13,18 +16,65 @@ struct LBTimelineSpine: View {
             Rectangle()
                 .fill(baseColor.opacity(lineOpacity))
                 .frame(width: temporalState == .current ? 1.5 : 1)
-            Circle()
-                .fill(temporalState == .current ? (hasTint ? baseColor : LBColorTokens.violet) : baseColor.opacity(dotOpacity))
-                .frame(width: temporalState == .current ? 12 : 7, height: temporalState == .current ? 12 : 7)
-                .overlay(Circle().stroke(LBColorTokens.canvas.opacity(0.92), lineWidth: temporalState == .current ? 3 : 2))
+            marker(baseColor: baseColor, hasTint: hasTint)
             Rectangle()
                 .fill(baseColor.opacity(lineOpacity))
                 .frame(width: temporalState == .current ? 1.5 : 1)
         }
     }
 
+    @ViewBuilder
+    private func marker(baseColor: Color, hasTint: Bool) -> some View {
+        if let iconSystemName {
+            if let iconAction {
+                Button(action: iconAction) {
+                    iconMarker(systemName: iconSystemName, baseColor: baseColor)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(iconAccessibilityLabel ?? "Timeline action")
+            } else {
+                iconMarker(systemName: iconSystemName, baseColor: baseColor)
+                    .accessibilityHidden(true)
+            }
+        } else {
+            Circle()
+                .fill(temporalState == .current ? (hasTint ? baseColor : LBColorTokens.violet) : baseColor.opacity(dotOpacity))
+                .frame(width: temporalState == .current ? 12 : 7, height: temporalState == .current ? 12 : 7)
+                .overlay(Circle().stroke(LBColorTokens.canvas.opacity(0.92), lineWidth: temporalState == .current ? 3 : 2))
+        }
+    }
+
+    private func iconMarker(systemName: String, baseColor: Color) -> some View {
+        Image(systemName: systemName)
+            .font(.system(size: iconSize(for: systemName), weight: .semibold, design: .rounded))
+            .foregroundStyle(baseColor.opacity(iconOpacity))
+            .frame(width: 44, height: 44)
+            .background {
+                Circle()
+                    .fill(LBColorTokens.glassStrong.opacity(iconBackgroundOpacity))
+                    .frame(width: 34, height: 34)
+            }
+            .overlay {
+                Circle()
+                    .stroke(baseColor.opacity(iconBorderOpacity), lineWidth: 1)
+                    .frame(width: 34, height: 34)
+            }
+            .shadow(color: baseColor.opacity(temporalState == .past ? 0 : 0.18), radius: 8, y: 2)
+    }
+
     private func resolvedBaseColor(fallback: Color) -> Color {
         LifeBoardHexColor.color(tintHex, fallback: fallback)
+    }
+
+    private func iconSize(for systemName: String) -> CGFloat {
+        switch systemName {
+        case "sun.max.fill", "sparkles":
+            return 22
+        case "moon.fill":
+            return 23
+        default:
+            return 20
+        }
     }
 
     private var lineOpacity: Double {
@@ -41,5 +91,17 @@ struct LBTimelineSpine: View {
         case .current: return 1
         case .future: return 0.86
         }
+    }
+
+    private var iconOpacity: Double {
+        temporalState == .past ? 0.52 : 1
+    }
+
+    private var iconBackgroundOpacity: Double {
+        temporalState == .past ? 0.34 : 0.82
+    }
+
+    private var iconBorderOpacity: Double {
+        temporalState == .past ? 0.24 : 0.54
     }
 }

--- a/LifeBoard/LifeBoardDesign/Components/TimelineRoutineAnchorCard.swift
+++ b/LifeBoard/LifeBoardDesign/Components/TimelineRoutineAnchorCard.swift
@@ -46,8 +46,6 @@ struct TimelineRoutineAnchorCard: View {
                 .resizable()
                 .scaledToFill()
                 .frame(width: proxy.size.width, height: proxy.size.height)
-                .scaleEffect(1.5)
-                .offset(x: artworkOffsetX(for: proxy.size.width))
                 .clipped()
         }
     }
@@ -67,6 +65,9 @@ struct TimelineRoutineAnchorCard: View {
 
     private var textLayer: some View {
         HStack(alignment: .center, spacing: 0) {
+            Color.clear
+                .frame(width: leadingArtworkReserve)
+
             VStack(alignment: .leading, spacing: 4) {
                 Text(style.displayTitle)
                     .font(.lifeboard(.headline))
@@ -87,14 +88,5 @@ struct TimelineRoutineAnchorCard: View {
         .padding(.leading, 16)
         .padding(.trailing, 16)
         .padding(.vertical, 14)
-    }
-
-    private func artworkOffsetX(for width: CGFloat) -> CGFloat {
-        switch style.variant {
-        case .morning:
-            return -width * 0.18
-        case .evening:
-            return -width * 0.24
-        }
     }
 }

--- a/LifeBoard/LifeBoardDesign/Components/TimelineRoutineAnchorCard.swift
+++ b/LifeBoard/LifeBoardDesign/Components/TimelineRoutineAnchorCard.swift
@@ -46,6 +46,8 @@ struct TimelineRoutineAnchorCard: View {
                 .resizable()
                 .scaledToFill()
                 .frame(width: proxy.size.width, height: proxy.size.height)
+                .scaleEffect(1.5)
+                .offset(x: artworkOffsetX(for: proxy.size.width))
                 .clipped()
         }
     }
@@ -65,10 +67,6 @@ struct TimelineRoutineAnchorCard: View {
 
     private var textLayer: some View {
         HStack(alignment: .center, spacing: 0) {
-            Color.clear
-                .frame(width: leadingArtworkReserve)
-                .accessibilityHidden(true)
-
             VStack(alignment: .leading, spacing: 4) {
                 Text(style.displayTitle)
                     .font(.lifeboard(.headline))
@@ -86,7 +84,17 @@ struct TimelineRoutineAnchorCard: View {
 
             Spacer(minLength: 0)
         }
+        .padding(.leading, 16)
         .padding(.trailing, 16)
         .padding(.vertical, 14)
+    }
+
+    private func artworkOffsetX(for width: CGFloat) -> CGFloat {
+        switch style.variant {
+        case .morning:
+            return -width * 0.18
+        case .evening:
+            return -width * 0.24
+        }
     }
 }

--- a/LifeBoard/LifeBoardDesign/SunriseHomeScreen.swift
+++ b/LifeBoard/LifeBoardDesign/SunriseHomeScreen.swift
@@ -387,12 +387,10 @@ struct SunriseHomeScreen: View {
                                     timeText: timeText(anchor.time),
                                     role: anchorRole,
                                     kind: .anchor,
-                                    systemImage: anchorSystemImage(for: anchor),
                                     tintHex: nil,
                                     accessoryText: nil,
                                     temporalState: temporalState,
                                     isCompleted: false,
-                                    isToggleable: false,
                                     isCurrent: temporalState == .current
                                 ),
                                 onTap: { onAnchorTap(anchor) }
@@ -412,7 +410,8 @@ struct SunriseHomeScreen: View {
                             tintHex: kind == .task ? item.tintHex : nil,
                             temporalState: temporalState,
                             spineIconSystemName: spineIconSystemName(for: item, kind: kind),
-                            spineIconAccessibilityLabel: item.isComplete ? "Reopen task" : "Complete task",
+                            spineIconAccessibilityLabel: item.isComplete ? "Reopen \(item.title)" : "Complete \(item.title)",
+                            spineIconAccessibilityValue: item.isComplete ? "Completed" : "Not completed",
                             spineIconAction: kind == .task ? taskToggleAction : nil
                         ) {
                             LBTimelineCard(
@@ -422,8 +421,7 @@ struct SunriseHomeScreen: View {
                                     now: context.date,
                                     nextUpcomingCalendarItemID: nextUpcomingCalendarItemID
                                 ),
-                                onTap: { onTimelineItemTap(item) },
-                                onToggleComplete: nil
+                                onTap: { onTimelineItemTap(item) }
                             )
                             .equatable()
                         }
@@ -841,12 +839,10 @@ struct SunriseHomeScreen: View {
             timeText: "\(timeText(item.startDate))\(item.endDate == nil ? "" : " – \(timeText(item.endDate))")",
             role: role(for: item),
             kind: kind,
-            systemImage: kind == .calendar ? "calendar" : item.systemImageName,
             tintHex: kind == .task ? item.tintHex : nil,
             accessoryText: nil,
             temporalState: temporalState,
             isCompleted: item.isComplete,
-            isToggleable: item.taskID != nil,
             isCurrent: temporalState == .current
         )
     }
@@ -872,13 +868,6 @@ struct SunriseHomeScreen: View {
 
     private func anchorTitle(for anchor: TimelineAnchorItem) -> String {
         anchor.id == "sleep" ? "Wind Down" : anchor.title
-    }
-
-    private func anchorSystemImage(for anchor: TimelineAnchorItem) -> String {
-        if anchor.id == "sleep" {
-            return LBColorTokens.role(.windDown).symbolName
-        }
-        return anchor.systemImageName.isEmpty ? "sunrise" : anchor.systemImageName
     }
 
     private func spineIconSystemName(for anchor: TimelineAnchorItem) -> String {

--- a/LifeBoard/LifeBoardDesign/SunriseHomeScreen.swift
+++ b/LifeBoard/LifeBoardDesign/SunriseHomeScreen.swift
@@ -373,7 +373,12 @@ struct SunriseHomeScreen: View {
                     switch row.kind {
                     case .anchor(let anchor):
                         let anchorRole = role(for: anchor)
-                        LBTimelineItem(timeText: timeText(anchor.time), role: anchorRole, temporalState: temporalState) {
+                        LBTimelineItem(
+                            timeText: timeText(anchor.time),
+                            role: anchorRole,
+                            temporalState: temporalState,
+                            spineIconSystemName: spineIconSystemName(for: anchor)
+                        ) {
                             LBTimelineCard(
                                 model: LBTimelineCard.Model(
                                     id: anchor.id,
@@ -396,11 +401,19 @@ struct SunriseHomeScreen: View {
                         }
                     case .item(let item):
                         let kind = cardKind(for: item)
+                        let taskToggleAction: (() -> Void)? = item.taskID == nil ? nil : {
+                            let interval = LifeBoardPerformanceTrace.begin("HomeTimelineTaskToggle")
+                            onTimelineItemToggleComplete(item)
+                            LifeBoardPerformanceTrace.end(interval)
+                        }
                         LBTimelineItem(
                             timeText: timeText(item.startDate),
                             role: role(for: item),
                             tintHex: kind == .task ? item.tintHex : nil,
-                            temporalState: temporalState
+                            temporalState: temporalState,
+                            spineIconSystemName: spineIconSystemName(for: item, kind: kind),
+                            spineIconAccessibilityLabel: item.isComplete ? "Reopen task" : "Complete task",
+                            spineIconAction: kind == .task ? taskToggleAction : nil
                         ) {
                             LBTimelineCard(
                                 model: timelineCardModel(
@@ -410,16 +423,17 @@ struct SunriseHomeScreen: View {
                                     nextUpcomingCalendarItemID: nextUpcomingCalendarItemID
                                 ),
                                 onTap: { onTimelineItemTap(item) },
-                                onToggleComplete: item.taskID == nil ? nil : {
-                                    let interval = LifeBoardPerformanceTrace.begin("HomeTimelineTaskToggle")
-                                    onTimelineItemToggleComplete(item)
-                                    LifeBoardPerformanceTrace.end(interval)
-                                }
+                                onToggleComplete: nil
                             )
                             .equatable()
                         }
                     case .meetingFlock(let model, let sourceItems):
-                        LBTimelineItem(timeText: model.timeRange.components(separatedBy: " – ").first ?? model.timeRange, role: .meeting, temporalState: temporalState) {
+                        LBTimelineItem(
+                            timeText: model.timeRange.components(separatedBy: " – ").first ?? model.timeRange,
+                            role: .meeting,
+                            temporalState: temporalState,
+                            spineIconSystemName: "calendar"
+                        ) {
                             LBMeetingFlockCard(model: model) { meeting in
                                 if let item = sourceItems.first(where: { $0.id == meeting.id }) {
                                     onTimelineItemTap(item)
@@ -427,7 +441,12 @@ struct SunriseHomeScreen: View {
                             }
                         }
                     case .gap(let gap):
-                        LBTimelineItem(timeText: timeText(row.sortDate(now: context.date)), role: .assistant, temporalState: temporalState) {
+                        LBTimelineItem(
+                            timeText: timeText(row.sortDate(now: context.date)),
+                            role: .assistant,
+                            temporalState: temporalState,
+                            spineIconSystemName: "sparkles"
+                        ) {
                             let copy = assistantCopy(for: gap)
                             LBAssistantPromptCard(
                                 title: copy.title,
@@ -860,6 +879,14 @@ struct SunriseHomeScreen: View {
             return LBColorTokens.role(.windDown).symbolName
         }
         return anchor.systemImageName.isEmpty ? "sunrise" : anchor.systemImageName
+    }
+
+    private func spineIconSystemName(for anchor: TimelineAnchorItem) -> String {
+        anchor.id == "sleep" ? "moon.fill" : "sun.max.fill"
+    }
+
+    private func spineIconSystemName(for item: TimelinePlanItem, kind: LBTimelineCard.Kind) -> String {
+        kind == .calendar ? "calendar" : "checkmark.square"
     }
 
     private func routineSubtitle(for period: TimeOfDayHeaderAsset.Period) -> String {

--- a/LifeBoard/LifeBoardDesign/SunriseHomeScreen.swift
+++ b/LifeBoard/LifeBoardDesign/SunriseHomeScreen.swift
@@ -875,7 +875,10 @@ struct SunriseHomeScreen: View {
     }
 
     private func spineIconSystemName(for item: TimelinePlanItem, kind: LBTimelineCard.Kind) -> String {
-        kind == .calendar ? "calendar" : "checkmark.square"
+        if kind == .calendar {
+            return "calendar"
+        }
+        return item.isComplete ? "checkmark.square.fill" : "checkmark.square"
     }
 
     private func routineSubtitle(for period: TimeOfDayHeaderAsset.Period) -> String {

--- a/LifeBoard/LifeBoardDesign/Tokens/LBSpacingTokens.swift
+++ b/LifeBoard/LifeBoardDesign/Tokens/LBSpacingTokens.swift
@@ -14,7 +14,7 @@ enum LBSpacingTokens {
     static let sunriseHeaderContentOverlap: CGFloat = 34
     static let sunriseHeaderAccessibilityContentOverlap: CGFloat = 20
     static let timelineTimeColumnWidth: CGFloat = 72
-    static let timelineRailWidth: CGFloat = 16
+    static let timelineRailWidth: CGFloat = 36
     static let timelineCardGap: CGFloat = 8
     static let timelineRailCenterX: CGFloat = screenMargin + timelineTimeColumnWidth + timelineRailWidth / 2
     static let bottomDockHeight: CGFloat = 84

--- a/LifeBoard/View/ReflectPlanStyle.swift
+++ b/LifeBoard/View/ReflectPlanStyle.swift
@@ -1,19 +1,20 @@
 import SwiftUI
 
 enum ReflectPlanStyle {
-    static let canvas = Color(lifeboardHex: "#FFF8EF")
-    static let cream = Color(lifeboardHex: "#FFFDF9")
-    static let peachSurface = Color(lifeboardHex: "#FFF1E9")
-    static let peachSurfaceStrong = Color(lifeboardHex: "#FFF7F1")
-    static let peachBorder = Color(lifeboardHex: "#FFD8C5")
-    static let blueSurface = Color(lifeboardHex: "#EAF6FF")
-    static let blueSurfaceStrong = Color(lifeboardHex: "#F5FBFF")
-    static let blueBorder = Color(lifeboardHex: "#CFE9FF")
-    static let greenCTA = Color(lifeboardHex: "#0F5B3D")
-    static let greenCTAPressed = Color(lifeboardHex: "#0A442D")
-    static let goldSurface = Color(lifeboardHex: "#FFF7DF")
-    static let goldBorder = Color(lifeboardHex: "#F6DE9A")
-    static let selectedChip = Color(lifeboardHex: "#E8F6E6")
-    static let selectedChipBorder = Color(lifeboardHex: "#9AD99A")
+    static let canvas = LBColorTokens.warmCanvas
+    static let cream = LBColorTokens.glassStrong
+    static let peachSurface = LBColorTokens.role(.personal).softSurface
+    static let peachSurfaceStrong = LBColorTokens.adaptive(light: "#FFF7F1", dark: "#211A18", darkHighContrast: "#2B201D")
+    static let peachBorder = LBColorTokens.role(.personal).border
+    static let blueSurface = LBColorTokens.role(.focus).softSurface
+    static let blueSurfaceStrong = LBColorTokens.adaptive(light: "#F5FBFF", dark: "#101F31", darkHighContrast: "#142A42")
+    static let blueBorder = LBColorTokens.role(.focus).border
+    static let greenCTA = LBColorTokens.adaptive(light: "#0F5B3D", dark: "#1F7A55", darkHighContrast: "#269866")
+    static let greenCTAPressed = LBColorTokens.adaptive(light: "#0A442D", dark: "#17613F", darkHighContrast: "#1F8054")
+    static let disabledCTA = LBColorTokens.adaptive(light: "#48607F", dark: "#56617B", darkHighContrast: "#66728E")
+    static let goldSurface = LBColorTokens.role(.warning).softSurface
+    static let goldBorder = LBColorTokens.role(.warning).border
+    static let selectedChip = LBColorTokens.role(.task).softSurface
+    static let selectedChipBorder = LBColorTokens.role(.task).border
     static let shadow = LBColorTokens.elevationShadow.opacity(0.10)
 }

--- a/LifeBoard/View/StickySaveButton.swift
+++ b/LifeBoard/View/StickySaveButton.swift
@@ -28,7 +28,7 @@ struct StickySaveButton: View {
                 .frame(minHeight: 56)
                 .background(
                     Capsule(style: .continuous)
-                        .fill(isEnabled ? ReflectPlanStyle.greenCTA : LBColorTokens.navyMuted.opacity(0.42))
+                        .fill(isEnabled ? ReflectPlanStyle.greenCTA : ReflectPlanStyle.disabledCTA)
                 )
                 .overlay(
                     Capsule(style: .continuous)

--- a/LifeBoard/View/SunriseAddHabitSheetView.swift
+++ b/LifeBoard/View/SunriseAddHabitSheetView.swift
@@ -320,7 +320,7 @@ public struct SunriseAddHabitSheetView: View {
                                         .overlay {
                                             if HabitColorFamily.family(for: viewModel.selectedColorHex) == family {
                                                 RoundedRectangle(cornerRadius: 12, style: .continuous)
-                                                    .stroke(Color.white, lineWidth: 2)
+                                                    .stroke(Color.lifeboard.accentOnPrimary, lineWidth: 2)
                                                     .padding(3)
                                             }
                                         }
@@ -605,6 +605,10 @@ private struct SunriseAddHabitWeekdayPickerRow: View {
                         .foregroundStyle(isSelected ? Color.lifeboard.accentOnPrimary : Color.lifeboard.textSecondary)
                         .frame(maxWidth: .infinity, minHeight: 44)
                         .background(isSelected ? Color.lifeboard.accentPrimary : Color.lifeboard.surfaceSecondary, in: Circle())
+                        .overlay {
+                            Circle()
+                                .stroke(isSelected ? Color.lifeboard.accentRing : Color.lifeboard.strokeHairline.opacity(0.7), lineWidth: 1)
+                        }
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel(item.fullLabel)
@@ -713,7 +717,7 @@ private extension View {
                 shape
                     .fill(.clear)
                     .glassEffect(.regular, in: shape)
-                    .overlay(shape.fill(LBColorTokens.glass.opacity(0.50)))
+                    .overlay(shape.fill(LBColorTokens.glass.opacity(0.66)))
             } else {
                 shape
                     .fill(.regularMaterial)

--- a/LifeBoard/View/SunriseHabitDetailScreen.swift
+++ b/LifeBoard/View/SunriseHabitDetailScreen.swift
@@ -360,7 +360,7 @@ struct SunriseHabitDetailScreen: View {
                                     .overlay {
                                         if colorFamily == family {
                                             RoundedRectangle(cornerRadius: 12, style: .continuous)
-                                                .stroke(Color.white, lineWidth: 2)
+                                                .stroke(Color.lifeboard.accentOnPrimary, lineWidth: 2)
                                                 .padding(3)
                                         }
                                     }
@@ -460,9 +460,9 @@ struct SunriseHabitDetailScreen: View {
     private var sunriseBackground: some View {
         LinearGradient(
             colors: [
-                Color(lifeboardHex: "#FFF8EF"),
-                Color(lifeboardHex: "#FFFDFC"),
-                Color(lifeboardHex: "#F7FBFF")
+                LBColorTokens.warmCanvas,
+                LBColorTokens.canvas,
+                LBColorTokens.coolCanvas
             ],
             startPoint: .topLeading,
             endPoint: .bottomTrailing
@@ -1047,6 +1047,10 @@ private struct SunriseHabitWeekdayPickerRow: View {
                         .foregroundStyle(isSelected ? Color.lifeboard.accentOnPrimary : Color.lifeboard.textSecondary)
                         .frame(maxWidth: .infinity, minHeight: 44)
                         .background(isSelected ? Color.lifeboard.accentPrimary : Color.lifeboard.surfaceSecondary, in: Circle())
+                        .overlay {
+                            Circle()
+                                .stroke(isSelected ? Color.lifeboard.accentRing : Color.lifeboard.strokeHairline.opacity(0.7), lineWidth: 1)
+                        }
                 }
                 .buttonStyle(.plain)
             }

--- a/LifeBoard/View/SunriseTaskDetailScreen.swift
+++ b/LifeBoard/View/SunriseTaskDetailScreen.swift
@@ -598,7 +598,7 @@ struct SunriseTaskDetailScreen: View {
             Spacer(minLength: 0)
         }
         .padding(spacing.s12)
-        .lifeboardDenseSurface(cornerRadius: LifeBoardTheme.CornerRadius.md, fillColor: style.tint.opacity(0.12), strokeColor: style.tint.opacity(0.24))
+        .lifeboardDenseSurface(cornerRadius: LifeBoardTheme.CornerRadius.md, fillColor: style.fill, strokeColor: style.stroke)
         .accessibilityIdentifier("taskDetail.taskFitHint")
     }
 
@@ -700,9 +700,9 @@ struct SunriseTaskDetailScreen: View {
     private var sunriseBackground: some View {
         LinearGradient(
             colors: [
-                Color(lifeboardHex: "#FFF8EF"),
-                Color(lifeboardHex: "#FFFDFC"),
-                Color(lifeboardHex: "#F7FBFF")
+                LBColorTokens.warmCanvas,
+                LBColorTokens.canvas,
+                LBColorTokens.coolCanvas
             ],
             startPoint: .topLeading,
             endPoint: .bottomTrailing
@@ -794,7 +794,7 @@ struct SunriseTaskDetailScreen: View {
     }
 
     private var taskAccentColor: Color {
-        viewModel.isComplete ? Color.lifeboard.statusSuccess : Color(lifeboardHex: "#28B53F")
+        Color.lifeboard.statusSuccess
     }
 
     private var autosaveSymbol: String {
@@ -819,12 +819,19 @@ struct SunriseTaskDetailScreen: View {
         return "Largest window: \(start.formatted(date: .omitted, time: .shortened)) - \(end.formatted(date: .omitted, time: .shortened))"
     }
 
-    private func taskFitStyle(for classification: LifeBoardTaskFitClassification) -> (symbol: String, tint: Color) {
+    private func taskFitStyle(for classification: LifeBoardTaskFitClassification) -> (symbol: String, tint: Color, fill: Color, stroke: Color) {
         switch classification {
-        case .fit: return ("checkmark.circle.fill", Color.lifeboard.statusSuccess)
-        case .tight: return ("exclamationmark.triangle.fill", Color.lifeboard.statusWarning)
-        case .conflict: return ("xmark.octagon.fill", Color.lifeboard.statusDanger)
-        case .unknown: return ("questionmark.circle.fill", Color.lifeboard.textSecondary)
+        case .fit:
+            let role = LBColorTokens.role(.task)
+            return ("checkmark.circle.fill", LifeBoardDetailTonePalette.successText, role.softSurface, role.border)
+        case .tight:
+            let role = LBColorTokens.role(.warning)
+            return ("exclamationmark.triangle.fill", LifeBoardDetailTonePalette.warningText, role.softSurface, role.border)
+        case .conflict:
+            let role = LBColorTokens.role(.error)
+            return ("xmark.octagon.fill", LifeBoardDetailTonePalette.dangerText, role.softSurface, role.border)
+        case .unknown:
+            return ("questionmark.circle.fill", Color.lifeboard.textSecondary, Color.lifeboard.surfaceSecondary, Color.lifeboard.strokeHairline)
         }
     }
 

--- a/LifeBoard/View/TaskDetailComponents.swift
+++ b/LifeBoard/View/TaskDetailComponents.swift
@@ -109,6 +109,12 @@ struct PriorityBadge: View {
 
 // MARK: - Shared Status And Metric Components
 
+enum LifeBoardDetailTonePalette {
+    static let successText = LBColorTokens.adaptive(light: "#0F7A25", dark: "#95F0A4", darkHighContrast: "#C8FFD1")
+    static let warningText = LBColorTokens.adaptive(light: "#704600", dark: "#FFE0A0", darkHighContrast: "#FFF0C2")
+    static let dangerText = LBColorTokens.adaptive(light: "#8E2E23", dark: "#FFB7AD", darkHighContrast: "#FFD8D0")
+}
+
 @MainActor
 enum LifeBoardStatusPillTone {
     case accent
@@ -125,11 +131,11 @@ enum LifeBoardStatusPillTone {
         case .neutral:
             return Color.lifeboard.textPrimary
         case .success:
-            return Color.lifeboard.statusSuccess
+            return LifeBoardDetailTonePalette.successText
         case .warning:
-            return Color.lifeboard.statusWarning
+            return LifeBoardDetailTonePalette.warningText
         case .danger:
-            return Color.lifeboard.statusDanger
+            return LifeBoardDetailTonePalette.dangerText
         case .quiet:
             return Color.lifeboard.textSecondary
         }
@@ -142,11 +148,11 @@ enum LifeBoardStatusPillTone {
         case .neutral:
             return Color.lifeboard.surfacePrimary
         case .success:
-            return Color.lifeboard.statusSuccess.opacity(0.12)
+            return LBColorTokens.role(.task).softSurface
         case .warning:
-            return Color.lifeboard.statusWarning.opacity(0.12)
+            return LBColorTokens.role(.warning).softSurface
         case .danger:
-            return Color.lifeboard.statusDanger.opacity(0.12)
+            return LBColorTokens.role(.error).softSurface
         case .quiet:
             return Color.lifeboard.surfaceSecondary
         }
@@ -159,11 +165,11 @@ enum LifeBoardStatusPillTone {
         case .neutral:
             return Color.lifeboard.strokeHairline.opacity(0.9)
         case .success:
-            return Color.lifeboard.statusSuccess.opacity(0.22)
+            return LBColorTokens.role(.task).border
         case .warning:
-            return Color.lifeboard.statusWarning.opacity(0.22)
+            return LBColorTokens.role(.warning).border
         case .danger:
-            return Color.lifeboard.statusDanger.opacity(0.22)
+            return LBColorTokens.role(.error).border
         case .quiet:
             return Color.lifeboard.strokeHairline.opacity(0.72)
         }
@@ -209,9 +215,9 @@ enum LifeBoardHeroMetricTone {
         case .accent:
             return Color.lifeboard.accentPrimary
         case .success:
-            return Color.lifeboard.statusSuccess
+            return LifeBoardDetailTonePalette.successText
         case .warning:
-            return Color.lifeboard.statusWarning
+            return LifeBoardDetailTonePalette.warningText
         case .neutral:
             return Color.lifeboard.textPrimary
         }
@@ -222,9 +228,9 @@ enum LifeBoardHeroMetricTone {
         case .accent:
             return Color.lifeboard.accentWash.opacity(0.92)
         case .success:
-            return Color.lifeboard.statusSuccess.opacity(0.12)
+            return LBColorTokens.role(.task).softSurface
         case .warning:
-            return Color.lifeboard.statusWarning.opacity(0.12)
+            return LBColorTokens.role(.warning).softSurface
         case .neutral:
             return Color.lifeboard.surfacePrimary.opacity(0.8)
         }
@@ -235,9 +241,9 @@ enum LifeBoardHeroMetricTone {
         case .accent:
             return Color.lifeboard.accentPrimary.opacity(0.18)
         case .success:
-            return Color.lifeboard.statusSuccess.opacity(0.18)
+            return LBColorTokens.role(.task).border
         case .warning:
-            return Color.lifeboard.statusWarning.opacity(0.18)
+            return LBColorTokens.role(.warning).border
         case .neutral:
             return Color.lifeboard.strokeHairline.opacity(0.72)
         }

--- a/LifeBoardTests/AppOnboardingTests.swift
+++ b/LifeBoardTests/AppOnboardingTests.swift
@@ -1239,23 +1239,7 @@ final class AppOnboardingTests: XCTestCase {
     private func contrast(_ foreground: UIColor, _ background: UIColor, traits: UITraitCollection) -> CGFloat {
         let fg = foreground.resolvedColor(with: traits)
         let bg = background.resolvedColor(with: traits)
-        let lighter = max(relativeLuminance(fg), relativeLuminance(bg))
-        let darker = min(relativeLuminance(fg), relativeLuminance(bg))
-        return (lighter + 0.05) / (darker + 0.05)
-    }
-
-    private func relativeLuminance(_ color: UIColor) -> CGFloat {
-        var red: CGFloat = 0
-        var green: CGFloat = 0
-        var blue: CGFloat = 0
-        var alpha: CGFloat = 0
-        XCTAssertTrue(color.getRed(&red, green: &green, blue: &blue, alpha: &alpha))
-
-        func channel(_ value: CGFloat) -> CGFloat {
-            value <= 0.03928 ? value / 12.92 : pow((value + 0.055) / 1.055, 2.4)
-        }
-
-        return 0.2126 * channel(red) + 0.7152 * channel(green) + 0.0722 * channel(blue)
+        return contrastRatio(fg, bg)
     }
 }
 

--- a/LifeBoardTests/HomeSunriseLayoutMetricsTests.swift
+++ b/LifeBoardTests/HomeSunriseLayoutMetricsTests.swift
@@ -2403,6 +2403,72 @@ final class HomeSunriseLayoutMetricsTests: XCTestCase {
         XCTAssertFalse(source.contains("Button(\"+ Create task\""))
     }
 
+    func testLifeBoardDesignTimelinePlacesTypeIconsOnSpine() throws {
+        let screenSource = try Self.sourceFile(
+            "LifeBoard",
+            "LifeBoardDesign",
+            "SunriseHomeScreen.swift"
+        )
+        let itemSource = try Self.sourceFile(
+            "LifeBoard",
+            "LifeBoardDesign",
+            "Components",
+            "LBTimelineItem.swift"
+        )
+        let spineSource = try Self.sourceFile(
+            "LifeBoard",
+            "LifeBoardDesign",
+            "Components",
+            "LBTimelineSpine.swift"
+        )
+
+        XCTAssertEqual(LBSpacingTokens.timelineRailWidth, 36, accuracy: 0.001)
+        XCTAssertTrue(itemSource.contains("spineIconSystemName"))
+        XCTAssertTrue(spineSource.contains("var iconSystemName: String?"))
+        XCTAssertTrue(spineSource.contains("Button(action: iconAction)"))
+        XCTAssertTrue(screenSource.contains("spineIconSystemName: spineIconSystemName(for: anchor)"))
+        XCTAssertTrue(screenSource.contains("spineIconSystemName: spineIconSystemName(for: item, kind: kind)"))
+        XCTAssertTrue(screenSource.contains("spineIconSystemName: \"calendar\""))
+        XCTAssertTrue(screenSource.contains("spineIconSystemName: \"sparkles\""))
+        XCTAssertTrue(screenSource.contains("anchor.id == \"sleep\" ? \"moon.fill\" : \"sun.max.fill\""))
+        XCTAssertTrue(screenSource.contains("kind == .calendar ? \"calendar\" : \"checkmark.square\""))
+    }
+
+    func testLifeBoardDesignTimelineCardsDoNotRepeatSpineIcons() throws {
+        let timelineCardSource = try Self.sourceFile(
+            "LifeBoard",
+            "LifeBoardDesign",
+            "Components",
+            "LBTimelineCard.swift"
+        )
+        let assistantSource = try Self.sourceFile(
+            "LifeBoard",
+            "LifeBoardDesign",
+            "Components",
+            "LBAssistantPromptCard.swift"
+        )
+        let routineSource = try Self.sourceFile(
+            "LifeBoard",
+            "LifeBoardDesign",
+            "Components",
+            "TimelineRoutineAnchorCard.swift"
+        )
+        let meetingFlockSource = try Self.sourceFile(
+            "LifeBoard",
+            "LifeBoardDesign",
+            "Components",
+            "LBMeetingFlockCard.swift"
+        )
+
+        XCTAssertFalse(timelineCardSource.contains("private func leadingControl"))
+        XCTAssertFalse(timelineCardSource.contains("LBIconBadge(systemName: model.systemImage"))
+        XCTAssertFalse(assistantSource.contains("Image(systemName: \"sparkles\")"))
+        XCTAssertTrue(assistantSource.contains("Image(systemName: \"chevron.right\")"))
+        XCTAssertFalse(routineSource.contains(".frame(width: leadingArtworkReserve)"))
+        XCTAssertTrue(routineSource.contains("artworkOffsetX(for: proxy.size.width)"))
+        XCTAssertFalse(meetingFlockSource.contains("LBIconBadge(systemName: \"calendar\""))
+    }
+
     func testTimelineSurfaceMetricsUsePadExpandedReadableWidthAndExpandedValues() {
         let metrics = TimelineSurfaceMetrics.make(for: .padExpanded)
 
@@ -2792,6 +2858,16 @@ private extension HomeSunriseLayoutMetricsTests {
             .appendingPathComponent("LifeBoard")
             .appendingPathComponent("View")
             .appendingPathComponent("SunriseTimelineSurface.swift")
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+
+    static func sourceFile(_ pathComponents: String...) throws -> String {
+        let workspaceRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let sourceURL = pathComponents.reduce(workspaceRoot) { url, component in
+            url.appendingPathComponent(component)
+        }
         return try String(contentsOf: sourceURL, encoding: .utf8)
     }
 

--- a/LifeBoardTests/HomeSunriseLayoutMetricsTests.swift
+++ b/LifeBoardTests/HomeSunriseLayoutMetricsTests.swift
@@ -2424,10 +2424,15 @@ final class HomeSunriseLayoutMetricsTests: XCTestCase {
 
         XCTAssertEqual(LBSpacingTokens.timelineRailWidth, 36, accuracy: 0.001)
         XCTAssertTrue(itemSource.contains("spineIconSystemName"))
+        XCTAssertTrue(itemSource.contains("spineIconAccessibilityValue"))
         XCTAssertTrue(spineSource.contains("var iconSystemName: String?"))
+        XCTAssertTrue(spineSource.contains("var iconAccessibilityValue: String?"))
         XCTAssertTrue(spineSource.contains("Button(action: iconAction)"))
+        XCTAssertTrue(spineSource.contains(".accessibilityValue(iconAccessibilityValue ?? \"\")"))
         XCTAssertTrue(screenSource.contains("spineIconSystemName: spineIconSystemName(for: anchor)"))
         XCTAssertTrue(screenSource.contains("spineIconSystemName: spineIconSystemName(for: item, kind: kind)"))
+        XCTAssertTrue(screenSource.contains("spineIconAccessibilityLabel: item.isComplete ? \"Reopen \\(item.title)\" : \"Complete \\(item.title)\""))
+        XCTAssertTrue(screenSource.contains("spineIconAccessibilityValue: item.isComplete ? \"Completed\" : \"Not completed\""))
         XCTAssertTrue(screenSource.contains("spineIconSystemName: \"calendar\""))
         XCTAssertTrue(screenSource.contains("spineIconSystemName: \"sparkles\""))
         XCTAssertTrue(screenSource.contains("anchor.id == \"sleep\" ? \"moon.fill\" : \"sun.max.fill\""))
@@ -2462,11 +2467,16 @@ final class HomeSunriseLayoutMetricsTests: XCTestCase {
 
         XCTAssertFalse(timelineCardSource.contains("private func leadingControl"))
         XCTAssertFalse(timelineCardSource.contains("LBIconBadge(systemName: model.systemImage"))
+        XCTAssertTrue(timelineCardSource.contains(".accessibilityLabel(accessibilityLabel)"))
+        XCTAssertTrue(timelineCardSource.contains("model.kind == .task ? (model.isCompleted ? \"Completed\" : \"Not completed\") : \"\""))
         XCTAssertFalse(assistantSource.contains("Image(systemName: \"sparkles\")"))
         XCTAssertTrue(assistantSource.contains("Image(systemName: \"chevron.right\")"))
-        XCTAssertFalse(routineSource.contains(".frame(width: leadingArtworkReserve)"))
-        XCTAssertTrue(routineSource.contains("artworkOffsetX(for: proxy.size.width)"))
+        XCTAssertTrue(assistantSource.contains(".accessibilityLabel(\"Assistant prompt, \\(title), \\(subtitle)\")"))
+        XCTAssertTrue(routineSource.contains(".frame(width: leadingArtworkReserve)"))
+        XCTAssertFalse(routineSource.contains("artworkOffsetX(for: proxy.size.width)"))
+        XCTAssertFalse(routineSource.contains(".scaleEffect(1.5)"))
         XCTAssertFalse(meetingFlockSource.contains("LBIconBadge(systemName: \"calendar\""))
+        XCTAssertTrue(meetingFlockSource.contains(".accessibilityLabel(\"Meeting, \\(meeting.title), \\(meeting.isNow ? \"Now\" : meeting.timeText)\")"))
     }
 
     func testTimelineSurfaceMetricsUsePadExpandedReadableWidthAndExpandedValues() {
@@ -2683,7 +2693,7 @@ final class HomeSunriseLayoutMetricsTests: XCTestCase {
         let defaultTitle = await MainActor.run { state.emptyStateTitle }
         let defaultVisible = await MainActor.run { state.shouldShowNoResultsMessage }
         XCTAssertTrue(defaultVisible)
-        XCTAssertEqual(defaultTitle, "Start searching")
+        XCTAssertEqual(defaultTitle, "Find anything in LifeBoard")
 
         await MainActor.run {
             state.updateQuery("xyz")
@@ -2854,11 +2864,21 @@ private extension HomeSunriseLayoutMetricsTests {
         let workspaceRoot = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
             .deletingLastPathComponent()
-        let sourceURL = workspaceRoot
+        let sourceDirectory = workspaceRoot
             .appendingPathComponent("LifeBoard")
-            .appendingPathComponent("View")
-            .appendingPathComponent("SunriseTimelineSurface.swift")
-        return try String(contentsOf: sourceURL, encoding: .utf8)
+            .appendingPathComponent("Presentation")
+            .appendingPathComponent("Home")
+            .appendingPathComponent("Timeline")
+            .appendingPathComponent("Surface")
+        let sourceURLs = try FileManager.default.contentsOfDirectory(
+            at: sourceDirectory,
+            includingPropertiesForKeys: nil
+        )
+        .filter { $0.pathExtension == "swift" }
+        .sorted { $0.lastPathComponent < $1.lastPathComponent }
+        return try sourceURLs
+            .map { try String(contentsOf: $0, encoding: .utf8) }
+            .joined(separator: "\n")
     }
 
     static func sourceFile(_ pathComponents: String...) throws -> String {

--- a/LifeBoardTests/HomeSunriseLayoutMetricsTests.swift
+++ b/LifeBoardTests/HomeSunriseLayoutMetricsTests.swift
@@ -2436,7 +2436,7 @@ final class HomeSunriseLayoutMetricsTests: XCTestCase {
         XCTAssertTrue(screenSource.contains("spineIconSystemName: \"calendar\""))
         XCTAssertTrue(screenSource.contains("spineIconSystemName: \"sparkles\""))
         XCTAssertTrue(screenSource.contains("anchor.id == \"sleep\" ? \"moon.fill\" : \"sun.max.fill\""))
-        XCTAssertTrue(screenSource.contains("kind == .calendar ? \"calendar\" : \"checkmark.square\""))
+        XCTAssertTrue(screenSource.contains("return item.isComplete ? \"checkmark.square.fill\" : \"checkmark.square\""))
     }
 
     func testLifeBoardDesignTimelineCardsDoNotRepeatSpineIcons() throws {

--- a/LifeBoardTests/SunriseHeaderAssetTests.swift
+++ b/LifeBoardTests/SunriseHeaderAssetTests.swift
@@ -821,60 +821,6 @@ final class SunriseHeaderAssetTests: XCTestCase {
         )
     }
 
-    #if canImport(UIKit)
-    private func resolvedColor(
-        _ color: Color,
-        style: UIUserInterfaceStyle,
-        contrast: UIAccessibilityContrast = .normal
-    ) -> UIColor {
-        let traits = UITraitCollection(traitsFrom: [
-            UITraitCollection(userInterfaceStyle: style),
-            UITraitCollection(accessibilityContrast: contrast)
-        ])
-        return UIColor(color).resolvedColor(with: traits)
-    }
-
-    private func contrastRatio(_ foreground: UIColor, _ background: UIColor) -> CGFloat {
-        let lighter = max(relativeLuminance(foreground), relativeLuminance(background))
-        let darker = min(relativeLuminance(foreground), relativeLuminance(background))
-        return (lighter + 0.05) / (darker + 0.05)
-    }
-
-    private func relativeLuminance(_ color: UIColor) -> CGFloat {
-        let components = rgbaComponents(color)
-        func channel(_ value: CGFloat) -> CGFloat {
-            value <= 0.03928 ? value / 12.92 : pow((value + 0.055) / 1.055, 2.4)
-        }
-        return 0.2126 * channel(components.red)
-            + 0.7152 * channel(components.green)
-            + 0.0722 * channel(components.blue)
-    }
-
-    private func redComponent(_ color: UIColor) -> CGFloat {
-        rgbaComponents(color).red
-    }
-
-    private func greenComponent(_ color: UIColor) -> CGFloat {
-        rgbaComponents(color).green
-    }
-
-    private func blueComponent(_ color: UIColor) -> CGFloat {
-        rgbaComponents(color).blue
-    }
-
-    private func alphaComponent(_ color: UIColor) -> CGFloat {
-        rgbaComponents(color).alpha
-    }
-
-    private func rgbaComponents(_ color: UIColor) -> (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat) {
-        var red: CGFloat = 0
-        var green: CGFloat = 0
-        var blue: CGFloat = 0
-        var alpha: CGFloat = 0
-        color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
-        return (red, green, blue, alpha)
-    }
-    #endif
 }
 
 #if canImport(UIKit)
@@ -1069,54 +1015,4 @@ final class TaskDetailStyleTests: XCTestCase {
     }
 }
 
-private func resolvedColor(
-    _ color: Color,
-    style: UIUserInterfaceStyle,
-    contrast: UIAccessibilityContrast = .normal
-) -> UIColor {
-    let traits = UITraitCollection(traitsFrom: [
-        UITraitCollection(userInterfaceStyle: style),
-        UITraitCollection(accessibilityContrast: contrast)
-    ])
-    return UIColor(color).resolvedColor(with: traits)
-}
-
-private func contrastRatio(_ foreground: UIColor, _ background: UIColor) -> CGFloat {
-    let lighter = max(relativeLuminance(foreground), relativeLuminance(background))
-    let darker = min(relativeLuminance(foreground), relativeLuminance(background))
-    return (lighter + 0.05) / (darker + 0.05)
-}
-
-private func composited(_ foreground: UIColor, over background: UIColor) -> UIColor {
-    let foregroundComponents = rgbaComponents(foreground)
-    let backgroundComponents = rgbaComponents(background)
-    let foregroundAlpha = foregroundComponents.alpha
-    let backgroundAlpha = backgroundComponents.alpha * (1 - foregroundAlpha)
-    let alpha = foregroundAlpha + backgroundAlpha
-    guard alpha > 0 else { return .clear }
-
-    let red = (foregroundComponents.red * foregroundAlpha + backgroundComponents.red * backgroundAlpha) / alpha
-    let green = (foregroundComponents.green * foregroundAlpha + backgroundComponents.green * backgroundAlpha) / alpha
-    let blue = (foregroundComponents.blue * foregroundAlpha + backgroundComponents.blue * backgroundAlpha) / alpha
-    return UIColor(red: red, green: green, blue: blue, alpha: alpha)
-}
-
-private func relativeLuminance(_ color: UIColor) -> CGFloat {
-    let components = rgbaComponents(color)
-    func channel(_ value: CGFloat) -> CGFloat {
-        value <= 0.03928 ? value / 12.92 : pow((value + 0.055) / 1.055, 2.4)
-    }
-    return 0.2126 * channel(components.red)
-        + 0.7152 * channel(components.green)
-        + 0.0722 * channel(components.blue)
-}
-
-private func rgbaComponents(_ color: UIColor) -> (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat) {
-    var red: CGFloat = 0
-    var green: CGFloat = 0
-    var blue: CGFloat = 0
-    var alpha: CGFloat = 0
-    color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
-    return (red, green, blue, alpha)
-}
 #endif

--- a/LifeBoardTests/SunriseHeaderAssetTests.swift
+++ b/LifeBoardTests/SunriseHeaderAssetTests.swift
@@ -389,7 +389,7 @@ final class SunriseHeaderAssetTests: XCTestCase {
         XCTAssertNil(SunriseHomeScreen.assistantDisplayDate(for: shortGap, now: now))
     }
 
-    func testTaskAndCalendarCardModelsExposeToggleSemantics() {
+    func testTaskAndCalendarCardModelsKeepCardOnlySemantics() {
         let taskModel = LBTimelineCard.Model(
             id: "task",
             title: "Task",
@@ -397,12 +397,10 @@ final class SunriseHeaderAssetTests: XCTestCase {
             timeText: "9:00 PM",
             role: .task,
             kind: .task,
-            systemImage: "checkmark.square",
             tintHex: "#123456",
             accessoryText: nil,
             temporalState: .future,
             isCompleted: false,
-            isToggleable: true,
             isCurrent: false
         )
         let calendarModel = LBTimelineCard.Model(
@@ -412,22 +410,18 @@ final class SunriseHeaderAssetTests: XCTestCase {
             timeText: "9:00 PM",
             role: .meeting,
             kind: .calendar,
-            systemImage: "calendar",
             tintHex: nil,
             accessoryText: nil,
             temporalState: .future,
             isCompleted: false,
-            isToggleable: false,
             isCurrent: false
         )
 
         XCTAssertEqual(taskModel.kind, .task)
         XCTAssertEqual(taskModel.tintHex, "#123456")
         XCTAssertNil(taskModel.accessoryText)
-        XCTAssertTrue(taskModel.isToggleable)
         XCTAssertEqual(calendarModel.kind, .calendar)
         XCTAssertNil(calendarModel.tintHex)
-        XCTAssertFalse(calendarModel.isToggleable)
     }
 
     func testCalendarCardSubtitleIsEmptyWhenEventIsNotNextUpcoming() {

--- a/LifeBoardTests/SunriseHeaderAssetTests.swift
+++ b/LifeBoardTests/SunriseHeaderAssetTests.swift
@@ -882,3 +882,247 @@ final class SunriseHeaderAssetTests: XCTestCase {
     }
     #endif
 }
+
+#if canImport(UIKit)
+final class ReflectPlanStyleTests: XCTestCase {
+    func testReflectPlanSurfacesResolveDarkAndReadable() {
+        let darkCanvas = resolvedColor(ReflectPlanStyle.canvas, style: .dark)
+        let darkCream = resolvedColor(ReflectPlanStyle.cream, style: .dark)
+        let darkPeach = resolvedColor(ReflectPlanStyle.peachSurfaceStrong, style: .dark)
+        let darkBlue = resolvedColor(ReflectPlanStyle.blueSurfaceStrong, style: .dark)
+        let primaryText = resolvedColor(LBColorTokens.navy, style: .dark)
+        let secondaryText = resolvedColor(LBColorTokens.navyMuted, style: .dark)
+
+        XCTAssertLessThan(relativeLuminance(darkCanvas), 0.02)
+        XCTAssertLessThan(relativeLuminance(darkCream), 0.08)
+        XCTAssertGreaterThan(contrastRatio(primaryText, darkCanvas), 10.0)
+        XCTAssertGreaterThan(contrastRatio(primaryText, darkPeach), 7.0)
+        XCTAssertGreaterThan(contrastRatio(primaryText, darkBlue), 7.0)
+        XCTAssertGreaterThan(contrastRatio(secondaryText, darkCream), 4.5)
+    }
+
+    func testReflectPlanActionColorsReadInBothAppearances() {
+        for style in [UIUserInterfaceStyle.light, .dark] {
+            XCTAssertGreaterThan(
+                contrastRatio(.white, resolvedColor(ReflectPlanStyle.greenCTA, style: style)),
+                4.5
+            )
+            XCTAssertGreaterThan(
+                contrastRatio(.white, resolvedColor(ReflectPlanStyle.disabledCTA, style: style)),
+                4.5
+            )
+        }
+    }
+
+    func testReflectPlanIncreasedContrastKeepsCardsDarkAndSeparated() {
+        let normalSurface = resolvedColor(ReflectPlanStyle.peachSurfaceStrong, style: .dark)
+        let highContrastSurface = resolvedColor(ReflectPlanStyle.peachSurfaceStrong, style: .dark, contrast: .high)
+        let highContrastBorder = resolvedColor(ReflectPlanStyle.peachBorder, style: .dark, contrast: .high)
+
+        XCTAssertLessThan(relativeLuminance(highContrastSurface), 0.04)
+        XCTAssertGreaterThan(contrastRatio(highContrastBorder, highContrastSurface), 2.0)
+        XCTAssertNotEqual(normalSurface, highContrastSurface)
+    }
+}
+
+final class HabitDetailStyleTests: XCTestCase {
+    func testHabitDetailBackgroundStopsResolveDark() {
+        let darkStops = [
+            resolvedColor(LBColorTokens.warmCanvas, style: .dark),
+            resolvedColor(LBColorTokens.canvas, style: .dark),
+            resolvedColor(LBColorTokens.coolCanvas, style: .dark)
+        ]
+
+        for stop in darkStops {
+            XCTAssertLessThan(relativeLuminance(stop), 0.03)
+        }
+    }
+
+    func testHabitDetailEditorSurfacesMaintainTextContrast() {
+        for style in [UIUserInterfaceStyle.light, .dark] {
+            let primaryText = resolvedColor(Color.lifeboard(.textPrimary), style: style)
+            let secondaryText = resolvedColor(Color.lifeboard(.textSecondary), style: style)
+            let surfacePrimary = resolvedColor(Color.lifeboard(.surfacePrimary), style: style)
+            let surfaceSecondary = resolvedColor(Color.lifeboard(.surfaceSecondary), style: style)
+            let accentPrimary = resolvedColor(Color.lifeboard(.accentPrimary), style: style)
+            let accentOnPrimary = resolvedColor(Color.lifeboard(.accentOnPrimary), style: style)
+
+            XCTAssertGreaterThan(contrastRatio(primaryText, surfacePrimary), 4.5)
+            XCTAssertGreaterThan(contrastRatio(primaryText, surfaceSecondary), 4.5)
+            XCTAssertGreaterThan(contrastRatio(secondaryText, surfacePrimary), 4.5)
+            XCTAssertGreaterThan(contrastRatio(accentOnPrimary, accentPrimary), 4.5)
+        }
+    }
+
+    func testHabitDetailDarkSeparatorsAndSelectionRingsRemainVisible() {
+        let darkSurface = resolvedColor(Color.lifeboard(.surfaceSecondary), style: .dark)
+        let darkStroke = resolvedColor(Color.lifeboard(.strokeHairline), style: .dark)
+        let darkRing = resolvedColor(Color.lifeboard(.accentRing), style: .dark)
+        let highContrastSurface = resolvedColor(Color.lifeboard(.surfaceSecondary), style: .dark, contrast: .high)
+        let highContrastStroke = resolvedColor(Color.lifeboard(.strokeHairline), style: .dark, contrast: .high)
+        let highContrastRing = resolvedColor(Color.lifeboard(.accentRing), style: .dark, contrast: .high)
+
+        XCTAssertGreaterThan(contrastRatio(darkStroke, darkSurface), 1.4)
+        XCTAssertGreaterThan(contrastRatio(darkRing, darkSurface), 1.8)
+        XCTAssertGreaterThan(contrastRatio(highContrastStroke, highContrastSurface), 1.4)
+        XCTAssertGreaterThan(contrastRatio(highContrastRing, highContrastSurface), 1.8)
+    }
+}
+
+final class TaskDetailStyleTests: XCTestCase {
+    private let traitVariants: [(style: UIUserInterfaceStyle, contrast: UIAccessibilityContrast)] = [
+        (.light, .normal),
+        (.dark, .normal),
+        (.dark, .high)
+    ]
+
+    func testTaskDetailBackgroundStopsResolveDark() {
+        let darkStops = [
+            resolvedColor(LBColorTokens.warmCanvas, style: .dark),
+            resolvedColor(LBColorTokens.canvas, style: .dark),
+            resolvedColor(LBColorTokens.coolCanvas, style: .dark)
+        ]
+        let highContrastDarkStops = [
+            resolvedColor(LBColorTokens.warmCanvas, style: .dark, contrast: .high),
+            resolvedColor(LBColorTokens.canvas, style: .dark, contrast: .high),
+            resolvedColor(LBColorTokens.coolCanvas, style: .dark, contrast: .high)
+        ]
+        let primaryText = resolvedColor(Color.lifeboard(.textPrimary), style: .dark)
+        let highContrastPrimaryText = resolvedColor(Color.lifeboard(.textPrimary), style: .dark, contrast: .high)
+
+        for stop in darkStops {
+            XCTAssertLessThan(relativeLuminance(stop), 0.03)
+            XCTAssertGreaterThan(contrastRatio(primaryText, stop), 10.0)
+        }
+        for stop in highContrastDarkStops {
+            XCTAssertLessThan(relativeLuminance(stop), 0.02)
+            XCTAssertGreaterThan(contrastRatio(highContrastPrimaryText, stop), 12.0)
+        }
+    }
+
+    func testTaskDetailHeroAndDisclosureSurfacesMaintainTextContrast() {
+        for traits in traitVariants {
+            let primaryText = resolvedColor(Color.lifeboard(.textPrimary), style: traits.style, contrast: traits.contrast)
+            let secondaryText = resolvedColor(Color.lifeboard(.textSecondary), style: traits.style, contrast: traits.contrast)
+            let tertiaryText = resolvedColor(Color.lifeboard(.textTertiary), style: traits.style, contrast: traits.contrast)
+            let surfacePrimary = resolvedColor(Color.lifeboard(.surfacePrimary), style: traits.style, contrast: traits.contrast)
+            let surfaceSecondary = resolvedColor(Color.lifeboard(.surfaceSecondary), style: traits.style, contrast: traits.contrast)
+            let iconWell = composited(
+                resolvedColor(Color.lifeboard(.surfacePrimary).opacity(0.78), style: traits.style, contrast: traits.contrast),
+                over: surfaceSecondary
+            )
+            let chevronWell = composited(
+                resolvedColor(Color.lifeboard(.surfacePrimary).opacity(0.70), style: traits.style, contrast: traits.contrast),
+                over: surfaceSecondary
+            )
+
+            XCTAssertGreaterThan(contrastRatio(primaryText, surfacePrimary), 4.5)
+            XCTAssertGreaterThan(contrastRatio(primaryText, surfaceSecondary), 4.5)
+            XCTAssertGreaterThan(contrastRatio(secondaryText, surfacePrimary), 4.5)
+            XCTAssertGreaterThan(contrastRatio(secondaryText, surfaceSecondary), 4.5)
+            XCTAssertGreaterThan(contrastRatio(secondaryText, iconWell), 3.0)
+            XCTAssertGreaterThan(contrastRatio(tertiaryText, chevronWell), 3.0)
+        }
+    }
+
+    func testTaskDetailMetricTilesAndEditorRowsMaintainContrast() {
+        for traits in traitVariants {
+            let surfacePrimary = resolvedColor(Color.lifeboard(.surfacePrimary), style: traits.style, contrast: traits.contrast)
+            let surfaceSecondary = resolvedColor(Color.lifeboard(.surfaceSecondary), style: traits.style, contrast: traits.contrast)
+            let primaryText = resolvedColor(Color.lifeboard(.textPrimary), style: traits.style, contrast: traits.contrast)
+            let secondaryText = resolvedColor(Color.lifeboard(.textSecondary), style: traits.style, contrast: traits.contrast)
+            let accentText = resolvedColor(Color.lifeboard(.accentPrimary), style: traits.style, contrast: traits.contrast)
+            let successText = resolvedColor(LifeBoardDetailTonePalette.successText, style: traits.style, contrast: traits.contrast)
+            let accentMetricFill = composited(
+                resolvedColor(Color.lifeboard(.accentWash).opacity(0.92), style: traits.style, contrast: traits.contrast),
+                over: surfacePrimary
+            )
+            let successMetricFill = resolvedColor(LBColorTokens.role(.task).softSurface, style: traits.style, contrast: traits.contrast)
+            let editorRowFill = composited(
+                resolvedColor(Color.lifeboard(.surfaceSecondary).opacity(0.72), style: traits.style, contrast: traits.contrast),
+                over: surfacePrimary
+            )
+
+            XCTAssertGreaterThan(contrastRatio(accentText, accentMetricFill), 4.0)
+            XCTAssertGreaterThan(contrastRatio(successText, successMetricFill), 3.0)
+            XCTAssertGreaterThan(contrastRatio(primaryText, editorRowFill), 4.5)
+            XCTAssertGreaterThan(contrastRatio(secondaryText, editorRowFill), 4.5)
+            XCTAssertGreaterThan(contrastRatio(primaryText, surfaceSecondary), 4.5)
+        }
+    }
+
+    func testTaskDetailCapsuleAndTaskFitTonesRemainReadable() {
+        for traits in traitVariants {
+            let surfaceSecondary = resolvedColor(Color.lifeboard(.surfaceSecondary), style: traits.style, contrast: traits.contrast)
+            let accentText = resolvedColor(Color.lifeboard(.accentPrimary), style: traits.style, contrast: traits.contrast)
+            let quietText = resolvedColor(Color.lifeboard(.textSecondary), style: traits.style, contrast: traits.contrast)
+            let successText = resolvedColor(LifeBoardDetailTonePalette.successText, style: traits.style, contrast: traits.contrast)
+            let warningText = resolvedColor(LifeBoardDetailTonePalette.warningText, style: traits.style, contrast: traits.contrast)
+            let dangerText = resolvedColor(LifeBoardDetailTonePalette.dangerText, style: traits.style, contrast: traits.contrast)
+            let accentFill = resolvedColor(Color.lifeboard(.accentWash), style: traits.style, contrast: traits.contrast)
+            let quietFill = resolvedColor(Color.lifeboard(.surfaceSecondary), style: traits.style, contrast: traits.contrast)
+            let successFill = resolvedColor(LBColorTokens.role(.task).softSurface, style: traits.style, contrast: traits.contrast)
+            let warningFill = resolvedColor(LBColorTokens.role(.warning).softSurface, style: traits.style, contrast: traits.contrast)
+            let dangerFill = resolvedColor(LBColorTokens.role(.error).softSurface, style: traits.style, contrast: traits.contrast)
+
+            XCTAssertGreaterThan(contrastRatio(accentText, accentFill), 4.0)
+            XCTAssertGreaterThan(contrastRatio(quietText, quietFill), 4.5)
+            XCTAssertGreaterThan(contrastRatio(quietText, surfaceSecondary), 4.5)
+            XCTAssertGreaterThan(contrastRatio(successText, successFill), 4.5)
+            XCTAssertGreaterThan(contrastRatio(warningText, warningFill), 4.5)
+            XCTAssertGreaterThan(contrastRatio(dangerText, dangerFill), 4.5)
+        }
+    }
+}
+
+private func resolvedColor(
+    _ color: Color,
+    style: UIUserInterfaceStyle,
+    contrast: UIAccessibilityContrast = .normal
+) -> UIColor {
+    let traits = UITraitCollection(traitsFrom: [
+        UITraitCollection(userInterfaceStyle: style),
+        UITraitCollection(accessibilityContrast: contrast)
+    ])
+    return UIColor(color).resolvedColor(with: traits)
+}
+
+private func contrastRatio(_ foreground: UIColor, _ background: UIColor) -> CGFloat {
+    let lighter = max(relativeLuminance(foreground), relativeLuminance(background))
+    let darker = min(relativeLuminance(foreground), relativeLuminance(background))
+    return (lighter + 0.05) / (darker + 0.05)
+}
+
+private func composited(_ foreground: UIColor, over background: UIColor) -> UIColor {
+    let foregroundComponents = rgbaComponents(foreground)
+    let backgroundComponents = rgbaComponents(background)
+    let foregroundAlpha = foregroundComponents.alpha
+    let backgroundAlpha = backgroundComponents.alpha * (1 - foregroundAlpha)
+    let alpha = foregroundAlpha + backgroundAlpha
+    guard alpha > 0 else { return .clear }
+
+    let red = (foregroundComponents.red * foregroundAlpha + backgroundComponents.red * backgroundAlpha) / alpha
+    let green = (foregroundComponents.green * foregroundAlpha + backgroundComponents.green * backgroundAlpha) / alpha
+    let blue = (foregroundComponents.blue * foregroundAlpha + backgroundComponents.blue * backgroundAlpha) / alpha
+    return UIColor(red: red, green: green, blue: blue, alpha: alpha)
+}
+
+private func relativeLuminance(_ color: UIColor) -> CGFloat {
+    let components = rgbaComponents(color)
+    func channel(_ value: CGFloat) -> CGFloat {
+        value <= 0.03928 ? value / 12.92 : pow((value + 0.055) / 1.055, 2.4)
+    }
+    return 0.2126 * channel(components.red)
+        + 0.7152 * channel(components.green)
+        + 0.0722 * channel(components.blue)
+}
+
+private func rgbaComponents(_ color: UIColor) -> (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat) {
+    var red: CGFloat = 0
+    var green: CGFloat = 0
+    var blue: CGFloat = 0
+    var alpha: CGFloat = 0
+    color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+    return (red, green, blue, alpha)
+}
+#endif

--- a/LifeBoardTests/TestSupport/SharedColorTestHelpers.swift
+++ b/LifeBoardTests/TestSupport/SharedColorTestHelpers.swift
@@ -1,0 +1,71 @@
+#if canImport(UIKit)
+import SwiftUI
+import UIKit
+
+func resolvedColor(
+    _ color: Color,
+    style: UIUserInterfaceStyle,
+    contrast: UIAccessibilityContrast = .normal
+) -> UIColor {
+    let traits = UITraitCollection(traitsFrom: [
+        UITraitCollection(userInterfaceStyle: style),
+        UITraitCollection(accessibilityContrast: contrast)
+    ])
+    return UIColor(color).resolvedColor(with: traits)
+}
+
+func contrastRatio(_ foreground: UIColor, _ background: UIColor) -> CGFloat {
+    let lighter = max(relativeLuminance(foreground), relativeLuminance(background))
+    let darker = min(relativeLuminance(foreground), relativeLuminance(background))
+    return (lighter + 0.05) / (darker + 0.05)
+}
+
+func composited(_ foreground: UIColor, over background: UIColor) -> UIColor {
+    let foregroundComponents = rgbaComponents(foreground)
+    let backgroundComponents = rgbaComponents(background)
+    let foregroundAlpha = foregroundComponents.alpha
+    let backgroundAlpha = backgroundComponents.alpha * (1 - foregroundAlpha)
+    let alpha = foregroundAlpha + backgroundAlpha
+    guard alpha > 0 else { return .clear }
+
+    let red = (foregroundComponents.red * foregroundAlpha + backgroundComponents.red * backgroundAlpha) / alpha
+    let green = (foregroundComponents.green * foregroundAlpha + backgroundComponents.green * backgroundAlpha) / alpha
+    let blue = (foregroundComponents.blue * foregroundAlpha + backgroundComponents.blue * backgroundAlpha) / alpha
+    return UIColor(red: red, green: green, blue: blue, alpha: alpha)
+}
+
+func relativeLuminance(_ color: UIColor) -> CGFloat {
+    let components = rgbaComponents(color)
+    func channel(_ value: CGFloat) -> CGFloat {
+        value <= 0.03928 ? value / 12.92 : pow((value + 0.055) / 1.055, 2.4)
+    }
+    return 0.2126 * channel(components.red)
+        + 0.7152 * channel(components.green)
+        + 0.0722 * channel(components.blue)
+}
+
+func redComponent(_ color: UIColor) -> CGFloat {
+    rgbaComponents(color).red
+}
+
+func greenComponent(_ color: UIColor) -> CGFloat {
+    rgbaComponents(color).green
+}
+
+func blueComponent(_ color: UIColor) -> CGFloat {
+    rgbaComponents(color).blue
+}
+
+func alphaComponent(_ color: UIColor) -> CGFloat {
+    rgbaComponents(color).alpha
+}
+
+func rgbaComponents(_ color: UIColor) -> (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat) {
+    var red: CGFloat = 0
+    var green: CGFloat = 0
+    var blue: CGFloat = 0
+    var alpha: CGFloat = 0
+    color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+    return (red, green, blue, alpha)
+}
+#endif


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Home timeline rendering and task completion UX move to new components and spine actions; regressions could affect scrolling performance, accessibility, or completion toggles without changing backend data.
> 
> **Overview**
> **Iconic timeline** refreshes the Sunrise Home day view with a time column, vertical **spine**, and role-aware cards wired through `SunriseHomeScreen`.
> 
> Wake and sleep anchors use **`TimelineRoutineAnchorCard`** (morning/evening artwork via `TimelineRoutineAnchorVisualStyle`) instead of generic glass cards. **`LBTimelineSpine`** adds **icon markers** (sun/moon, calendar, sparkles, task checkmarks) with optional **spine tap-to-complete** for tasks. **`LBTimelineTemporalState`** drives muted past vs emphasized current styling on cards, spine, and time labels.
> 
> Row building gains **meeting flocks** (`LBMeetingFlockCard`), **assistant gap** prompts (`LBAssistantPromptCard`), a **Now** rail, and calendar **countdown** subtitles on the next upcoming event. **`LBSpacingTokens`** adds dedicated timeline column/rail metrics. Related detail/sheet surfaces pick up shared **LB role/token** styling (e.g. `ReflectPlanStyle`, task/habit detail components).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 270cc92169199314ef80f648ca6ec1a15ae4d22b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->